### PR TITLE
fix(content): reword TODO false positive in differentiator card

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const differences = [
   },
   {
     title: 'No unsafe code, anywhere',
-    body: 'Every crate carries `#![forbid(unsafe_code)]`. FFI is centralized in confium-core and uses edition 2024\'s #[unsafe(no_mangle)] form. All threshold protocols (FROST, CMP20, GG18) ship real cryptography — not stubs, not placeholders, not "TODO".',
+    body: 'Every crate carries `#![forbid(unsafe_code)]`. FFI is centralized in confium-core and uses edition 2024\'s #[unsafe(no_mangle)] form. All threshold protocols (FROST, CMP20, GG18) ship real cryptography — not stubs, not placeholders, not unfinished work.',
   },
 ];
 


### PR DESCRIPTION
CI gate failed because grep matched the literal string "TODO" inside card body copy. Reworded to 'unfinished work'.