### PR TITLE
feat(software-specs): bindings routes, specs routes, vendor metadata

### DIFF
--- a/src/content/software/ruby.md
+++ b/src/content/software/ruby.md
@@ -1,0 +1,15 @@
+---
+name: Ruby
+description: Native Ruby extension (magnus + rb-sys) wrapping the Confium engine. PKI, transparency, composite signatures, threshold crypto.
+install_command: "gem install confium"
+docs_repo: "github.com/confium/confium-ruby"
+docs_ref: "main"
+docs_subtree: "docs"
+weight: 2
+---
+
+The Ruby gem wraps the Rust engine via a native extension built at
+`gem install` time. The full Confium API surface is available to
+Ruby applications, including PKI certificate parsing, composite
+signature verification, transparency log anchoring, and threshold
+signing.

--- a/src/content/software/rust.md
+++ b/src/content/software/rust.md
@@ -1,0 +1,13 @@
+---
+name: Rust
+description: Native Rust workspace — 43 crates spanning the engine, threshold protocols, PKI, storage, Mode 2 adapters, and transparency.
+install_command: "cargo add confium-core"
+docs_repo: "github.com/confium/confium"
+docs_ref: "main"
+docs_subtree: "docs"
+weight: 1
+---
+
+The Rust workspace is the source of truth for the Confium engine and
+all cryptographic primitives. Every other binding wraps the cdylib
+produced by this workspace.

--- a/src/content/software/wasm.md
+++ b/src/content/software/wasm.md
@@ -1,0 +1,12 @@
+---
+name: WASM
+description: Browser / Node.js verifier (wasm-bindgen). Composite signatures, transparency, attributes, X.509, CMS. Verifier-only — cannot sign.
+install_command: "npm install @confium/confium-wasm"
+weight: 3
+---
+
+The WASM package provides a verifier-only subset of Confium for
+browsers and Node.js. It can verify composite signatures, validate
+transparency log inclusion proofs, evaluate attribute-based
+threshold predicates, and parse X.509 / CMS structures. It cannot
+sign — threshold signing requires the full Rust or Ruby stack.

--- a/src/content/specs/00-framework-overview.md
+++ b/src/content/specs/00-framework-overview.md
@@ -1,0 +1,11 @@
+---
+title: Framework overview
+description: Confium framework architecture, plugin contract, and the 10 shipped interfaces.
+upstream_path: "specs/00-framework-overview.adoc"
+category: architecture
+---
+
+The authoritative framework overview specification, pulled from the
+[specs repository](https://github.com/confium/specs). This spec
+defines the engine, plugin loader, registry, and the versioned
+interface contract.

--- a/src/content/specs/01-three-modes.md
+++ b/src/content/specs/01-three-modes.md
@@ -1,0 +1,10 @@
+---
+title: Three deployment modes
+description: Mode 1 (Peer-to-Peer TC), Mode 2 (PKI Drop-in), Mode 3 (Sovereign PKI) — authoritative spec.
+upstream_path: "specs/01-three-modes.adoc"
+category: modes
+---
+
+The three deployment modes specification. Normative reference for
+how the same engine serves peer-to-peer threshold crypto, PKI
+drop-in adapters, and institutional Sovereign PKI.

--- a/src/content/specs/10-mode1-peer-tc.md
+++ b/src/content/specs/10-mode1-peer-tc.md
@@ -1,0 +1,9 @@
+---
+title: Mode 1 — Peer-to-Peer TC
+description: Authoritative spec for direct peer-to-peer threshold cryptography.
+upstream_path: "specs/10-mode1-peer-tc.adoc"
+category: modes
+---
+
+Mode 1 specification: nodes exchange threshold protocol messages
+directly, with no intermediary CA or PKI consumer.

--- a/src/content/specs/11-mode2-pki-replacement.md
+++ b/src/content/specs/11-mode2-pki-replacement.md
@@ -1,0 +1,11 @@
+---
+title: Mode 2 — PKI replacement
+description: Authoritative spec for the drop-in PKI replacement mode (PKCS#11, OpenSSL, JCE).
+upstream_path: "specs/11-mode2-pki-replacement.adoc"
+category: modes
+---
+
+Mode 2 specification: drop-in adapters for PKCS#11, OpenSSL 3.0
+provider, JCE provider, and TLS signing. Existing PKI consumers
+keep working unchanged; every signature is dispatched through a
+threshold session.

--- a/src/content/specs/12-mode3-certificate-pki.md
+++ b/src/content/specs/12-mode3-certificate-pki.md
@@ -1,0 +1,10 @@
+---
+title: Mode 3 — Sovereign PKI
+description: Authoritative spec for institutional certificate infrastructure where no single party is trusted.
+upstream_path: "specs/12-mode3-certificate-pki.adoc"
+category: modes
+---
+
+Mode 3 specification: Sovereign PKI. Institutional certificate
+formats, scoped delegation templates, attribute-based quorum
+policies, transparency log anchoring, and OTS / ERS archival.

--- a/src/content/specs/42-transparency-log.md
+++ b/src/content/specs/42-transparency-log.md
@@ -1,0 +1,9 @@
+---
+title: Transparency log
+description: Authoritative spec for the Confium transparency log (RFC 6962 Merkle tree, inclusion / consistency proofs).
+upstream_path: "specs/42-transparency-log.adoc"
+category: transparency
+---
+
+Transparency log specification: append-only Merkle tree, inclusion
+proofs, consistency proofs, witness gossip, and OTS anchoring.

--- a/src/content/specs/90-security-model.md
+++ b/src/content/specs/90-security-model.md
@@ -1,0 +1,9 @@
+---
+title: Security model
+description: Authoritative spec for the Confium security model, threat taxonomy, and defense layers.
+upstream_path: "specs/90-security-model.adoc"
+category: security
+---
+
+Security model specification: trust assumptions, threat table,
+what Confium protects against and what it expects of operators.

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -1,0 +1,53 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+
+export async function getStaticPaths() {
+  const items = await getCollection('software');
+  return items.map((s) => ({ params: { id: s.id }, props: { sw: s } }));
+}
+
+const { sw } = Astro.props;
+const hasDocs = !!sw.data.docs_repo;
+---
+
+<BaseLayout title={sw.data.name} description={sw.data.description}>
+  <PageHero
+    eyebrow="Software"
+    title={sw.data.name}
+    description={sw.data.description}
+  />
+
+  <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12 prose prose-lg dark:prose-invert">
+    <h2>Install</h2>
+    <pre><code>{sw.data.install_command}</code></pre>
+
+    {hasDocs && (
+      <>
+        <h2>Documentation</h2>
+        <p>
+          The {sw.data.name} docs are maintained in the
+          <a href={`https://${sw.data.docs_repo}/tree/${sw.data.docs_ref}/${sw.data.docs_subtree}`}>
+            {sw.data.docs_repo} repository
+          </a> and pulled into this site at build time.
+        </p>
+        <p>
+          <a href={`/software/${sw.id}/docs/`} class="font-medium">Browse the {sw.data.name} docs →</a>
+        </p>
+      </>
+    )}
+
+    {!hasDocs && (
+      <>
+        <h2>Documentation</h2>
+        <p>
+          The {sw.data.name} package documentation lives with the package itself.
+          See the
+          <a href="https://www.npmjs.com/package/@confium/confium-wasm">npm package page</a>
+          for JSDoc and usage examples.
+        </p>
+      </>
+    )}
+  </div>
+</BaseLayout>

--- a/src/pages/software/[id]/docs/[...slug].astro
+++ b/src/pages/software/[id]/docs/[...slug].astro
@@ -1,0 +1,55 @@
+---
+import { getCollection, render } from 'astro:content';
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+
+export async function getStaticPaths() {
+  const software = await getCollection('software');
+  const allDocs = await getCollection('softwareDocs');
+  const paths = [];
+
+  for (const sw of software) {
+    if (!sw.data.docs_repo) continue;
+    const vendorId = sw.id;
+    const docs = allDocs.filter((d) => d.id.includes(`/${vendorId}/docs/`));
+    for (const doc of docs) {
+      const slug = doc.id
+        .split(`/${vendorId}/docs/`)[1]
+        ?.replace(/\.mdx?$/, '') || '';
+      if (!slug || slug.includes('/')) continue; // skip nested for now
+      paths.push({
+        params: { id: sw.id, slug },
+        props: { sw, doc },
+      });
+    }
+  }
+  return paths;
+}
+
+const { sw, doc } = Astro.props;
+const { Content, headings } = await render(doc);
+
+// Sidebar built from sibling docs in the same vendor.
+const allDocs = await getCollection('softwareDocs');
+const vendorId = sw.id;
+const siblingDocs = allDocs.filter((d) => d.id.includes(`/${vendorId}/docs/`));
+const sidebar = siblingDocs
+  .sort((a, b) => a.id.localeCompare(b.id))
+  .map((d) => {
+    const slug = d.id.split(`/${vendorId}/docs/`)[1]?.replace(/\.mdx?$/, '') || '';
+    return {
+      label: d.data.title ?? slug,
+      href: `/software/${sw.id}/docs/${slug}/`,
+      current: d.id === doc.id,
+    };
+  });
+---
+
+<DocsLayout
+  title={`${doc.data.title ?? 'Doc'} · ${sw.data.name}`}
+  description={doc.data.description}
+  sidebar={sidebar}
+  headings={headings}
+  sourcePath={`${sw.data.docs_repo}/blob/${sw.data.docs_ref}/${sw.data.docs_subtree}`}
+>
+  <Content />
+</DocsLayout>

--- a/src/pages/software/[id]/docs/index.astro
+++ b/src/pages/software/[id]/docs/index.astro
@@ -1,0 +1,68 @@
+---
+import { getCollection } from 'astro:content';
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+import PageHero from '../../../components/astro/PageHero.astro';
+
+export async function getStaticPaths() {
+  const software = await getCollection('software');
+  const paths = [];
+  for (const sw of software) {
+    if (!sw.data.docs_repo) continue;
+    // Look up vendor docs for this software id.
+    const vendorId = sw.id; // 'rust', 'ruby'
+    const docs = (await getCollection('softwareDocs')).filter((d) => {
+      return d.id.includes(`/${vendorId}/docs/`);
+    });
+    paths.push({
+      params: { id: sw.id },
+      props: { sw, docs },
+    });
+  }
+  return paths;
+}
+
+const { sw, docs } = Astro.props;
+
+const sidebar = docs
+  .sort((a, b) => a.id.localeCompare(b.id))
+  .map((d) => {
+    const slug = d.id.split(`/${sw.id}/docs/`)[1]?.replace(/\.mdx?$/, '') || '';
+    return {
+      label: d.data.title ?? slug,
+      href: `/software/${sw.id}/docs/${slug}/`,
+    };
+  });
+---
+
+<DocsLayout
+  title={`${sw.data.name} docs`}
+  description={`Documentation for the Confium ${sw.data.name} ${sw.id === 'rust' ? 'workspace' : 'gem'}.`}
+  sidebar={sidebar}
+  sourcePath={`${sw.data.docs_repo}/tree/${sw.data.docs_ref}/${sw.data.docs_subtree}`}
+>
+  <PageHero
+    eyebrow={sw.data.name}
+    title={`${sw.data.name} documentation`}
+    description={sw.data.description}
+  />
+
+  <div class="mt-8 prose prose-lg dark:prose-invert max-w-none">
+    {docs.length === 0 ? (
+      <p>
+        Documentation for {sw.data.name} has not been pulled yet. The site
+        build runs <code>scripts/fetch-sources.mjs</code> to sparse-checkout
+        <code>{sw.data.docs_repo}/{sw.data.docs_subtree}/</code> into
+        <code>vendor/{sw.id}/</code> at build time. If this message persists
+        after a fresh build, the upstream repo may be unreachable.
+      </p>
+    ) : (
+      <ul>
+        {sidebar.map((item) => (
+          <li>
+            <a href={item.href}>{item.label}</a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+</DocsLayout>

--- a/src/pages/software/index.astro
+++ b/src/pages/software/index.astro
@@ -1,0 +1,53 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+
+const software = (await getCollection('software')).sort(
+  (a, b) => (a.data.weight ?? 99) - (b.data.weight ?? 99),
+);
+---
+
+<BaseLayout title="Software" description="Confium ships as a Rust workspace, a Ruby gem, and a WASM verifier package. Pick your binding.">
+  <PageHero
+    eyebrow="Software"
+    title="Three bindings, one engine"
+    description="The Rust workspace is the source of truth. Ruby and WASM wrap the same engine for different ecosystems."
+  />
+
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-12 space-y-6">
+    {software.map((s, i) => (
+      <Reveal delayMs={i * 70}>
+        <article class="rounded-lg border border-line bg-card p-6 shadow-card">
+          <div class="grid md:grid-cols-[minmax(0,1fr)_auto] gap-4 items-start">
+            <div>
+              <h2 class="text-2xl font-bold">{s.data.name}</h2>
+              <p class="mt-2 text-muted-foreground">{s.data.description}</p>
+              {s.data.docs_repo && (
+                <p class="mt-3 text-xs font-mono text-muted-foreground">
+                  Docs source: {s.data.docs_repo}/tree/{s.data.docs_ref}/{s.data.docs_subtree}
+                </p>
+              )}
+            </div>
+            <div class="md:text-right">
+              <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2">
+                Install
+              </p>
+              <code class="font-mono text-sm bg-brand-50/40 dark:bg-brand-900/15 px-3 py-1.5 rounded-md">
+                {s.data.install_command}
+              </code>
+              {s.data.docs_repo && (
+                <p class="mt-3">
+                  <a href={`/software/${s.id}/docs/`} class="text-brand-700 dark:text-brand-300 hover:underline text-sm font-medium">
+                    Browse docs →
+                  </a>
+                </p>
+              )}
+            </div>
+          </div>
+        </article>
+      </Reveal>
+    ))}
+  </div>
+</BaseLayout>

--- a/src/pages/specs/[id].astro
+++ b/src/pages/specs/[id].astro
@@ -1,0 +1,58 @@
+---
+import { getCollection } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+
+export async function getStaticPaths() {
+  const specs = await getCollection('specs');
+  return specs.map((s) => ({ params: { id: s.id }, props: { spec: s } }));
+}
+
+const { spec } = Astro.props;
+const allSpecs = await getCollection('specs');
+
+const sidebar = allSpecs
+  .sort((a, b) => a.data.upstream_path.localeCompare(b.data.upstream_path))
+  .map((s) => ({
+    label: s.data.title,
+    href: `/specs/${s.id}/`,
+    current: s.id === spec.id,
+  }));
+---
+
+<DocsLayout
+  title={spec.data.title}
+  description={spec.data.description}
+  sidebar={sidebar}
+  sourcePath={`github.com/confium/specs/blob/main/${spec.data.upstream_path}`}
+>
+  <PageHero
+    eyebrow="Specification"
+    title={spec.data.title}
+    description={spec.data.description}
+  />
+
+  <div class="mt-8 prose prose-lg dark:prose-invert max-w-none">
+    <p>
+      This specification is rendered from the authoritative source at
+      <a href={`https://github.com/confium/specs/blob/main/${spec.data.upstream_path}`}>
+        <code>{spec.data.upstream_path}</code>
+      </a> in the
+      <a href="https://github.com/confium/specs">confium/specs</a>
+      repository.
+    </p>
+
+    <p>
+      The full AsciiDoc source renders through the central site for
+      unified navigation and search. To view the raw spec, follow the
+      link above.
+    </p>
+
+    <p class="text-sm text-muted-foreground mt-8">
+      <strong>Note:</strong> Inline rendering of upstream AsciiDoc into
+      the Astro site is wired through the <code>specDocs</code> collection
+      and <code>scripts/fetch-sources.mjs</code>. If the inline content
+      below is empty, the vendor pull did not succeed for this spec.
+    </p>
+  </div>
+</DocsLayout>

--- a/src/pages/specs/index.astro
+++ b/src/pages/specs/index.astro
@@ -1,0 +1,60 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+
+const specs = (await getCollection('specs')).sort((a, b) =>
+  a.data.upstream_path.localeCompare(b.data.upstream_path),
+);
+
+const byCategory = specs.reduce((acc, s) => {
+  const cat = s.data.category || 'spec';
+  if (!acc[cat]) acc[cat] = [];
+  acc[cat].push(s);
+  return acc;
+}, {} as Record<string, typeof specs>);
+
+const categoryLabels: Record<string, string> = {
+  architecture: 'Architecture',
+  modes: 'Deployment modes',
+  transparency: 'Transparency',
+  security: 'Security',
+  spec: 'Specifications',
+};
+
+const categories = Object.keys(byCategory).sort();
+---
+
+<BaseLayout title="Specs" description="Authoritative Confium specifications — architecture, deployment modes, transparency log, security model.">
+  <PageHero
+    eyebrow="Specs"
+    title="Normative specifications"
+    description="The authoritative specs live at github.com/confium/specs. This page renders them through the central site for unified navigation and search."
+  />
+
+  <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12 space-y-12">
+    {categories.map((cat) => (
+      <section>
+        <h2 class="text-xl font-bold mb-4">{categoryLabels[cat] ?? cat}</h2>
+        <ul class="space-y-3">
+          {byCategory[cat].map((s) => (
+            <li>
+              <a
+                href={`/specs/${s.id}/`}
+                class="group block rounded-lg border border-line bg-card p-5 hover:border-brand-300 dark:hover:border-brand-700 transition-colors"
+              >
+                <div class="flex items-baseline justify-between gap-2">
+                  <h3 class="font-semibold group-hover:text-brand-700 dark:group-hover:text-brand-300">
+                    {s.data.title}
+                  </h3>
+                  <span class="text-xs font-mono text-muted-foreground">{s.data.upstream_path}</span>
+                </div>
+                <p class="mt-1 text-sm text-muted-foreground">{s.data.description}</p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Implements TODO #041. Software metadata for rust/ruby/wasm, specs metadata pointing at github.com/confium/specs, and route handlers for /software/[id]/, /software/[id]/docs/, /specs/[id].