### PR TITLE
ci(actions): upgrade ALL GHA actions to latest 2026 versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
     # needs: [set_environment]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -55,7 +55,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
@@ -22,7 +22,7 @@ jobs:
         cache-version: 0 # Increment this number if you need to re-download cached gems
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
 
     - name: Build with Jekyll
       # Outputs to the './_site' directory by default
@@ -31,7 +31,7 @@ jobs:
         JEKYLL_ENV: production
 
     - name: Link Checker
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@v2.9.0
       with:
         args: --verbose --no-progress --exclude-file .lycheeignore -- _site/**/*.html
         fail: true


### PR DESCRIPTION
checkout v4→v7, configure-pages v5→v6, upload-pages-artifact v3→v5, deploy-pages v4→v5, lychee v2→v2.9.0