### PR TITLE
docs(blog): three seed posts + index, single-post, and RSS routes

### DIFF
--- a/src/content/blog/2026-07-28-introducing-confium.mdx
+++ b/src/content/blog/2026-07-28-introducing-confium.mdx
@@ -1,0 +1,109 @@
+---
+title: "Introducing Confium"
+description: "Confium is an open-source framework for multi-stakeholder threshold cryptography. Three deployment modes, post-quantum-ready, transparent by design."
+date: 2026-07-28
+author: Confium Project
+tags: [announcement, framework]
+category: announcement
+order: 1
+---
+
+# Introducing Confium
+
+Public Key Infrastructure has a structural weakness: every
+Certificate Authority holds a single private key that can sign
+anything. If that key is compromised, every certificate the CA
+ever issued is called into question.
+
+We've watched this happen repeatedly. DigiNotar in 2011.
+Symantec from 2015 to 2018. Let's Encrypt revocation events in
+2020. Each incident cost millions of dollars, disrupted services,
+and eroded public trust.
+
+**Confium is our answer.** An open-source framework for
+multi-stakeholder threshold cryptography. No single party holds
+the signing key; a configurable quorum must participate. The same
+relationship a TLS library has to transport security — a
+configurable framework organizations deploy with their own
+parameters.
+
+## What ships today
+
+The Confium Rust workspace contains 43 crates organized into
+three deployment modes:
+
+- **Mode 1 — Peer-to-Peer TC**. Nodes do threshold cryptography
+  directly. Hours to value. For MPC, distributed custody, BFT
+  consensus.
+- **Mode 2 — PKI Drop-in**. Drop-in adapters for PKCS#11 v3.0,
+  OpenSSL 3.0, JCE, and TLS 1.3. Existing PKI consumers keep
+  working — every signature now requires a threshold quorum.
+- **Mode 3 — Sovereign PKI**. Custom certificate formats for
+  institutions where no single party can be trusted. Sovereign
+  over formats, delegation rules, archival cadence, quorum
+  composition.
+
+All three modes share the same engine, the same threshold
+protocols (FROST, CMP20, GG18, threshold ElGamal), the same
+transparency log, the same coordinator. What differs is the
+integration surface.
+
+## Real cryptography
+
+Every threshold protocol crate ships real cryptography, not
+stubs:
+
+- `confium-tc-frost-ed25519` — real FROST-ed25519 with the full
+  three-round signing protocol.
+- `confium-tc-frost-p256` — real P-256 Shamir secret sharing and
+  ECDSA threshold signing.
+- `confium-tc-cmp20` — real CMP20 threshold ECDSA.
+- `confium-tc-gg18` — real GG18 threshold ECDSA.
+- `confium-tc-elgamal-p256` — real threshold ElGamal-P256.
+
+The composite signature crate (`confium-composite`) supports
+hybrid classical + PQ signatures — Ed25519 + ECDSA-P256 +
+ML-DSA-65 verified as one. Post-quantum migration as a software
+upgrade, not an HSM replacement.
+
+## Three bindings
+
+- **Ruby gem** (`gem install confium`) — native extension built
+  via magnus + rb-sys at install time. Full Confium API surface.
+- **Rust workspace** (`cargo add confium-core`) — the source of
+  truth.
+- **WASM verifier** (`npm install @confium/confium-wasm`) —
+  browser / Node.js verifier for composite signatures,
+  transparency proofs, X.509 / CMS parsing.
+
+## Transparency by design
+
+Every signing operation can anchor into an append-only Merkle
+transparency log implementing RFC 6962 semantics. Inclusion
+proofs let any verifier independently confirm a certificate is
+in the log. Consistency proofs make split-view attacks
+detectable. OpenTimestamps anchoring in Bitcoin provides an
+irrefutable "what head existed at time T" record.
+
+Three defenses against split-view attacks, layered:
+
+1. Consistency proofs on every new tree head.
+2. Witness gossip between coordinators (default: hourly).
+3. OTS anchoring of tree heads in Bitcoin (default: daily).
+
+## Open source, sustainably funded
+
+BSD-2-Clause licensed. Funded by [NLnet NGI Zero PET](https://nlnet.nl/project/Confium/)
+and [Mozilla MOSS](https://www.mozilla.org/moss/). Funders do
+not direct the technical roadmap.
+
+## What to read next
+
+- [Architecture](/docs/architecture/) — understand the engine.
+- [Three modes](/docs/three-modes/) — pick a deployment shape.
+- [Threshold crypto 101](/concepts/threshold-crypto-101/) — if
+  you're new to threshold cryptography.
+- [Sovereign PKI launch post](/blog/sovereign-pki-launch/) — the
+  Mode 3 deep dive.
+
+Welcome to Confium.

--- a/src/content/blog/2026-07-28-pq-migration-walkthrough.mdx
+++ b/src/content/blog/2026-07-28-pq-migration-walkthrough.mdx
@@ -1,0 +1,154 @@
+---
+title: "Post-quantum migration without re-issuing every certificate"
+description: "How composite signatures make PQ migration a software upgrade, not an HSM replacement. A four-phase timeline and worked example."
+date: 2026-07-28
+author: Confium Project
+tags: [pq, composite-signatures, migration]
+category: deep-dive
+order: 3
+---
+
+# Post-quantum migration without re-issuing every certificate
+
+Every signature algorithm in production today is breakable by a
+sufficiently large quantum computer running Shor's algorithm.
+RSA, ECDSA, Ed25519 — all of them.
+
+The new post-quantum algorithms (ML-DSA, SLH-DSA) replace them.
+But you can't re-issue every certificate on a single flag day —
+the installed base of verifiers won't all upgrade simultaneously,
+and the new algorithms are still young, less analyzed, not yet
+trusted to stand alone.
+
+**Composite signatures** are Confium's answer. A composite
+signature contains the artifacts of multiple algorithms;
+verification succeeds only when every component verifies.
+Migration becomes a software upgrade, not an HSM replacement.
+
+## What a composite signature looks like
+
+```
+CompositeSignature {
+  components: [
+    { algorithm: "1.3.101.112",         signature: <64 bytes Ed25519> },
+    { algorithm: "1.2.840.10045.4.3.2", signature: <DER ECDSA-P256> },
+    { algorithm: "2.16.840.1.101.3.4.3.18", signature: <ML-DSA-65> },
+  ],
+}
+```
+
+Three signatures, three algorithms, one composite. Verification
+checks all three; accept only if every one passes.
+
+## The four-phase migration
+
+### Phase 1 — Classical only (today)
+
+Your existing baseline. Every certificate signed with Ed25519
+or ECDSA-P256. Verifiers accept.
+
+### Phase 2 — Hybrid (migration begins)
+
+New certificates signed with a composite of (classical + PQ).
+Verifiers split:
+
+- **Upgraded** verifiers check both components. They accept the
+  composite as valid.
+- **Legacy** verifiers don't understand composites; they fall
+  back to the classical component and continue to accept.
+
+This is the key property: **adding a PQ component does not
+break legacy verifiers**. You can start emitting composite
+signatures today without coordinating with every downstream
+consumer.
+
+### Phase 3 — PQ required
+
+Once every verifier has been upgraded, tighten the deployment
+policy: composite signatures must include a PQ component.
+Signers stop emitting classical-only signatures.
+
+### Phase 4 — PQ only
+
+Eventually the classical component can be removed for new
+signatures. It's retained for archival verification of
+pre-migration signatures, but new issuances are PQ-only.
+
+## Software upgrade, not HSM replacement
+
+The entire migration happens via:
+
+1. A `confium-composite` crate update that knows about ML-DSA-65.
+2. A plugin that provides the ML-DSA-65 verifier (currently via
+   caller-supplied callback; native support arrives when a
+   suitable pure-Rust verifier crate ships).
+3. A deployment policy update that requires the new component.
+
+No new HSM. No re-issuance of every certificate. No flag day.
+
+## Caller-supplied PQ verifiers
+
+For PQ algorithms without a bundled pure-Rust verifier, Confium
+accepts a caller-supplied verifier callback. The deployment
+wires its preferred ML-DSA / SLH-DSA implementation into the
+composite verifier:
+
+```ruby
+sig = Confium::Composite::Signature.new(components)
+result = sig.verify(message, {
+  "ML-DSA-65" => ->(pk, msg, sig) {
+    my_ml_dsa_verifier.verify(pk, msg, sig)
+  },
+})
+```
+
+The verifier can be a Botan plugin, an in-process Rust crate,
+an FFI binding to a C library, or a remote verification
+service. **A missing verifier is a hard failure, never a silent
+soft-accept.** This is critical: the composite layer never
+silently accepts on the subset of components it can verify.
+
+## The WASM equivalent
+
+The `@confium/confium-wasm` package supports the same callback
+pattern for browser / Node.js verifiers:
+
+```javascript
+import init, { CompositeSignature } from "@confium/confium-wasm";
+await init();
+const sig = CompositeSignature.from_json(jsonString);
+const result = sig.verify(messageBytes, {
+  "Ed25519": "builtin",
+  "ECDSA-P256": "builtin",
+  "ML-DSA-65": (pk, msg, sig) => myExternalVerifier(pk, msg, sig),
+});
+console.log(result.all_verified);
+```
+
+Ed25519 and ECDSA-P256 ship built-in. ML-DSA-65 is a callback —
+bring your own verifier (FFI to a C library, WebAssembly module,
+or a remote service).
+
+## Defense in depth
+
+Even setting PQ aside, composite signatures give you
+defense-in-depth against algorithm breaks. An attacker who
+breaks Ed25519 still has to break ECDSA-P256 and ML-DSA-65 to
+forge a composite signature. The breakdown of one algorithm
+doesn't compromise your signatures.
+
+## When to start
+
+Start now. Even if you don't plan to migrate to PQ-only for
+years, begin emitting composite signatures with a PQ component
+as soon as your signing infrastructure supports it. The cost is
+a few extra hundred bytes per signature and one extra verifier
+per consumer. The benefit: every signature you issue today is
+already PQ-migration-ready.
+
+## Read more
+
+- [PQ migration docs](/docs/pq-migration/)
+- [Composite signatures concept](/concepts/composite-signatures/)
+- [Use case: PQ migration](/use-cases/pq-migration/)
+- [Ruby gem docs](https://github.com/confium/confium-ruby/tree/main/docs/pq-migration/composite-signatures.mdx)

--- a/src/content/blog/2026-07-28-sovereign-pki-launch.mdx
+++ b/src/content/blog/2026-07-28-sovereign-pki-launch.mdx
@@ -1,0 +1,137 @@
+---
+title: "Sovereign PKI: institutional trust without a single point of failure"
+description: "Mode 3 deep dive. Sovereign PKI gives institutions control over certificate formats, delegation, archival, and quorum composition — without trusting any single party."
+date: 2026-07-28
+author: Confium Project
+tags: [mode-3, sovereign-pki, institutional]
+category: deep-dive
+order: 2
+---
+
+# Sovereign PKI: institutional trust without a single point of failure
+
+Conventional PKI assumes a single trusted Certificate Authority.
+For many institutional settings, that assumption doesn't hold.
+Multi-stakeholder cooperatives, calibration chains, regulatory
+bodies, accreditation networks, treaty organizations — none of
+them have a natural single party that everyone else trusts.
+
+**Sovereign PKI** is Confium's Mode 3 deployment shape:
+institutional certificate infrastructure where no single party
+can be trusted. The institution keeps sovereignty over four
+dimensions that conventional PKI locks down:
+
+1. Certificate formats
+2. Delegation rules
+3. Archival cadence
+4. Quorum composition
+
+## What sovereignty means
+
+| Dimension | Conventional PKI | Sovereign PKI |
+| --- | --- | --- |
+| Certificate format | Fixed (X.509) | Custom profiles, custom extensions |
+| Delegation | Fixed hierarchy | Scoped, time-bounded, attribute-based |
+| Archival cadence | CA's discretion | Configurable per-deployment |
+| Quorum | Single CA key | T-of-N with attribute constraints |
+| Audit | Internal records | Public transparency log |
+
+## Reference deployments
+
+Sovereign PKI is the right shape for a wide range of
+institutional settings:
+
+- **Calibration registries** — BIPM-style metrology chains where
+  measurements must be traceable to a sovereign reference.
+- **Pharma regulator approvals** — multi-jurisdiction sign-off
+  on clinical trial data and drug approvals.
+- **Academic accreditation** — cross-institutional degree and
+  credential verification without a single trusted authority.
+- **Supply-chain provenance** — manufacturing step attestation
+  anchored in a public transparency log.
+- **Treaty organizations** — multi-state cooperative instruments
+  requiring concurrent sovereign approval.
+- **CNML** — certified measuring instruments list, a reference
+  Mode 3 deployment.
+
+CNML is one reference deployment among six. Sovereign PKI is a
+general framework; CNML is one specific instance that fits the
+shape.
+
+## The architecture
+
+A Mode 3 deployment typically includes:
+
+- **Custom certificate profile** via `confium-cert`. The
+  institution defines its certificate structure, extensions,
+  and encoding (CMS, X.509, custom ASN.1, or JSON).
+- **Delegation templates** via `confium-cert-delegation`.
+  Scoped delegation: "this issuer can issue
+  measuring-instrument certificates, but only for category C,
+  and only until 2027-04-01".
+- **Attribute-based threshold predicates** via
+  `confium-attributes`. Express policies like "5-of-9 directors
+  from 3 distinct regions".
+- **Transparency log** via `confium-transparency`. Every
+  issuance is anchored in an RFC 6962 Merkle tree.
+- **OpenTimestamps anchoring** via `confium-ots`. Tree heads
+  timestamped in the Bitcoin blockchain for defense in depth.
+- **Archival** via `confium-ers`. RFC 4998 Evidence Record
+  Syntax for long-term evidence retention.
+- **Coordinator** via `confium-tc-coordinator`. Orchestrates
+  signing sessions across the institutional signers.
+
+## Defense in depth
+
+Mode 3 deployments should layer three defenses against
+split-view attacks:
+
+1. **Consistency proofs** on every new tree head.
+2. **Witness gossip** between coordinators (default: hourly).
+3. **OTS anchoring** of tree heads in Bitcoin (default: daily).
+
+Together, these defeat any adversary who doesn't simultaneously
+control the log operator, all witnesses, *and* has the ability
+to rewrite Bitcoin history. See
+[the transparency logs concept](/concepts/transparency-logs/)
+for the full analysis.
+
+## Attribute-based threshold
+
+Real institutions have richer requirements than "any 5 of 9
+directors". They want "5 of 9 directors from 3 distinct regions"
+or "3 of 5 labs from 2 distinct jurisdictions".
+
+Confium ships an attribute-based threshold DSL:
+
+```
+5-of-9 directors
+from 3 distinct regions
+```
+
+The coordinator evaluates this predicate at signing time. If
+the participating signers don't satisfy both the count threshold
+and the diversity constraint, the session waits for additional
+signers or fails with `Confium::PolicyViolationError`.
+
+Every predicate evaluation is recorded in the transparency log
+— auditable, deterministic, and tamper-evident.
+
+## When to choose Mode 3
+
+- You operate an institutional CA where no single stakeholder
+  can be trusted.
+- You need custom certificate formats, delegation rules, or
+  archival policies.
+- You're deploying across multiple jurisdictions with different
+  algorithm requirements.
+- You need a public, auditable record of every certificate ever
+  issued.
+
+## Read more
+
+- [Mode 3 docs](/docs/mode3-sovereign-pki/)
+- [Transparency logs concept](/concepts/transparency-logs/)
+- [Attribute-based threshold concept](/concepts/attribute-based-threshold/)
+- [Security model](/docs/security-model/)
+- [Use case: Sovereign PKI](/use-cases/sovereign-pki/)

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,0 +1,65 @@
+---
+import { getCollection, render } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+
+export async function getStaticPaths() {
+  const posts = (await getCollection('blog')).sort((a, b) => {
+    const aDate = a.data.date?.getTime() ?? 0;
+    const bDate = b.data.date?.getTime() ?? 0;
+    return bDate - aDate;
+  });
+  return posts.map((post) => ({
+    params: { id: post.id },
+    props: { post, allPosts: posts },
+  }));
+}
+
+const { post, allPosts } = Astro.props;
+const { Content, headings } = await render(post);
+
+const sidebar = allPosts.map((p) => ({
+  label: p.data.title,
+  href: `/blog/${p.id}/`,
+  current: p.id === post.id,
+}));
+
+const dateStr = post.data.date
+  ? post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  : '';
+---
+
+<DocsLayout
+  title={post.data.title}
+  description={post.data.description}
+  sidebar={sidebar}
+  headings={headings}
+>
+  <article>
+    <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-400 mb-3">
+      {post.data.category} · {dateStr}
+    </p>
+    <h1 class="text-4xl font-bold tracking-tight mb-3">{post.data.title}</h1>
+    {post.data.author && (
+      <p class="text-sm text-muted-foreground mb-6">By {post.data.author}</p>
+    )}
+    <div class="h-px bg-gradient-to-r from-brand-500 to-transparent mb-8"></div>
+
+    <div class="prose prose-lg dark:prose-invert max-w-none">
+      <Content />
+    </div>
+
+    {post.data.tags && post.data.tags.length > 0 && (
+      <div class="mt-12 pt-6 border-t border-line">
+        <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2">Tags</p>
+        <div class="flex flex-wrap gap-2">
+          {post.data.tags.map((tag: string) => (
+            <span class="text-xs font-mono px-2 py-1 rounded-md bg-brand-50/40 dark:bg-brand-900/15 text-brand-700 dark:text-brand-300">
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    )}
+  </article>
+</DocsLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,70 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+
+const posts = (await getCollection('blog')).sort((a, b) => {
+  const aDate = a.data.date?.getTime() ?? 0;
+  const bDate = b.data.date?.getTime() ?? 0;
+  return bDate - aDate;
+});
+
+const byYear = posts.reduce((acc, post) => {
+  const year = post.data.date ? post.data.date.getFullYear() : 0;
+  if (!acc[year]) acc[year] = [];
+  acc[year].push(post);
+  return acc;
+}, {} as Record<number, typeof posts>);
+
+const years = Object.keys(byYear).map(Number).sort((a, b) => b - a);
+---
+
+<BaseLayout title="Blog" description="Confium project blog — launch posts, deep dives, and engineering updates.">
+  <PageHero
+    eyebrow="Blog"
+    title="Project writing"
+    description="Launch announcements, deep dives on individual modes, and engineering walkthroughs."
+  />
+
+  <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12 space-y-16">
+    {years.map((year, yi) => (
+      <section>
+        <Reveal delayMs={yi * 60}>
+          <h2 class="text-2xl font-bold mb-6 text-brand-700 dark:text-brand-300">{year}</h2>
+        </Reveal>
+        <ul class="space-y-8">
+          {byYear[year].map((post, pi) => {
+            const dateStr = post.data.date
+              ? post.data.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+              : '';
+            return (
+              <Reveal delayMs={yi * 60 + pi * 40}>
+                <li>
+                  <a href={`/blog/${post.id}/`} class="group block">
+                    <div class="flex items-baseline gap-3 mb-1">
+                      <span class="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+                        {dateStr}
+                      </span>
+                      {post.data.category && (
+                        <span class="text-xs font-mono text-brand-600 dark:text-brand-400 uppercase tracking-wider">
+                          {post.data.category}
+                        </span>
+                      )}
+                    </div>
+                    <h3 class="text-xl font-semibold group-hover:text-brand-700 dark:group-hover:text-brand-300 transition-colors">
+                      {post.data.title}
+                    </h3>
+                    {post.data.description && (
+                      <p class="mt-2 text-muted-foreground">{post.data.description}</p>
+                    )}
+                  </a>
+                </li>
+              </Reveal>
+            );
+          })}
+        </ul>
+      </section>
+    ))}
+  </div>
+</BaseLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+---
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+
+export async function GET(context: { site: URL }) {
+  const posts = (await getCollection('blog')).sort((a, b) => {
+    const aDate = a.data.date?.getTime() ?? 0;
+    const bDate = b.data.date?.getTime() ?? 0;
+    return bDate - aDate;
+  });
+
+  return rss({
+    title: 'Confium Blog',
+    description: 'Threshold-native trust infrastructure for a post-quantum world.',
+    site: context.site,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      link: `/blog/${post.id}/`,
+      categories: post.data.tags,
+    })),
+    customData: '<language>en-us</language>',
+  });
+}


### PR DESCRIPTION
Implements TODO #042. Three launch posts dated 2026-07-28: Introducing Confium, Sovereign PKI launch, PQ migration walkthrough. Plus blog index (year-grouped), single-post route, and RSS feed via @astrojs/rss.