### PR TITLE
feat(homepage): seven-section landing + 6 interactive Vue islands

### DIFF
--- a/src/components/vue/CopyButton.vue
+++ b/src/components/vue/CopyButton.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+interface Props {
+  /** The text to copy. */
+  value: string;
+  /** Optional label override (defaults to "Copy"). */
+  label?: string;
+  /** Visual size: small for inline use, medium for primary CTA. */
+  size?: 'sm' | 'md';
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  label: 'Copy',
+  size: 'md',
+});
+
+const copied = ref(false);
+let resetTimer: number | null = null;
+
+async function copy() {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(props.value);
+    } else {
+      // Legacy fallback.
+      const ta = document.createElement('textarea');
+      ta.value = props.value;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    copied.value = true;
+    if (resetTimer !== null) window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      copied.value = false;
+    }, 1800);
+  } catch (err) {
+    console.warn('[CopyButton] copy failed:', err);
+  }
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="[
+      'inline-flex items-center gap-1.5 rounded-md font-mono transition-colors',
+      size === 'sm' ? 'text-xs px-2 py-1' : 'text-sm px-3 py-1.5',
+      copied
+        ? 'bg-brand-100 dark:bg-brand-900/30 text-brand-700 dark:text-brand-300'
+        : 'bg-brand-50 dark:bg-brand-900/20 text-brand-700 dark:text-brand-300 hover:bg-brand-100 dark:hover:bg-brand-900/40',
+    ]"
+    :aria-label="`${label} command`"
+    @click="copy"
+  >
+    <span v-if="copied" aria-hidden="true">✓</span>
+    <span v-else aria-hidden="true">⧉</span>
+    <span>{{ copied ? 'Copied' : label }}</span>
+  </button>
+</template>

--- a/src/components/vue/HeroDecrypt.vue
+++ b/src/components/vue/HeroDecrypt.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { CONFUM_EVENTS, on } from '@lib/events';
+
+const props = defineProps<{
+  text: string;
+  /** ms per character reveal */
+  intervalMs?: number;
+  /** character pool to draw from for the decrypt effect */
+  alphabet?: string;
+}>();
+
+const intervalMs = props.intervalMs ?? 35;
+const alphabet =
+  props.alphabet ||
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/+=';
+
+const displayed = ref<string>(props.text);
+let frameId: number | null = null;
+let cleanupReplay: (() => void) | null = null;
+
+interface RevealState { position: number; final: string; }
+
+function reveal(target: string) {
+  if (frameId !== null) {
+    clearInterval(frameId);
+    frameId = null;
+  }
+  const finalChars = target.split('');
+  let revealed = 0;
+  const total = finalChars.length;
+  displayed.value = '';
+
+  frameId = window.setInterval(() => {
+    if (revealed >= total) {
+      if (frameId !== null) {
+        clearInterval(frameId);
+        frameId = null;
+      }
+      displayed.value = target;
+      return;
+    }
+    let out = '';
+    for (let i = 0; i < total; i++) {
+      if (i < revealed) {
+        out += finalChars[i];
+      } else if (finalChars[i] === ' ') {
+        out += ' ';
+      } else {
+        out += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+    }
+    displayed.value = out;
+    revealed += 1;
+  }, intervalMs);
+}
+
+onMounted(() => {
+  reveal(props.text);
+  cleanupReplay = on(CONFUM_EVENTS.replayHero, () => reveal(props.text));
+});
+
+onUnmounted(() => {
+  if (frameId !== null) clearInterval(frameId);
+  cleanupReplay?.();
+});
+</script>
+
+<template>
+  <span aria-label={props.text}>
+    <span aria-hidden="true">{{ displayed }}</span>
+  </span>
+</template>

--- a/src/components/vue/InstallTabs.vue
+++ b/src/components/vue/InstallTabs.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import CopyButton from './CopyButton.vue';
+
+interface Tab {
+  id: string;
+  label: string;
+  command: string;
+  hint?: string;
+}
+
+const tabs: Tab[] = [
+  {
+    id: 'ruby',
+    label: 'Ruby',
+    command: 'gem install confium',
+    hint: 'Ruby ≥ 3.1 + Rust stable for the native extension.',
+  },
+  {
+    id: 'rust',
+    label: 'Rust',
+    command: 'cargo add confium-core',
+    hint: 'Add the engine to your Cargo.toml workspace.',
+  },
+  {
+    id: 'wasm',
+    label: 'WASM',
+    command: 'npm install @confium/confium-wasm',
+    hint: 'Browser / Node.js verifier (composite, transparency, PKI).',
+  },
+  {
+    id: 'source',
+    label: 'Source',
+    command: 'git clone https://github.com/confium/confium.git',
+    hint: 'Build the workspace from source (Nix flake available).',
+  },
+];
+
+const activeId = ref<string>('ruby');
+const active = ref<Tab>(tabs[0]);
+
+function select(id: string) {
+  activeId.value = id;
+  active.value = tabs.find((t) => t.id === id) ?? tabs[0];
+}
+</script>
+
+<template>
+  <div class="rounded-lg border border-line bg-card overflow-hidden shadow-card">
+    <div class="flex border-b border-line bg-brand-50/30 dark:bg-brand-900/10">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        type="button"
+        :class="[
+          'px-4 py-2.5 text-sm font-medium border-b-2 transition-colors',
+          activeId === tab.id
+            ? 'border-brand-500 text-brand-700 dark:text-brand-300'
+            : 'border-transparent text-muted-foreground hover:text-foreground',
+        ]"
+        @click="select(tab.id)"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+    <div class="p-4">
+      <div class="flex items-center justify-between gap-3">
+        <code class="font-mono text-sm flex-1 overflow-x-auto whitespace-nowrap">
+          <span class="text-muted-foreground select-none">$ </span>
+          <span>{{ active.command }}</span>
+        </code>
+        <CopyButton :value="active.command" label="Copy" size="sm" />
+      </div>
+      <p v-if="active.hint" class="mt-3 text-xs text-muted-foreground">
+        {{ active.hint }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/vue/ModeSelector.vue
+++ b/src/components/vue/ModeSelector.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+
+interface Mode {
+  id: string;
+  name: string;
+  tagline: string;
+  description: string;
+  href: string;
+  ctaLabel: string;
+}
+
+const modes: Mode[] = [
+  {
+    id: 'peer-tc',
+    name: 'Peer-to-Peer TC',
+    tagline: 'Nodes do threshold cryptography directly. Hours to value.',
+    description:
+      'The simplest deployment: peers exchange threshold signing messages directly over the transport of choice. Use this for MPC, distributed custody, BFT consensus, and any setting where the participants already have a channel.',
+    href: '/docs/mode1-peer-tc/',
+    ctaLabel: 'Read the Mode 1 docs',
+  },
+  {
+    id: 'pki-drop-in',
+    name: 'PKI Drop-in',
+    tagline:
+      'Replace single-party keys with threshold keys. No ecosystem changes.',
+    description:
+      'Drop Confium in front of existing PKCS#11, OpenSSL, or JCE consumers. They keep working — but every signature now requires a quorum. Use this for HSM replacement, KMS, TLS signing, code signing.',
+    href: '/docs/mode2-pki-drop-in/',
+    ctaLabel: 'Read the Mode 2 docs',
+  },
+  {
+    id: 'sovereign-pki',
+    name: 'Sovereign PKI',
+    tagline: 'Custom certificate formats for institutions. No single trusted party.',
+    description:
+      'Custom certificate formats, delegation rules, archival cadence, and quorum composition for institutions where no single party can be trusted. Sovereign PKI deployments include calibration registries, pharma regulator approvals, academic accreditation, and supply-chain provenance.',
+    href: '/docs/mode3-sovereign-pki/',
+    ctaLabel: 'Read the Mode 3 docs',
+  },
+];
+
+const selectedId = ref<string>('sovereign-pki');
+const selected = ref<Mode>(modes[2]);
+
+function select(id: string) {
+  selectedId.value = id;
+  selected.value = modes.find((m) => m.id === id) ?? modes[0];
+  if (typeof window !== 'undefined') {
+    history.replaceState(null, '', `#mode-${id}`);
+  }
+}
+
+function fromHash(): string | null {
+  if (typeof window === 'undefined') return null;
+  const h = window.location.hash;
+  const m = h.match(/^#mode-(.+)$/);
+  return m ? m[1] : null;
+}
+
+onMounted(() => {
+  const hash = fromHash();
+  if (hash && modes.some((m) => m.id === hash)) {
+    select(hash);
+  }
+});
+
+onUnmounted(() => {});
+</script>
+
+<template>
+  <div>
+    <div class="grid md:grid-cols-3 gap-4">
+      <button
+        v-for="mode in modes"
+        :key="mode.id"
+        type="button"
+        :class="[
+          'text-left rounded-lg border p-5 transition-all',
+          selectedId === mode.id
+            ? 'border-brand-500 bg-brand-50/40 dark:bg-brand-900/15 shadow-card'
+            : 'border-line bg-card hover:border-brand-300 dark:hover:border-brand-700',
+        ]"
+        @click="select(mode.id)"
+      >
+        <div class="flex items-baseline justify-between gap-2">
+          <h3 class="font-semibold text-lg">{{ mode.name }}</h3>
+          <span
+            v-if="selectedId === mode.id"
+            class="text-brand-600 dark:text-brand-400 text-sm"
+            aria-hidden="true"
+          >●</span>
+        </div>
+        <p class="mt-2 text-sm text-muted-foreground">{{ mode.tagline }}</p>
+      </button>
+    </div>
+
+    <div class="mt-6 rounded-lg border border-line bg-card p-6">
+      <p class="text-base leading-relaxed">{{ selected.description }}</p>
+      <a
+        :href="selected.href"
+        class="mt-4 inline-flex items-center gap-1 text-brand-700 dark:text-brand-300 font-medium hover:underline"
+      >
+        {{ selected.ctaLabel }}
+        <span aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</template>

--- a/src/components/vue/QuorumPlayground.vue
+++ b/src/components/vue/QuorumPlayground.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+
+const total = ref(5);
+const threshold = ref(3);
+const attempted = ref(0);
+
+const insufficient = computed(() => attempted.value > 0 && attempted.value < threshold.value);
+const quorumReached = computed(() => attempted.value >= threshold.value);
+const canSign = computed(() => quorumReached.value);
+
+const parties = computed(() => {
+  return Array.from({ length: total.value }, (_, i) => ({
+    id: i,
+    signed: i < attempted.value,
+  }));
+});
+
+function attempt(value: number) {
+  attempted.value = Math.min(value, total.value);
+}
+
+function reset() {
+  attempted.value = 0;
+}
+
+// Keep threshold sensible when total changes.
+watch(total, (n) => {
+  if (threshold.value > n) threshold.value = n;
+  if (attempted.value > n) attempted.value = n;
+});
+</script>
+
+<template>
+  <div class="rounded-lg border border-line bg-card p-6 shadow-card">
+    <div class="grid sm:grid-cols-2 gap-6 mb-6">
+      <div>
+        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+          Total parties (N)
+        </label>
+        <div class="mt-2 flex items-center gap-3">
+          <input
+            v-model.number="total"
+            type="range"
+            min="2"
+            max="9"
+            class="w-full accent-brand-600"
+          />
+          <span class="font-mono text-lg w-8 text-right">{{ total }}</span>
+        </div>
+      </div>
+      <div>
+        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+          Threshold required (T)
+        </label>
+        <div class="mt-2 flex items-center gap-3">
+          <input
+            v-model.number="threshold"
+            type="range"
+            min="2"
+            :max="total"
+            class="w-full accent-brand-600"
+          />
+          <span class="font-mono text-lg w-8 text-right">{{ threshold }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="flex items-center justify-between mb-3">
+        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+          Signers participating
+        </label>
+        <span class="text-xs text-muted-foreground">
+          {{ attempted }} / {{ total }} (need {{ threshold }})
+        </span>
+      </div>
+      <input
+        :value="attempted"
+        type="range"
+        min="0"
+        :max="total"
+        class="w-full accent-brand-600"
+        @input="attempt(Number(($event.target as HTMLInputElement).value))"
+      />
+    </div>
+
+    <div class="mt-6 flex flex-wrap gap-2">
+      <button
+        v-for="p in parties"
+        :key="p.id"
+        type="button"
+        :class="[
+          'w-12 h-12 rounded-full font-mono text-sm border transition-all',
+          p.signed
+            ? 'bg-brand-600 text-white border-brand-600 shadow-card'
+            : 'bg-card text-muted-foreground border-line hover:border-brand-400',
+        ]"
+        :title="`Party ${p.id + 1}${p.signed ? ' (signed)' : ''}`"
+        @click="attempt(p.signed ? p.id : p.id + 1)"
+      >
+        {{ p.id + 1 }}
+      </button>
+    </div>
+
+    <div class="mt-6 p-4 rounded-md border border-line bg-brand-50/30 dark:bg-brand-900/10">
+      <div class="flex items-center gap-3">
+        <div
+          :class="[
+            'w-3 h-3 rounded-full',
+            canSign
+              ? 'bg-brand-500'
+              : insufficient
+                ? 'bg-amber-500'
+                : 'bg-muted-foreground/40',
+          ]"
+        />
+        <p class="text-sm">
+          <template v-if="attempted === 0">
+            No signers yet — the signature cannot be produced.
+          </template>
+          <template v-else-if="insufficient">
+            Only {{ attempted }} of {{ threshold }} required signers
+            participated. <strong>No single party can sign alone.</strong>
+          </template>
+          <template v-else-if="canSign">
+            Quorum reached: {{ attempted }} ≥ {{ threshold }}.
+            The composite signature is valid.
+          </template>
+        </p>
+      </div>
+    </div>
+
+    <p class="mt-4 text-xs text-muted-foreground">
+      Adjust N and T to model any quorum policy — 3-of-5 directors,
+      5-of-9 from 3 distinct regions, and so on. Confium's
+      attribute-based threshold DSL expresses policies that the
+      coordinator enforces at signing time.
+    </p>
+  </div>
+</template>

--- a/src/components/vue/Reveal.vue
+++ b/src/components/vue/Reveal.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+
+interface Props {
+  /** ms delay before reveal after entering viewport */
+  delayMs?: number;
+  /** translate distance in px before reveal */
+  translateY?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  delayMs: 0,
+  translateY: 16,
+});
+
+const el = ref<HTMLElement | null>(null);
+const visible = ref(false);
+let observer: IntersectionObserver | null = null;
+
+onMounted(() => {
+  if (!el.value) return;
+
+  // Respect prefers-reduced-motion.
+  if (
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ) {
+    visible.value = true;
+    return;
+  }
+
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          if (props.delayMs > 0) {
+            window.setTimeout(() => {
+              visible.value = true;
+            }, props.delayMs);
+          } else {
+            visible.value = true;
+          }
+          observer?.disconnect();
+        }
+      }
+    },
+    { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+  );
+  observer.observe(el.value);
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+});
+</script>
+
+<template>
+  <div
+    ref="el"
+    :style="{
+      transform: visible ? 'translateY(0)' : `translateY(${props.translateY}px)`,
+      opacity: visible ? 1 : 0,
+      transition: 'transform 600ms cubic-bezier(0.22, 1, 0.36, 1), opacity 600ms ease-out',
+    }"
+  >
+    <slot />
+  </div>
+</template>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,20 +1,68 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import HeroDecrypt from '../components/vue/HeroDecrypt.vue';
+import ModeSelector from '../components/vue/ModeSelector.vue';
+import QuorumPlayground from '../components/vue/QuorumPlayground.vue';
+import InstallTabs from '../components/vue/InstallTabs.vue';
+import Reveal from '../components/vue/Reveal.vue';
+
+const differences = [
+  {
+    title: 'Software upgrade, not HSM replacement',
+    body: 'Add ML-DSA-65 alongside Ed25519 via composite signatures. Verifiers that haven\'t upgraded still accept the classical component; verifiers that have have already migrated.',
+  },
+  {
+    title: 'Catches silent certificate fraud',
+    body: 'Every signing operation anchors into an append-only Merkle transparency log (RFC 6962). Split-view attacks are detectable via consistency proofs and witness gossip.',
+  },
+  {
+    title: 'Standards-only — no vendor lock-in',
+    body: 'PKCS#11 v3.0, OpenSSL 3.0 provider, JCE provider, CMS (RFC 5652), X.509. Integrations slot into existing infrastructure.',
+  },
+  {
+    title: 'Globally distributed signers',
+    body: 'The async coordinator handles round-trip latency. Parties don\'t need to be online simultaneously — sessions complete across hours or days.',
+  },
+  {
+    title: 'Open-source, BSD-2-Clause',
+    body: 'No per-transaction fees, no proprietary protocol. Funded by NLnet NGI Zero PET and Mozilla MOSS.',
+  },
+];
+
+const notConfium = [
+  { title: 'Not a crypto library', body: 'Plugins provide algorithms. Confium is the engine that loads, dispatches, and coordinates them.' },
+  { title: 'Not an HSM', body: 'Confium integrates with HSMs via PKCS#11 / TPM. The threshold protocol is software; the secrets stay where you put them.' },
+  { title: 'Not just OpenPGP', body: 'RNP is one consumer. The framework is general — any consumer that speaks PKCS#11, OpenSSL, or JCE works.' },
+];
+
+const deployments = [
+  { name: 'Calibration registries', body: 'BIPM-style metrology chains where measurements must be traceable to a sovereign reference.' },
+  { name: 'Pharma regulator approvals', body: 'Multi-jurisdiction regulatory sign-off on clinical trial data and drug approvals.' },
+  { name: 'Academic accreditation', body: 'Cross-institutional degree and credential verification without a single trusted authority.' },
+  { name: 'Supply-chain provenance', body: 'Manufacturing step attestation anchored in a public transparency log.' },
+  { name: 'Treaty organizations', body: 'Multi-state cooperative instruments requiring concurrent sovereign approval.' },
+  { name: 'CNML', body: 'Certified measuring instruments list — one reference Mode 3 deployment.' },
+];
 ---
 
 <BaseLayout
   title="Confium"
-  description="Threshold-native trust infrastructure for a post-quantum world."
+  description="Threshold-native trust infrastructure for a post-quantum world. A configurable framework organizations deploy with their own parameters."
 >
-  <section class="pt-32 pb-16">
+  <!-- 1. Hero -->
+  <section class="pt-32 pb-20 relative overflow-hidden">
+    <div class="absolute inset-0 -z-10 opacity-30">
+      <div class="absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-brand-500/20 blur-3xl"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-96 h-96 rounded-full bg-brand-700/20 blur-3xl"></div>
+    </div>
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-400 mb-4">
-        Under construction
-      </p>
-      <h1 class="text-5xl sm:text-6xl font-bold tracking-tight">
         Threshold-native trust infrastructure
+      </p>
+      <h1 class="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight leading-[1.05]">
+        <HeroDecrypt text="Threshold-native trust" client:load />
         <span class="block text-brand-600 dark:text-brand-400 mt-2">
-          for a post-quantum world.
+          <HeroDecrypt text="for a post-quantum world." :interval-ms="45" client:load />
         </span>
       </h1>
       <p class="mt-6 text-xl text-muted-foreground max-w-3xl">
@@ -22,16 +70,16 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         transport security — a configurable framework organizations
         deploy with their own parameters.
       </p>
-
       <div class="mt-8 flex flex-wrap gap-3">
         <a
           href="/docs/architecture/"
           class="inline-flex items-center px-5 py-2.5 rounded-md bg-brand-600 hover:bg-brand-700 text-white font-medium transition-colors shadow-card"
         >
           Read the architecture
+          <span class="ml-2" aria-hidden="true">→</span>
         </a>
         <a
-          href="/software/"
+          href="#install"
           class="inline-flex items-center px-5 py-2.5 rounded-md border border-line hover:bg-brand-50/50 dark:hover:bg-brand-900/10 font-medium transition-colors"
         >
           Install
@@ -40,30 +88,189 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
   </section>
 
+  <!-- 2. Three modes -->
   <section class="py-16 border-t border-line">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-4">
-        Three deployment modes
+      <Reveal>
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+          Three deployment modes
+        </p>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight mb-2">
+          One engine, three ways to deploy
+        </h2>
+        <p class="text-muted-foreground max-w-3xl">
+          The same primitives serve all three modes. Pick the deployment
+          shape that matches your integration surface.
+        </p>
+      </Reveal>
+      <div class="mt-10">
+        <ModeSelector client:visible />
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. What makes Confium different -->
+  <section class="py-16 border-t border-line bg-card/30">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <Reveal>
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+          What makes Confium different
+        </p>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+          Five properties no single-key PKI gives you
+        </h2>
+      </Reveal>
+      <div class="mt-10 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {differences.map((d, i) => (
+          <Reveal delayMs={i * 60}>
+            <div class="rounded-lg border border-line bg-card p-6 h-full shadow-card">
+              <h3 class="font-semibold text-lg">{d.title}</h3>
+              <p class="mt-2 text-sm text-muted-foreground">{d.body}</p>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- 4. What Confium is NOT -->
+  <section class="py-16 border-t border-line">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <Reveal>
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+          What Confium is not
+        </p>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+          Avoid these common misclassifications
+        </h2>
+      </Reveal>
+      <div class="mt-10 grid md:grid-cols-3 gap-6">
+        {notConfium.map((n) => (
+          <div class="rounded-lg border border-line bg-card p-6 shadow-card">
+            <div class="flex items-start gap-3">
+              <span class="text-brand-600 dark:text-brand-400 text-xl font-mono">×</span>
+              <div>
+                <h3 class="font-semibold">{n.title}</h3>
+                <p class="mt-1 text-sm text-muted-foreground">{n.body}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. Get started -->
+  <section id="install" class="py-16 border-t border-line bg-card/30">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <Reveal>
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+          Get started
+        </p>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+          Install in your language of choice
+        </h2>
+        <p class="mt-2 text-muted-foreground max-w-3xl">
+          Three bindings shipped today. The Rust workspace is the source
+          of truth; Ruby and WASM wrap the same engine.
+        </p>
+      </Reveal>
+      <div class="mt-8 max-w-2xl">
+        <InstallTabs client:visible />
+      </div>
+    </div>
+  </section>
+
+  <!-- 6. Reference deployments -->
+  <section class="py-16 border-t border-line">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <Reveal>
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+          Reference deployments
+        </p>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+          Where Sovereign PKI is already the right shape
+        </h2>
+        <p class="mt-2 text-muted-foreground max-w-3xl">
+          Institutional certificate infrastructure where no single
+          party can be trusted. CNML is one example among many.
+        </p>
+      </Reveal>
+      <div class="mt-10 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {deployments.map((d, i) => (
+          <Reveal delayMs={i * 50}>
+            <div class="rounded-lg border border-line bg-card p-6 h-full">
+              <h3 class="font-semibold text-lg">{d.name}</h3>
+              <p class="mt-2 text-sm text-muted-foreground">{d.body}</p>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- 7. Quorum playground -->
+  <section class="py-16 border-t border-line bg-card/30">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid lg:grid-cols-2 gap-12 items-start">
+        <Reveal>
+          <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-3">
+            Interactive
+          </p>
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+            No single party can sign alone
+          </h2>
+          <p class="mt-4 text-lg text-muted-foreground">
+            Threshold cryptography means a T-of-N quorum must
+            participate before any signature is valid. Try it: drag
+            the sliders and watch what happens when the threshold
+            isn't met.
+          </p>
+          <ul class="mt-6 space-y-2 text-sm text-muted-foreground">
+            <li class="flex gap-2">
+              <span class="text-brand-600 dark:text-brand-400">→</span>
+              <span>The full secret is never reconstructed on any single machine.</span>
+            </li>
+            <li class="flex gap-2">
+              <span class="text-brand-600 dark:text-brand-400">→</span>
+              <span>Compromising any T−1 parties reveals nothing useful.</span>
+            </li>
+            <li class="flex gap-2">
+              <span class="text-brand-600 dark:text-brand-400">→</span>
+              <span>Policies compose: 5-of-9 directors from 3 distinct regions.</span>
+            </li>
+          </ul>
+          <a
+            href="/concepts/threshold-crypto-101/"
+            class="mt-6 inline-flex items-center gap-1 text-brand-700 dark:text-brand-300 font-medium hover:underline"
+          >
+            Read the threshold crypto primer
+            <span aria-hidden="true">→</span>
+          </a>
+        </Reveal>
+        <Reveal delayMs={120}>
+          <QuorumPlayground client:visible />
+        </Reveal>
+      </div>
+    </div>
+  </section>
+
+  <!-- Funding band -->
+  <section class="py-12 border-t border-line">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-6 text-center">
+        Funded by
       </p>
-      <div class="grid md:grid-cols-3 gap-6">
-        <div class="rounded-lg border border-line bg-card p-6 shadow-card">
-          <h3 class="font-semibold text-lg">Peer-to-Peer TC</h3>
-          <p class="mt-2 text-sm text-muted-foreground">
-            Nodes do threshold cryptography directly. Hours to value.
-          </p>
-        </div>
-        <div class="rounded-lg border border-line bg-card p-6 shadow-card">
-          <h3 class="font-semibold text-lg">PKI Drop-in</h3>
-          <p class="mt-2 text-sm text-muted-foreground">
-            Replace single-party keys with threshold keys. No ecosystem changes.
-          </p>
-        </div>
-        <div class="rounded-lg border border-line bg-card p-6 shadow-card">
-          <h3 class="font-semibold text-lg">Sovereign PKI</h3>
-          <p class="mt-2 text-sm text-muted-foreground">
-            Custom certificate formats for institutions. No single trusted party.
-          </p>
-        </div>
+      <div class="flex flex-wrap justify-center items-center gap-8">
+        <a href="https://nlnet.nl/project/Confium/" class="opacity-70 hover:opacity-100 transition-opacity">
+          <img src="/assets/nlnet-banner.svg" alt="NLnet" class="h-10" />
+        </a>
+        <a href="https://www.ngi.eu/ngi-projects/ngi-zero-pet/" class="opacity-70 hover:opacity-100 transition-opacity">
+          <img src="/assets/ngi-zeropet-banner.svg" alt="NGI Zero PET" class="h-10" />
+        </a>
+        <a href="https://www.mozilla.org/moss/" class="opacity-70 hover:opacity-100 transition-opacity">
+          <span class="font-mono text-sm">Mozilla MOSS</span>
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Implements TODO #035 — replaces the placeholder homepage with the full seven-section layout and adds the six interactive Vue islands called out in the plan.

## Homepage sections

1. **Hero** — animated tagline via `HeroDecrypt` (character-decrypt reveal), subtitle, dual CTA (Read the architecture / Install).
2. **Three modes** — interactive `ModeSelector` card picker with expandable detail panel. URL hash sync (`#mode-<id>`).
3. **What makes Confium different** — 5 differentiator cards (software-upgrade PQ migration, transparency logs, standards-only, async coordinator, open source).
4. **What Confium is NOT** — 3 negation cards (not a crypto library, not an HSM, not just OpenPGP).
5. **Get started** — `InstallTabs` (Ruby / Rust / WASM / Source) with `CopyButton`.
6. **Reference deployments** — 6 Sovereign PKI scenarios (CNML as one among six).
7. **Quorum playground** — interactive T-of-N slider showing "no single party can sign alone".

Funding footer band closes the page (NLnet + NGI Zero PET + Mozilla MOSS).

## Vue islands added

- **`HeroDecrypt.vue`** — character decrypt animation; replays on `confium:replay-hero` event.
- **`ModeSelector.vue`** — three-mode card picker; URL hash state for shareable links.
- **`QuorumPlayground.vue`** — N/T sliders + party dots + status banner (insufficient / quorum reached).
- **`InstallTabs.vue`** — platform tab switcher (Ruby / Rust / WASM / Source).
- **`CopyButton.vue`** — clipboard with `execCommand` fallback + success state.
- **`Reveal.vue`** — IntersectionObserver scroll reveal with `prefers-reduced-motion` opt-out.

## Coordination

Cross-island communication via `@lib/events` (typed event bus) — no shared state, no prop drilling.

Below-the-fold islands use `client:visible`; above-the-fold use `client:load`. SSR-safe (no `window` access at module top level).

## Content constraints

- No "OIML" anywhere.
- No "TODO" / "coming soon" / "planned" / "milestone" / "roadmap" language.
- CNML appears as one of six deployment cards in section 6, never as the headline.

## Verification (local)

- `npm run build` succeeds.
- `grep -ril OIML dist/` → zero hits.
- `grep -rEi 'TODO|coming soon|planned|milestone|roadmap' dist/` → zero hits.
- Mobile viewport (375px): hero text wraps cleanly, mode cards stack, quorum playground remains usable.

## Follow-up

- TODO #036 — `/docs/` pages (10 files).
- TODO #037 — about + 404 + meta pages.
