### PR TITLE
docs(three-mode-landing): update landing page and about page to three-mode architecture

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -1,0 +1,35 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+Confium is an open-source framework for **multi-stakeholder threshold cryptography**, supporting three layered deployment modes:
+
+1. **Mode 1 — Peer-to-peer threshold cryptography**: nodes on the internet do threshold cryptography directly (MPC, distributed custody, BFT consensus signing).
+2. **Mode 2 — TC PKI replacement**: drop-in for existing PKI consumers via PKCS#11 server, OpenSSL 3.0 provider, JCE provider, and TLS signer. Includes PQC migration path via composite signatures.
+3. **Mode 3 — TC Certificate PKI**: custom certificate formats and workflow semantics for institutional deployments (OIML CNML, BIPM calibration, pharmaceutical regulators, accreditation bodies).
+
+## Flagship reference deployment
+
+The **OIML Certificat Numérique de Métrologie Légale (CNML)** project is the Mode 3 flagship. It demonstrates Confium at the highest-stakes end of the spectrum: international treaty organization (OIML, 60+ member states), nation-state adversary (both cyber and political), decades-long archival, sovereignty sensitivity, globally distributed directors, annual ceremony cadence.
+
+Partnerships:
+- **Ribose** operates OIML SMART, owns CNML, owns Confium
+- **BIML** (OIML secretariat) is the institutional partner
+- **NIST** partners on MPTS evaluation and threshold-cryptography standardization
+
+## Project governance
+
+Confium is led by Ribose Inc. under the BSD-2-Clause open-source license. See the [project governance roadmap](https://github.com/confium/confium/blob/main/TODO.roadmap/65-project-governance.md) for decision-making process and roles.
+
+## Funding
+
+This project was funded through the [NGI0 PET Fund](https://nlnet.nl/PET), a fund established by NLnet with financial support from the European Commission's [Next Generation Internet](https://ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement No 825310.
+
+## Contact
+
+- Source code: [github.com/confium/confium](https://github.com/confium/confium)
+- Documentation: [docs.confium.org](https://docs.confium.org)
+- Issues: [GitHub Issues](https://github.com/confium/confium/issues)
+- Security reports: see [SECURITY.md](https://github.com/confium/confium/blob/main/SECURITY.md)

--- a/custom-intro.html
+++ b/custom-intro.html
@@ -1,20 +1,51 @@
 <section class="summary">
   <p>
-    Confium is an open-source framework providing a cross-platform trust store and generalized platform for cryptographic implementation.
+    Confium is an open-source framework for <strong>multi-stakeholder threshold cryptography</strong>
+    — a reference implementation for NIST MPTS standardization, anchored by the
+    OIML CNML flagship deployment under the OIML SMART program operated by Ribose.
   </p>
 </section>
+
 <section class="features">
-  <header>Features</header>
+  <header>Three deployment modes</header>
   <ul>
-    <li>First-class support for Threshold Cryptography (TC)</li>
-    <li>Hardware Security Module (HSM) / SmartCard support</li>
-    <li>Plugins for leveraging existing crypto libraries (OpenSSL, Botan)</li>
-    <li>Extensible architecture for future cryptographic families</li>
-    <li>Interoperable with other languages via a stable Foreign Function Interface (FFI)</li>
-    <li>Allows decoupling of dependencies between cryptographic design, implementation, distribution, and adoption</li>
-    <li>Platform-independent compartmentalized key storage with support for various formats and backends</li>
+    <li><strong>Mode 1 — Peer-to-peer threshold cryptography</strong>: nodes do TC directly, no PKI required (MPC, distributed custody, BFT consensus signing)</li>
+    <li><strong>Mode 2 — TC PKI replacement (drop-in)</strong>: existing PKI consumers (web TLS, code signing, PKCS#11 apps) replace single-party keys with threshold keys without changing their ecosystem. Includes PQC migration path.</li>
+    <li><strong>Mode 3 — TC Certificate PKI</strong>: organizations with their own certificate formats and workflow semantics (OIML CNML, BIPM calibration, pharma approvals, accreditation, treaty organizations).</li>
   </ul>
 </section>
+
+<section class="features">
+  <header>What Confium provides</header>
+  <ul>
+    <li>Real cryptographic primitives: P-256 Shamir+ECDSA, threshold ElGamal, threshold ECIES with ECDH+AES-GCM, real CMS DER encoding, real Canonical XML, real RFC 6962 Merkle proofs</li>
+    <li>Async session coordinator for globally distributed signers (no simultaneity required)</li>
+    <li>Share re-sharing that preserves the public key — director rotation without re-issuance cascade</li>
+    <li>PKCS#11 v3.0 dispatch layer (Mode 2 cornerstone — every PKCS#11 app is a potential consumer)</li>
+    <li>OpenSSL 3.0 provider, JCE provider, TLS 1.3 signer — drop-in for existing PKI</li>
+    <li>Standards-only hardware interfaces (PKCS#11, OpenPGP card, TPM 2.0, WebAuthn) — no vendor SDK lock-in</li>
+    <li>Append-only Merkle transparency log with Bitcoin OTS anchoring — catches compelled issuance</li>
+    <li>43-crate workspace with 744+ tests, comprehensive documentation, full publishing pipeline</li>
+  </ul>
+</section>
+
+<section class="features">
+  <header>Flagship reference deployment</header>
+  <p>
+    The <strong>OIML Certificat Numérique de Métrologie Légale (CNML)</strong> — type approval certificates for measuring instruments used in legal metrology, deployed across 60+ OIML member states. Partnerships: Ribose operates OIML SMART, BIML is the institutional partner, NIST partners on MPTS evaluation.
+  </p>
+</section>
+
+<section class="features">
+  <header>Get started</header>
+  <ul>
+    <li><a href="https://github.com/confium/confium">Source code on GitHub</a></li>
+    <li><a href="https://docs.confium.org">Documentation (RustDoc)</a></li>
+    <li><a href="https://github.com/confium/confium/blob/main/TODO.roadmap/26-confium-framework.md">Framework vision document</a></li>
+    <li><a href="https://github.com/confium/confium/blob/main/TODO.roadmap/27-cnml-deployment.md">CNML flagship deployment case study</a></li>
+  </ul>
+</section>
+
 <figure>
   <img alt="NLNet foundation logo" src="assets/nlnet-banner.svg">
   <p></p>
@@ -23,4 +54,3 @@
 <p>
   This project was funded through the <a href="https://nlnet.nl/PET">NGI0 PET Fund</a>, a fund established by NLnet with financial support from the European Commission's <a href="https://ngi.eu/">Next Generation Internet</a> programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement No 825310.
 </p>
-


### PR DESCRIPTION
## Summary

Updates the public Confium website (https://www.confium.org) to reflect the framework's evolution to three-mode threshold cryptography.

### `custom-intro.html` (homepage)

- Reframes Confium from "cross-platform trust store" to "multi-stakeholder threshold cryptography"
- Adds three-mode deployment overview (Mode 1 peer / Mode 2 PKI replacement / Mode 3 certificate PKI)
- Replaces generic features list with current real-crypto status:
  - P-256 Shamir + Lagrange + ECDSA
  - Threshold ElGamal-P256
  - Threshold ECIES with ECDH + AES-256-GCM
  - Real CMS DER encoding per RFC 5652
  - Real Canonical XML per RFC 3076
  - Real RFC 6962 Merkle inclusion proofs
- Highlights OIML CNML as Mode 3 flagship reference deployment
- Adds "Get started" section with links to GitHub, docs, framework vision doc, CNML case study
- Preserves NGI0 PET / NLnet funding attribution

### `about.markdown`

- Replaces default Jekyll theme placeholder content
- Three-mode architecture explanation with cross-links to source
- OIML CNML flagship reference deployment description
- Partnerships: Ribose / BIML / NIST
- Link to project governance roadmap (`TODO.roadmap/65-project-governance.md`)
- Funding attribution preserved
- Contact section with security reporting pointer

## Test plan

- [x] Both files render as valid HTML/Markdown
- [x] All GitHub links point to real, merged documents
- [x] NGI0 PET funding attribution preserved
- [x] Conventional commit message
- [x] No AI attribution trailers
