### PR TITLE
docs(ten-docs-pages): 10 MDX doc pages + index and dynamic routes

### DIFF
--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -1,0 +1,132 @@
+---
+title: Architecture
+description: Confium's engine, plugin loader, versioned interfaces, coordinator, and the principles that shape every crate.
+audience: developer
+order: 1
+---
+
+import Prose from '../../components/astro/Prose.astro';
+
+# Architecture
+
+Confium is a configurable engine for multi-stakeholder threshold
+cryptography. The engine loads plugins that implement cryptographic
+primitives; bindings and adapters wrap the engine for different
+language ecosystems and integration points.
+
+## Layers
+
+| Layer | Role |
+| --- | --- |
+| **Host library** | `libconfium` — the engine. Loads plugins, dispatches calls, exposes the `cfm_*` C ABI. |
+| **Plugins** | Dynamic libraries implementing the `cfmp_*` contract for one or more interfaces. |
+| **Adapters** | Mode 2 wrappers (PKCS#11 server, OpenSSL provider, JCE provider, TLS signer) that translate industry-standard APIs into Confium calls. |
+| **Bindings** | Ruby, WASM, and future language bindings that wrap the C ABI for application developers. |
+| **Coordinator** | Async session service for distributed threshold cryptography across geographically separated parties. |
+
+## The plugin contract
+
+A Confium plugin is a `cdylib` that exports a small set of bootstrap
+symbols. Confium loads the library, calls `cfmp_query_interfaces` to
+discover what the plugin provides, then negotiates per-interface
+versions before routing calls.
+
+Bootstrap symbols:
+
+| Symbol | Role |
+| --- | --- |
+| `cfmp_interface_version` | Returns the plugin-contract ABI version this plugin targets. |
+| `cfmp_initialize(cfm, opts)` | One-time setup. `cfm` is an opaque host handle; `opts` is the loader-supplied option bag. |
+| `cfmp_finalize(cfm)` | One-time teardown. |
+| `cfmp_query_interfaces` | Returns `name\0version\0` pairs naming the interface types and versions the plugin implements. |
+| `cfmp_metadata` *(optional)* | Returns static metadata (name, version, vendor, license) for the registry. |
+| `cfmp_query_dependencies` *(optional)* | Returns a dependency list. Confium resolves these before `cfmp_initialize`. |
+
+Per-interface symbols follow the pattern `cfmp_<interface>_*` (e.g.
+`cfmp_hash_create`, `cfmp_hash_update`, `cfmp_hash_finalize`).
+
+## Versioned interfaces
+
+Each interface is independently versioned. A plugin can implement
+`hash` v0 and `cipher` v1 simultaneously. The host negotiates the
+highest mutually-supported version per interface, per plugin.
+
+Shipped interfaces (in `confium-core`):
+
+- `hash` — cryptographic hash
+- `rng` — random number generation
+- `cipher` — symmetric encryption
+- `aead` — authenticated encryption
+- `kdf` — key derivation
+- `kem` — key encapsulation
+- `key_fmt` — key serialization
+- `signature` — digital signatures
+
+Adding a new interface is one module that calls `register_interface!`.
+No edits to existing interfaces or to the host dispatch.
+
+## The coordinator
+
+Threshold cryptography protocols (FROST, CMP20, GG18) require multiple
+parties to exchange messages across rounds. The
+`confium-tc-coordinator` service orchestrates these sessions
+asynchronously, so parties do not need to be online simultaneously.
+
+Sessions are identified by a session ID. Each party joins, submits
+their round messages, and the coordinator aggregates them and either
+advances the round or returns the final signature.
+
+The coordinator is transport-agnostic (`confium-net` abstraction with
+TCP, QUIC, and WebSocket implementations).
+
+## Architecture principles
+
+### OCP via traits
+
+New backends add new files. The trait is the contract; the
+implementations are closed for modification. Examples:
+
+- `IdentityBackend` — pluggable identity sources
+- `Encapsulator` — KEM backends
+- `Aead` — AEAD backends
+- `QuorumDispatcher` — quorum decision logic
+- `OpenpgpCardBackend` — OpenPGP card hardware backends
+- `ThresholdSigner` — threshold signing protocols
+
+### No unsafe code
+
+Every crate carries `#![forbid(unsafe_code)]`. All FFI is contained in
+`confium-core` and uses `#[unsafe(no_mangle)]` per edition 2024
+requirements.
+
+### No vendor SDKs
+
+Confium integrates with hardware via standards only:
+
+- PKCS#11 v3.0 (HSMs)
+- OpenPGP card (YubiKey, Nitrokey)
+- OpenSSL 3.0 provider (TLS libraries)
+- JCE provider (Java)
+- TPM 2.0
+
+This keeps Confium deployable across vendor boundaries without
+licensing or redistribution concerns.
+
+### Documentation is required
+
+Every crate carries `#![warn(missing_docs)]`. Every public item has a
+doc comment. `cargo doc --workspace --no-deps` must build cleanly.
+
+### Type-safe errors
+
+Errors are typed via `thiserror` (or `snafu` 0.8 in legacy crates).
+Each crate has its own error enum with descriptive variants. No
+string errors.
+
+## See also
+
+- [Three modes](./three-modes.mdx)
+- [Components](./components.mdx)
+- [Security model](./security-model.mdx)
+- [Plugin author guide](https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx)
+  in the Rust workspace docs.

--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -1,0 +1,142 @@
+---
+title: Components
+description: The 43-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency.
+audience: developer
+order: 6
+---
+
+# Components
+
+The Confium Rust workspace contains 43 crates organized by concern.
+This page maps every crate to its category and role. For full API
+details, see the [RustDoc](https://docs.confium.org/).
+
+## Categories
+
+| Category | Role |
+| --- | --- |
+| **Engine / Core** | The host library, plugin loader, public API, CLI. |
+| **Threshold cryptography** | Threshold signing protocols (FROST, CMP20, GG18). |
+| **Threshold encryption** | Threshold encryption schemes (ElGamal, ECIES, ML-KEM, FHE). |
+| **PKI / Certificates** | X.509, CMS, XMLDSig, composite signatures, attribute predicates. |
+| **Storage / Hardware** | Compartmentalized backends: PKCS#11, TPM, cloud KMS, OpenPGP card. |
+| **Mode 2 / PKI replacement** | Drop-in adapters for PKCS#11, OpenSSL, JCE, TLS. |
+| **Network / Transport** | TCP, QUIC, WebSocket transports and sandbox runtimes. |
+| **Thunderbird-inspired** | Threshold key escrow and revocation service patterns. |
+| **Identity / Config** | Actor identity and deployment manifest types. |
+| **Transparency / Archival** | Merkle transparency logs, OTS, ERS archival. |
+| **Research frontier** | Threshold ring signatures and other explorations. |
+
+## Engine / Core
+
+| Crate | Role |
+| --- | --- |
+| `confium-core` | Engine: plugin loader, registry, FFI entry points (10 interfaces shipped). |
+| `confium-api` | Public Rust API + plugin SDK shared types. |
+| `confium-macros` | Proc-macros for plugin authors. |
+| `confium-cli` | `confium` end-user command. |
+| `confium-daemon` | JSON-RPC daemon over Unix socket / TCP. |
+| `confium-mock-plugin` | Reference mock plugin for testing. |
+| `confium-publish` | Author tool for the plugin registry. |
+| `confium-test-harness` | NIST MPTS evaluation bench. |
+| `confium-examples` | Standalone example binaries. |
+| `confium-patterns` | Cross-cutting architectural patterns and helpers. |
+| `confium-registry` | Static plugin / publisher / trust-root catalog. |
+
+## Threshold cryptography
+
+| Crate | Role |
+| --- | --- |
+| `confium-tc` | TC session primitives (interface). |
+| `confium-tc-frost-ed25519` | Real FROST-ed25519 (3-round signing). |
+| `confium-tc-frost-p256` | Real P-256 Shamir + ECDSA. |
+| `confium-tc-cmp20` | Real CMP20 threshold ECDSA. |
+| `confium-tc-gg18` | Real GG18 threshold ECDSA. |
+| `confium-tc-bls` | Threshold BLS skeleton. |
+| `confium-tc-frost-ml-dsa-65` | Threshold ML-DSA-65 (research). |
+| `confium-tc-coordinator` | Async session coordinator service. |
+| `confium-tc-reshare` | Share re-sharing + Herzberg refresh. |
+| `confium-tc-kem` | Threshold KEM session interface. |
+
+## Threshold encryption
+
+| Crate | Role |
+| --- | --- |
+| `confium-tc-elgamal-p256` | Real threshold ElGamal-P256. |
+| `confium-tc-ecies-p256` | Threshold ECIES skeleton. |
+| `confium-tc-ml-kem` | Threshold ML-KEM (FIPS 203) research. |
+| `confium-tc-fhe-bfv` | Threshold BFV FHE research. |
+
+## PKI / Certificates
+
+| Crate | Role |
+| --- | --- |
+| `confium-cert` | X.509 cert + CSR types, path validation. |
+| `confium-cert-delegation` | Scoped delegation templates. |
+| `confium-cms` | CMS / PKCS#7 SignedData envelope. |
+| `confium-xmldsig` | XMLDSig + Exclusive C14N. |
+| `confium-composite` | Composite multi-alg signatures for PQC migration. |
+| `confium-attributes` | Attribute-based threshold predicates + DSL. |
+
+## Storage / Hardware
+
+| Crate | Role |
+| --- | --- |
+| `confium-store` | Store pillar with compartmentalized backends. |
+| `confium-store-pkcs11` | PKCS#11 wrapping backend. |
+| `confium-store-tpm` | TPM 2.0 sealed storage. |
+| `confium-store-cloud` | AWS / GCP / Azure KMS REST. |
+| `confium-store-openpgp-card` | OpenPGP card backend (YubiKey, Nitrokey). |
+
+## Mode 2 / PKI replacement
+
+| Crate | Role |
+| --- | --- |
+| `confium-pkcs11-server` | PKCS#11 v3.0 dispatch to threshold protocol. |
+| `confium-openssl-provider` | OpenSSL 3.0 provider. |
+| `confium-tls-signer` | TLS 1.3 signature callback. |
+| `confium-jce-provider` | Java Cryptography Extension provider. |
+
+## Network / Transport
+
+| Crate | Role |
+| --- | --- |
+| `confium-net` | Network abstraction. |
+| `confium-net-tcp` | TCP transport. |
+| `confium-net-quic` | QUIC transport. |
+| `confium-net-ws` | WebSocket transport. |
+| `confium-sandbox-wasm` | WASM sandbox for browser director signing. |
+| `confium-sandbox-process` | Out-of-process sandbox. |
+
+## Identity / Config
+
+| Crate | Role |
+| --- | --- |
+| `confium-identity` | Actor identity (manufacturer, lab, director). |
+| `confium-config` | Deployment manifest (TOML) with validation. |
+
+## Transparency / Archival
+
+| Crate | Role |
+| --- | --- |
+| `confium-transparency` | Append-only Merkle tree + OTS anchoring. |
+| `confium-ots` | OpenTimestamps client. |
+| `confium-ers` | RFC 4998 Evidence Record Syntax. |
+
+## Choosing a crate
+
+- **As a library**: `confium-core` + interface crates (`composite`,
+  `pki`, `attributes`, `transparency`).
+- **Plugin author**: `confium-api` + `confium-macros`.
+- **Threshold signing**: pick a protocol crate (`frost-ed25519`,
+  `frost-p256`, `cmp20`, `gg18`) and use `confium-tc-coordinator`.
+- **HSM/PKI replacement**: Mode 2 crates — `confium-pkcs11-server`,
+  `confium-openssl-provider`, `confium-jce-provider`.
+- **Institutional PKI**: Mode 3 — `confium-cert`,
+  `confium-cert-delegation`, `confium-cms`, `confium-attributes`,
+  `confium-transparency`.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [RustDoc](https://docs.confium.org/)

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -1,0 +1,81 @@
+---
+title: Getting started
+description: Quickstart hub for Confium — Ruby, Rust, and WASM install commands and pointers into per-binding docs.
+audience: developer
+order: 10
+---
+
+# Getting started
+
+Three bindings shipped today. Pick your language.
+
+## Ruby
+
+```sh
+gem install confium
+```
+
+The native extension is built at install time via rake-compiler. You
+need Ruby ≥ 3.1 and Rust stable. See the
+[Ruby installation guide](https://github.com/confium/confium-ruby/tree/main/docs/installation.mdx).
+
+Quickstart: build a Sinatra verifier app in ~60 lines →
+[Sinatra verifier quickstart](https://github.com/confium/confium-ruby/tree/main/docs/quickstarts/sinatra-verifier.mdx).
+
+## Rust
+
+```sh
+cargo add confium-core
+```
+
+The cdylib is built as
+`target/{debug,release}/libconfium.{so,dylib,dll}`. See the
+[Rust installation guide](https://github.com/confium/confium/tree/main/docs/installation.mdx).
+
+Quickstart: walk through threshold signing with FROST-P256 →
+[threshold-signing.mdx](https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx).
+
+## WASM
+
+```sh
+npm install @confium/confium-wasm
+```
+
+Browser / Node.js verifier for composite signatures, transparency
+logs, attribute predicates, and X.509 / CMS structures. The WASM
+package is **verifier-only** — it cannot sign.
+
+Quickstart: load a composite signature and verify it in the browser:
+
+```javascript
+import init, { CompositeSignature } from "@confium/confium-wasm";
+await init();
+const sig = CompositeSignature.from_json(jsonString);
+const result = sig.verify(messageBytes, {
+  "Ed25519": "builtin",
+  "ECDSA-P256": "builtin",
+  "ML-DSA-65": (pk, msg, sig) => myExternalVerifier(pk, msg, sig),
+});
+console.log(result.all_verified);
+```
+
+## What to read next
+
+- [Architecture](./architecture.mdx) — understand the engine.
+- [Three modes](./three-modes.mdx) — pick a deployment shape.
+- [Security model](./security-model.mdx) — threat model and defenses.
+- [PQ migration](./pq-migration.mdx) — composite signatures.
+
+## Concepts
+
+If you're new to threshold cryptography:
+
+- [Threshold crypto 101](/concepts/threshold-crypto-101/)
+- [TLS analogy](/concepts/tls-analogy/)
+- [Composite signatures](/concepts/composite-signatures/)
+- [Transparency logs](/concepts/transparency-logs/)
+- [Attribute-based threshold](/concepts/attribute-based-threshold/)
+
+## Specs
+
+For normative specifications, see the [specs repository](https://github.com/confium/specs).

--- a/src/content/docs/mode1-peer-tc.mdx
+++ b/src/content/docs/mode1-peer-tc.mdx
@@ -1,0 +1,70 @@
+---
+title: Mode 1 — Peer-to-Peer TC
+description: Nodes do threshold cryptography directly. Hours to value. The simplest deployment shape.
+audience: developer
+order: 3
+---
+
+# Mode 1 — Peer-to-Peer TC
+
+In Mode 1, participants exchange threshold protocol messages
+directly. There's no intermediary CA, no PKCS#11 adapter, no
+existing infrastructure to integrate with — just nodes running
+Confium and a transport between them.
+
+## When to choose Mode 1
+
+- You're building a new distributed system from scratch.
+- Both sides of every signing session are online (or can complete
+  sessions across hours via async messaging).
+- You want minimal moving parts — no adapter, no translation layer.
+- You don't need to interoperate with an existing PKI consumer.
+
+Typical Mode 1 deployments: MPC, distributed custody, BFT consensus,
+threshold-key backup, multi-stakeholder signing of any kind where the
+participants already have a channel.
+
+## What you need
+
+- A `libconfium` build on each participating node.
+- The threshold protocol crate matching your algorithm choice (FROST,
+  CMP20, GG18, threshold ElGamal).
+- A transport — pick from `confium-net-tcp`, `confium-net-quic`,
+  `confium-net-ws`, or supply your own via the `confium-net`
+  abstraction.
+- A deployment manifest (TOML) describing signers, quorum policy,
+  and algorithm allow-list.
+
+## Signing flow
+
+1. **Setup**: Each party generates a key share. The shares
+   collectively form the threshold key but no single share reveals
+   the secret.
+2. **Session start**: One party initiates a signing session with the
+   coordinator, specifying the message, threshold, and participant
+   list.
+3. **Round 1, 2, ...**: Each party commits nonces and partial
+   signatures. The coordinator aggregates inputs.
+4. **Finalization**: Once T parties have participated, the coordinator
+   produces the final signature. The signature is indistinguishable
+   from one produced by a single-key signer.
+5. **Audit**: The signing event is recorded in the transparency log.
+
+## Async vs synchronous sessions
+
+Mode 1 sessions can be:
+
+- **Synchronous** — all parties online, session completes in seconds.
+- **Asynchronous** — parties join and submit over hours or days. The
+  coordinator holds state until threshold is reached.
+
+The async mode is what enables globally distributed signers. A
+director in Tokyo can submit their share during their workday; a
+director in New York submits theirs hours later; the coordinator
+combines them when quorum is reached.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Components](./components.mdx)
+- [Use case: Distributed custody](/use-cases/distributed-custody/)

--- a/src/content/docs/mode2-pki-drop-in.mdx
+++ b/src/content/docs/mode2-pki-drop-in.mdx
@@ -1,0 +1,73 @@
+---
+title: Mode 2 — PKI Drop-in
+description: Replace single-party keys with threshold keys. Existing PKCS#11 / OpenSSL / JCE consumers keep working unchanged.
+audience: developer
+order: 4
+---
+
+# Mode 2 — PKI Drop-in
+
+Mode 2 is for existing PKI consumers that need to migrate from
+single-party keys to threshold keys without touching the application
+layer. The application keeps talking PKCS#11, OpenSSL, JCE, or a TLS
+callback — Confium translates every operation into a threshold
+session behind the scenes.
+
+## When to choose Mode 2
+
+- You have an existing TLS terminator, code signer, document signer,
+  KMS, or HSM-backed service.
+- You want threshold-key security without rewriting the consumer.
+- You want to migrate to post-quantum algorithms via composite
+  signatures.
+
+## The integration surface
+
+Confium ships four adapters:
+
+| Adapter | What it speaks | What it replaces |
+| --- | --- | --- |
+| `confium-pkcs11-server` | PKCS#11 v3.0 | HSM |
+| `confium-openssl-provider` | OpenSSL 3.0 provider | OpenSSL EVP_PKEY backend |
+| `confium-jce-provider` | JCE provider | Java KeyStore / Cipher / Signature |
+| `confium-tls-signer` | TLS 1.3 signature callback | TLS private-key operations |
+
+Each adapter exposes the standard API; under the hood it dispatches
+to a Confium coordinator that runs a threshold session per
+operation.
+
+## Deployment shape
+
+```
+[ Existing consumer ] --- PKCS#11 / OpenSSL / JCE ---> [ Confium adapter ]
+                                                                |
+                                                                v
+                                                        [ Coordinator ]
+                                                                |
+                                                       [ Party 1 ] [ Party 2 ] [ Party N ]
+```
+
+The consumer doesn't know about threshold keys, quorum, or sessions.
+It calls `C_Sign()` (or `EVP_DigestSign()`, or `Signature.sign()`)
+and gets back a signature. The adapter handles the rest.
+
+## Post-quantum migration
+
+Mode 2 is the natural home for PQ migration via composite signatures:
+
+1. The deployment adds an ML-DSA-65 component to the existing
+   classical algorithm (Ed25519 or ECDSA-P256).
+2. The composite signature is published alongside the existing single-algorithm signature.
+3. Upgraded verifiers check both components; legacy verifiers check only the classical component and continue to accept.
+4. Once all verifiers are upgraded, the classical component can be removed.
+
+This is a software upgrade, not an HSM replacement. No new hardware,
+no re-issuance of every certificate, no flag day.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [PQ migration](./pq-migration.mdx)
+- [Use case: Web TLS](/use-cases/web-tls/)
+- [Use case: Code signing](/use-cases/code-signing/)
+- [Use case: PQ migration](/use-cases/pq-migration/)

--- a/src/content/docs/mode3-sovereign-pki.mdx
+++ b/src/content/docs/mode3-sovereign-pki.mdx
@@ -1,0 +1,90 @@
+---
+title: Mode 3 — Sovereign PKI
+description: Custom certificate formats for institutions where no single party can be trusted. Sovereign over formats, delegation, archival, quorum.
+audience: developer
+order: 5
+---
+
+# Mode 3 — Sovereign PKI
+
+Sovereign PKI is institutional certificate infrastructure where no
+single party can be trusted. Confium's Mode 3 gives institutions
+sovereignty over four dimensions that conventional PKI locks down:
+
+1. **Certificate formats** — define your own certificate structure,
+   extensions, and encoding. CMS, X.509, custom ASN.1, or JSON.
+2. **Delegation rules** — express scoped delegation ("this issuer
+   can issue measuring-instrument certificates, but only for
+   category C, and only until 2027-04-01").
+3. **Archival cadence** — define how often tree heads are anchored
+   in external media (Bitcoin via OTS, RFC 4998 ERS archival).
+4. **Quorum composition** — express attribute-based threshold
+   policies: "5-of-9 directors from 3 distinct regions".
+
+## When to choose Mode 3
+
+- You're an institution that issues certificates and no single
+  stakeholder can hold the signing key alone.
+- Conventional CA software doesn't model your delegation,
+  jurisdiction, or quorum rules.
+- You need a public, verifiable record of every certificate ever
+  issued (transparency log).
+- You operate across jurisdictions with different algorithm
+  requirements.
+
+## Reference deployments
+
+Sovereign PKI is the right shape for:
+
+- **Calibration registries** — BIPM-style metrology chains where
+  measurements must be traceable to a sovereign reference.
+- **Pharma regulator approvals** — multi-jurisdiction sign-off on
+  clinical trial data and drug approvals.
+- **Academic accreditation** — cross-institutional degree and
+  credential verification without a single trusted authority.
+- **Supply-chain provenance** — manufacturing step attestation
+  anchored in a public transparency log.
+- **Treaty organizations** — multi-state cooperative instruments
+  requiring concurrent sovereign approval.
+- **CNML** — certified measuring instruments list, a reference Mode 3
+  deployment.
+
+## Architecture
+
+A Mode 3 deployment typically includes:
+
+- **Custom certificate profile** — declared via the `confium-cert`
+  crate's profile mechanism.
+- **Delegation templates** — `confium-cert-delegation` for scoped
+  delegation chains.
+- **Attribute-based threshold predicates** — `confium-attributes`
+  for quorum policies ("T-of-N from K distinct groups").
+- **Transparency log** — `confium-transparency` (RFC 6962 Merkle
+  tree) anchoring every certificate issuance.
+- **OpenTimestamps anchoring** — `confium-ots` for Bitcoin-anchored
+  tree heads (defense in depth).
+- **Archival** — `confium-ers` (RFC 4998 Evidence Record Syntax) for
+  long-term evidence retention.
+- **Coordinator** — `confium-tc-coordinator` orchestrating signing
+  sessions across the institutional signers.
+
+## Defense in depth
+
+Mode 3 deployments should layer:
+
+1. **Consistency proofs** (RFC 6962 §2.1.2) — every new tree head
+   extends the previous one.
+2. **Witness gossip** — coordinators share tree heads periodically
+   so split-view attacks are detectable.
+3. **OTS anchoring** — tree heads are timestamped in Bitcoin for an
+   irrefutable "what head existed at time T" record.
+
+See [the transparency logs security analysis](https://github.com/confium/confium/tree/main/docs/security/transparency-logs.mdx)
+for details.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Transparency logs](./transparency-logs.mdx)
+- [Security model](./security-model.mdx)
+- [Use case: Sovereign PKI](/use-cases/sovereign-pki/)

--- a/src/content/docs/pq-migration.mdx
+++ b/src/content/docs/pq-migration.mdx
@@ -1,0 +1,107 @@
+---
+title: Post-quantum migration
+description: Migrate from classical to post-quantum signatures via composite signatures. Software upgrade, not HSM replacement. No certificate re-issuance flag day.
+audience: developer
+order: 8
+---
+
+# Post-quantum migration
+
+The post-quantum migration problem is hard. Every existing
+certificate in the world is signed with a classical algorithm
+(RSA, ECDSA, Ed25519). When a sufficiently large quantum computer
+arrives, every one of those signatures becomes forgeable. But you
+can't re-issue every certificate on a single flag day — the
+installed base of verifiers won't all upgrade simultaneously.
+
+Confium's answer: **composite signatures**. A composite signature
+contains the artifacts of multiple algorithms (e.g. Ed25519 +
+ECDSA-P256 + ML-DSA-65); verifiers check all components and accept
+the signature only if every component verifies. Migration becomes a
+software upgrade, not an HSM replacement.
+
+## How composite signatures work
+
+A composite signature is a value type that bundles:
+
+- A list of `(algorithm_oid, public_key, signature)` tuples.
+- Optional metadata describing the policy under which the composite
+  was produced.
+
+Verification is per-component:
+
+1. For each component, look up the verifier for its algorithm OID.
+2. Verify the component's signature against the message.
+3. If every component verifies, the composite is valid.
+4. If any component fails or any required algorithm is missing, the
+   composite is invalid.
+
+## Migration timeline
+
+### Phase 1 — Classical only (today)
+
+Existing certificates signed with Ed25519 or ECDSA-P256. Verifiers
+accept.
+
+### Phase 2 — Hybrid (migration begins)
+
+New certificates signed with a composite of (classical + PQ).
+Verifiers split into two populations:
+
+- **Upgraded** verifiers check both components. They accept the
+  composite as valid.
+- **Legacy** verifiers don't understand composites; they fall back
+  to the classical component and continue to accept.
+
+This is the key property: **adding a PQ component does not break
+legacy verifiers**.
+
+### Phase 3 — PQ required
+
+Once every verifier has been upgraded, the deployment policy is
+tightened: composite signatures must include a PQ component.
+Signers stop emitting classical-only signatures.
+
+### Phase 4 — PQ only
+
+Eventually the classical component can be removed. New certificates
+are PQ-only. The classical component is retained for archival
+verification of pre-migration signatures.
+
+## Software upgrade, not HSM replacement
+
+The entire migration happens via:
+
+1. A `confium-composite` crate update that knows about ML-DSA-65.
+2. A plugin that provides the ML-DSA-65 verifier (currently via
+   caller-supplied callback; native support arrives when a suitable
+   pure-Rust verifier crate ships).
+3. A deployment policy update that requires the new component.
+
+No new HSM. No re-issuance of every certificate. No flag day.
+
+## Caller-supplied PQ verifiers
+
+For PQ algorithms without a bundled pure-Rust verifier, Confium
+accepts a caller-supplied verifier callback. The deployment wires
+its preferred ML-DSA / SLH-DSA implementation (Botan plugin,
+in-process Rust crate, FFI to a C library, or a remote verification
+service) into the composite verifier.
+
+```ruby
+sig = Confium::Composite::Signature.new(components)
+result = sig.verify(message, {
+  "ML-DSA-65" => ->(pk, msg, sig) { my_ml_dsa_verifier.verify(pk, msg, sig) },
+})
+```
+
+A missing verifier for any component is a hard failure, not a
+soft-accept. This is critical: the composite layer never silently
+accepts on the subset of components it can verify.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Mode 2 — PKI Drop-in](./mode2-pki-drop-in.mdx)
+- [Use case: PQ migration](/use-cases/pq-migration/)
+- [Concepts: Composite signatures](/concepts/composite-signatures/)

--- a/src/content/docs/security-model.mdx
+++ b/src/content/docs/security-model.mdx
@@ -1,0 +1,107 @@
+---
+title: Security model
+description: Confium's threat model, trust assumptions, and defense-in-depth layers. What the framework protects against and what it expects of operators.
+audience: evaluator
+order: 7
+---
+
+# Security model
+
+Confium protects against single-party key compromise by requiring a
+threshold of parties to participate in every signing operation. The
+broader security model layers additional defenses against
+split-view attacks, share compromise over time, and policy
+violations.
+
+## Trust model
+
+A Confium deployment with threshold T-of-N tolerates compromise of
+up to T−1 parties without losing the ability to produce valid
+signatures. Equally important: compromise of up to T−1 parties
+**does not** let the attacker produce valid signatures on their own.
+
+The trust assumption is that an attacker cannot compromise T or more
+parties simultaneously within a single signing session.
+
+## Threats and defenses
+
+### Single-key compromise
+
+**Threat**: An attacker steals the signing key.
+**Defense**: There is no single signing key. The secret is split
+across N parties via Shamir secret sharing (or the FROST / CMP20 /
+GG18 protocol equivalent). Compromising one party reveals one share,
+which is mathematically useless on its own.
+
+### Split-view attack
+
+**Threat**: A transparency log operator presents different tree
+heads to different verifiers, allowing selective insertion or
+omission of entries per audience.
+**Defense**: Three layers, see
+[transparency logs](./transparency-logs.mdx):
+
+1. **Consistency proofs** (RFC 6962 §2.1.2) — every new tree head
+   extends the previous one.
+2. **Witness gossip** — coordinators share tree heads periodically.
+3. **OTS anchoring** — tree heads timestamped in Bitcoin.
+
+### Share compromise over time
+
+**Threat**: An attacker compromises one party today and another
+next year, eventually collecting T shares.
+**Defense**: **Proactive share refresh** (Herzberg refresh) via
+`confium-tc-reshare`. Shares are periodically re-randomized so a
+compromised share from period 1 is useless in period 2. To compromise
+T shares, the attacker must do it within a single refresh window.
+
+### Side-channel attacks
+
+**Threat**: Timing or memory-disclosure side channels leak share
+material.
+**Defense**: Constant-time scalar arithmetic via the `p256` crate's
+`CtOption` API. `SecureBytes` zeroizes on drop. Every crate carries
+`#![forbid(unsafe_code)]`.
+
+### Policy violations
+
+**Threat**: A signer or operator attempts to use an algorithm
+disallowed by jurisdictional policy (e.g. SHA-1 in a FIPS deployment).
+**Defense**: `Confium::Policy` is process-global and enforced on
+every signing / verification / hashing call. Violations raise
+`Confium::PolicyViolationError`.
+
+### Coordinator compromise
+
+**Threat**: The coordinator is compromised and attempts to forge a
+signature or replay a session.
+**Defense**: The coordinator cannot produce a valid signature
+without T party contributions. Sessions carry unique nonces;
+replaying a session produces a detectable hash mismatch.
+
+The coordinator is a trusted *availability* party, not a trusted
+*secrecy* party. Compromising it can denial-of-service the
+deployment but cannot produce unauthorized signatures.
+
+## What Confium does NOT protect against
+
+- **Out-of-band key generation**: If you generate keys outside
+  Confium and import them improperly, that's your problem.
+- **Operator error**: A misconfigured quorum policy that allows
+  T=1 defeats the threshold property. Audit your deployment manifest.
+- **Endpoint compromise**: If a signer's machine is fully
+  compromised (kernel-level rootkit), share material can be exfiltrated
+  at the moment of use. Use hardware enclaves (TPM, OpenPGP card) for
+  the highest-assurance deployments.
+- **Social engineering of quorum members**: T directors colluding
+  can sign anything. This is by design.
+
+## Reporting a vulnerability
+
+See [/security/](/security/) for disclosure policy, PGP key, and SLA.
+
+## See also
+
+- [Transparency logs](./transparency-logs.mdx)
+- [Architecture](./architecture.mdx)
+- [Mode 3 — Sovereign PKI](./mode3-sovereign-pki.mdx)

--- a/src/content/docs/three-modes.mdx
+++ b/src/content/docs/three-modes.mdx
@@ -1,0 +1,65 @@
+---
+title: Three deployment modes
+description: Mode 1 (Peer-to-Peer TC), Mode 2 (PKI Drop-in), Mode 3 (Sovereign PKI). One engine, three integration shapes.
+audience: developer
+order: 2
+---
+
+# Three deployment modes
+
+Confium is layered across three deployment modes. The same engine
+and the same primitives serve all three — what differs is where the
+integration boundary sits and what shape the trust relationship
+takes.
+
+## At a glance
+
+| Mode | Name | Integration shape | When to choose |
+| --- | --- | --- | --- |
+| 1 | **Peer-to-Peer TC** | Nodes exchange threshold messages directly | You control both sides of the channel and want minimal moving parts |
+| 2 | **PKI Drop-in** | Existing PKCS#11 / OpenSSL / JCE consumer + Confium server | You have an existing PKI consumer that needs to migrate to threshold keys |
+| 3 | **Sovereign PKI** | Custom certificate formats, custom workflows, multi-stakeholder governance | You are an institution where no single party can be trusted |
+
+## Why three modes
+
+Threshold cryptography is a *primitive*. How you deploy it depends on
+what you're plugging it into.
+
+- If you're building a new distributed system from scratch, you want
+  peer-to-peer: every node speaks the protocol directly. (Mode 1)
+- If you have an existing PKI consumer (a TLS terminator, a code
+  signer, an HSM-backed signing service), you want a drop-in: the
+  consumer keeps talking PKCS#11 / OpenSSL / JCE; Confium translates
+  each call into a threshold session behind the scenes. (Mode 2)
+- If you're an institution that needs custom certificate formats,
+  delegation rules, archival cadence, or quorum composition — the
+  kind of thing a conventional CA can't represent — you want Mode 3.
+
+The three modes are not mutually exclusive. A single deployment may
+use Mode 2 internally (to migrate an existing code signer) and
+Mode 3 externally (to issue certificates that downstream verifiers
+trust).
+
+## What's common
+
+Regardless of mode, every deployment shares:
+
+- The **engine** (`libconfium`) and its plugin loader.
+- The **threshold protocols** (FROST, CMP20, GG18, threshold ElGamal).
+- The **coordinator** for async multi-party sessions.
+- The **transparency log** for tamper-evident audit.
+- The **attribute DSL** for quorum policies.
+
+What changes is the *adapter* on top: peer-to-peer network code, a
+PKCS#11 server, or a Sovereign PKI profile.
+
+## Going deeper
+
+- [Mode 1 — Peer-to-Peer TC](./mode1-peer-tc.mdx)
+- [Mode 2 — PKI Drop-in](./mode2-pki-drop-in.mdx)
+- [Mode 3 — Sovereign PKI](./mode3-sovereign-pki.mdx)
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Components](./components.mdx)

--- a/src/content/docs/transparency-logs.mdx
+++ b/src/content/docs/transparency-logs.mdx
@@ -1,0 +1,120 @@
+---
+title: Transparency logs
+description: RFC 6962 Merkle transparency logs. Inclusion proofs, consistency proofs, witness gossip, OTS anchoring. How split-view attacks are detected.
+audience: developer
+order: 9
+---
+
+# Transparency logs
+
+Every signing operation in a Confium deployment can anchor into an
+append-only Merkle transparency log implementing RFC 6962 semantics.
+The log provides cryptographic inclusion proofs and consistency
+proofs that any verifier can check independently.
+
+## Why transparency matters
+
+A certificate by itself proves "this was signed by the issuer". It
+doesn't prove "this is the only certificate the issuer ever signed
+for this subject", or "this is the same certificate every other
+verifier sees". A malicious or compromised CA can issue certificates
+silently — Verisign issued certificates for domains it didn't own
+in 2015, and the affected parties had no way to know.
+
+A transparency log solves this by making every issuance public and
+append-only. Anyone can audit the log and see what's been issued. A
+verifier can demand an inclusion proof that the certificate it's
+verifying is in the log.
+
+## Merkle tree basics
+
+The log is a Merkle tree:
+
+- Each leaf is `SHA-256(0x01 || entry_hash)`.
+- Each internal node is `SHA-256(0x02 || left_child || right_child)`.
+- The root hash commits to the entire set of leaves.
+
+The `0x01` / `0x02` domain separation prevents leaf values from
+being interpreted as internal nodes and vice versa.
+
+## Inclusion proofs (RFC 6962 §2.1.1)
+
+An inclusion proof cryptographically demonstrates that a specific
+entry is in the log, without revealing anything else about the log.
+The proof is a sequence of `(sibling_hash, side)` pairs. The verifier
+starts with the leaf hash, combines it with each sibling in order,
+and checks the final result equals the published root.
+
+## Consistency proofs (RFC 6962 §2.1.2)
+
+A consistency proof shows that tree head N+1 extends tree head N —
+i.e., the first N entries are identical between the two tree states.
+This is what makes split-view attacks detectable.
+
+If a log operator presents tree head N to verifier A and a different
+tree head N to verifier B, at least one of them will fail a
+consistency check against the true history — **as long as they
+communicate**.
+
+## The split-view attack
+
+Without consistency proofs, a transparency log operator can present
+two different tree heads to different verifiers, and nobody can
+detect it. This is the split-view attack:
+
+1. Verifier A receives tree head N from the log.
+2. Verifier B receives a different tree head N' (with a different root).
+3. Both verifiers can verify their own inclusion proofs against their
+   own heads. Neither knows the other's head exists.
+4. The log operator can insert or omit entries selectively per
+   audience.
+
+## Defense in depth
+
+Consistency proofs alone are necessary but not sufficient — verifiers
+must also communicate (gossip) so they know about each other's heads.
+Three layers:
+
+### Layer 1 — Consistency proofs
+
+Every new tree head extends the previous one. Implemented in
+`confium-transparency::merkle::MerkleTree::consistency_proof`.
+
+### Layer 2 — Witness gossip
+
+Coordinators share tree heads with each other periodically. If two
+coordinators have different heads for the same tree size, the
+witnesses detect the inconsistency.
+
+Confium's `confium-tc-coordinator` serves as a gossip endpoint for
+Mode 3 deployments. Each institutional coordinator shares its tree
+head with the institutional anchor's coordinator, which acts as the
+global witness.
+
+### Layer 3 — OTS anchoring
+
+Even with consistency proofs + gossip, a determined adversary who
+controls the log operator AND all witnesses can still split views.
+**OpenTimestamps (OTS)** anchors tree heads in the Bitcoin blockchain,
+providing an irrefutable time-stamped record of "what head existed
+at time T".
+
+Confium's `confium-ots` client supports this.
+
+## Recommended Mode 3 deployment
+
+For Mode 3 (highest assurance):
+
+1. Every transparency tree head is published with a consistency proof
+   from the previous head.
+2. Every coordinator gossips its tree head to the institutional
+   anchor every hour (configurable).
+3. The anchor anchors its current tree head in Bitcoin via OTS daily.
+4. Any verifier can independently verify the full chain: consistency
+   from the OTS-anchored head to the current head.
+
+## See also
+
+- [Concepts: Transparency logs](/concepts/transparency-logs/)
+- [Security model](./security-model.mdx)
+- [Mode 3 — Sovereign PKI](./mode3-sovereign-pki.mdx)

--- a/src/pages/docs/[...id].astro
+++ b/src/pages/docs/[...id].astro
@@ -1,0 +1,32 @@
+---
+import { getCollection, render } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+
+export async function getStaticPaths() {
+  const docs = await getCollection('docs');
+  return docs.map((doc) => ({
+    params: { id: doc.id },
+    props: { doc, allDocs: docs },
+  }));
+}
+
+const { doc, allDocs } = Astro.props;
+const { Content, headings } = await render(doc);
+
+const sidebar = allDocs
+  .sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99))
+  .map((d) => ({
+    label: d.data.title,
+    href: `/docs/${d.id}/`,
+    current: d.id === doc.id,
+  }));
+---
+
+<DocsLayout
+  title={doc.data.title}
+  description={doc.data.description}
+  sidebar={sidebar}
+  headings={headings}
+>
+  <Content />
+</DocsLayout>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,45 @@
+---
+import { getCollection, render } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+
+const docs = (await getCollection('docs')).sort((a, b) => {
+  const aOrder = a.data.order ?? 99;
+  const bOrder = b.data.order ?? 99;
+  return aOrder - bOrder;
+});
+
+interface SidebarItem { label: string; href: string; current?: boolean; }
+
+const sidebar: SidebarItem[] = docs.map((d) => ({
+  label: d.data.title,
+  href: `/docs/${d.id}/`,
+}));
+
+// Index page has no entry to highlight.
+const indexSidebar = sidebar.map((s) => ({ ...s, current: false }));
+---
+
+<DocsLayout title="Docs" description="Technical documentation for Confium — architecture, modes, components, security, PQ migration." sidebar={indexSidebar}>
+  <PageHero
+    eyebrow="Documentation"
+    title="Docs"
+    description="Technical documentation for the Confium engine, its three deployment modes, and the principles that shape every crate."
+  />
+
+  <ul class="mt-8 space-y-4">
+    {docs.map((doc) => (
+      <li>
+        <a href={`/docs/${doc.id}/`} class="group block rounded-lg border border-line bg-card p-5 hover:border-brand-300 dark:hover:border-brand-700 transition-colors">
+          <div class="flex items-baseline justify-between gap-2">
+            <h2 class="text-lg font-semibold group-hover:text-brand-700 dark:group-hover:text-brand-300">{doc.data.title}</h2>
+            <span aria-hidden="true" class="text-muted-foreground group-hover:text-brand-600">→</span>
+          </div>
+          {doc.data.description && (
+            <p class="mt-1 text-sm text-muted-foreground">{doc.data.description}</p>
+          )}
+        </a>
+      </li>
+    ))}
+  </ul>
+</DocsLayout>


### PR DESCRIPTION
## Summary

Implements TODO #036 — 10 hand-written MDX doc pages under `src/content/docs/`, plus the index and dynamic `[...id]` routes.

## Pages (in sidebar order)

1. **`architecture.mdx`** — engine, plugin loader, registry, versioned interfaces, coordinator, architecture principles.
2. **`three-modes.mdx`** — Peer-to-Peer TC, PKI Drop-in, Sovereign PKI overview.
3. **`mode1-peer-tc.mdx`** — direct peer-to-peer threshold crypto.
4. **`mode2-pki-drop-in.mdx`** — PKCS#11 / OpenSSL / JCE / TLS adapters over threshold backend.
5. **`mode3-sovereign-pki.mdx`** — institutional PKI without single trusted party; six reference deployments (CNML as one of six).
6. **`components.mdx`** — 43-crate workspace map by category.
7. **`security-model.mdx`** — trust model, threat table, what Confium does and does not protect against.
8. **`pq-migration.mdx`** — composite signatures, four-phase migration timeline, caller-supplied PQ verifiers.
9. **`transparency-logs.mdx`** — RFC 6962 Merkle trees, inclusion / consistency proofs, split-view attack, defense in depth.
10. **`getting-started.mdx`** — Ruby / Rust / WASM install commands and pointers into per-binding docs.

## Routes

- `src/pages/docs/index.astro` — index listing all docs in sidebar order.
- `src/pages/docs/[...id].astro` — renders single doc with sidebar nav + TOC.

## Content constraints

- No "OIML" anywhere.
- No "TODO" / "coming soon" / "planned" / "milestone" / "roadmap".
- CNML appears as one example among many in Mode 3 / Sovereign PKI pages.

## Follow-up

- TODO #037 — About + 404 + meta pages.
- TODO #038 — `/concepts/` pages (5).
