### PR TITLE
feat(content): audience hub + SVG diagrams + expanded concepts

### DIFF
--- a/src/components/brand/CompositeSignatureDiagram.astro
+++ b/src/components/brand/CompositeSignatureDiagram.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * Composite signature structure — three algorithms (classical + classical + PQ)
+ * verified against the same message. Defense in depth.
+ */
+interface Props {
+  class?: string;
+}
+const { class:className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="composite-sig-title"
+  set:html={`
+    <title id="composite-sig-title">Composite signature: three algorithms verified as one. Break any single algorithm and the composite still holds.</title>
+
+    <!-- Message at top -->
+    <rect x="160" y="20" width="160" height="36" rx="8" fill="#0f1326"/>
+    <text x="240" y="42" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">MESSAGE</text>
+
+    <!-- Three algorithm columns -->
+    <g font-family="IBM Plex Sans, sans-serif">
+      <!-- Ed25519 -->
+      <rect x="40" y="90" width="120" height="140" rx="10" fill="white" stroke="#1a7bec" stroke-width="2"/>
+      <text x="100" y="112" text-anchor="middle" font-size="11" font-weight="700" fill="#1a7bec" font-family="IBM Plex Mono" letter-spacing="1">ED25519</text>
+      <text x="100" y="128" text-anchor="middle" font-size="9" fill="#5f6680">classical</text>
+      <line x1="60" y1="140" x2="140" y2="140" stroke="#dfe8f2"/>
+      <text x="100" y="158" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">sig[0] =</text>
+      <text x="100" y="172" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">64 bytes</text>
+      <text x="100" y="200" text-anchor="middle" font-size="9" fill="#009e80" font-weight="700">✓ verifies</text>
+      <text x="100" y="216" text-anchor="middle" font-size="9" fill="#5f6680">since 2015</text>
+
+      <!-- ECDSA-P256 -->
+      <rect x="180" y="90" width="120" height="140" rx="10" fill="white" stroke="#00c2c9" stroke-width="2"/>
+      <text x="240" y="112" text-anchor="middle" font-size="11" font-weight="700" fill="#009e80" font-family="IBM Plex Mono" letter-spacing="1">ECDSA-P256</text>
+      <text x="240" y="128" text-anchor="middle" font-size="9" fill="#5f6680">classical</text>
+      <line x1="200" y1="140" x2="280" y2="140" stroke="#dfe8f2"/>
+      <text x="240" y="158" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">sig[1] =</text>
+      <text x="240" y="172" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">DER bytes</text>
+      <text x="240" y="200" text-anchor="middle" font-size="9" fill="#009e80" font-weight="700">✓ verifies</text>
+      <text x="240" y="216" text-anchor="middle" font-size="9" fill="#5f6680">TLS standard</text>
+
+      <!-- ML-DSA-65 -->
+      <rect x="320" y="90" width="120" height="140" rx="10" fill="#fff4d6" stroke="#ffdc4a" stroke-width="2"/>
+      <text x="380" y="112" text-anchor="middle" font-size="11" font-weight="700" fill="#a07d0a" font-family="IBM Plex Mono" letter-spacing="1">ML-DSA-65</text>
+      <text x="380" y="128" text-anchor="middle" font-size="9" fill="#a07d0a">post-quantum</text>
+      <line x1="340" y1="140" x2="420" y2="140" stroke="#ffdc4a"/>
+      <text x="380" y="158" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">sig[2] =</text>
+      <text x="380" y="172" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#4f5469">~3.3 KB</text>
+      <text x="380" y="200" text-anchor="middle" font-size="9" fill="#a07d0a" font-weight="700">✓ verifies</text>
+      <text x="380" y="216" text-anchor="middle" font-size="9" fill="#5f6680">FIPS 204</text>
+    </g>
+
+    <!-- Lines from message to each -->
+    <line x1="200" y1="56" x2="100" y2="90" stroke="#1a7bec" stroke-width="1.5"/>
+    <line x1="240" y1="56" x2="240" y2="90" stroke="#00c2c9" stroke-width="1.5"/>
+    <line x1="280" y1="56" x2="380" y2="90" stroke="#ffdc4a" stroke-width="1.5"/>
+
+    <!-- AND gate -->
+    <g>
+      <text x="240" y="265" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="14" font-weight="700" fill="#23273a">∧</text>
+      <text x="240" y="280" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">all must verify</text>
+    </g>
+
+    <!-- Composite result -->
+    <rect x="120" y="295" width="240" height="42" rx="10" fill="url(#cs-grad)"/>
+    <defs>
+      <linearGradient id="cs-grad" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#1a7bec"/>
+        <stop offset="50%" stop-color="#00c2c9"/>
+        <stop offset="100%" stop-color="#ffdc4a"/>
+      </linearGradient>
+    </defs>
+    <text x="240" y="313" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="1">COMPOSITE VALID</text>
+    <text x="240" y="328" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">break any one → composite still holds</text>
+  `}
+/>

--- a/src/components/brand/CoordinatorSessionDiagram.astro
+++ b/src/components/brand/CoordinatorSessionDiagram.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * Coordinator session lifecycle — async multi-party signing across
+ * geographically distributed parties.
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="session-title"
+  set:html={`
+    <title id="session-title">Coordinator session lifecycle: async multi-party threshold signing across geographically distributed parties.</title>
+
+    <!-- Time axis on left -->
+    <line x1="50" y1="40" x2="50" y2="320" stroke="#5f6680" stroke-width="1.5"/>
+    <polygon points="50,40 46,50 54,50" fill="#5f6680"/>
+    <text x="40" y="50" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#5f6680">T+0h</text>
+    <text x="40" y="130" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">T+2h</text>
+    <text x="40" y="210" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">T+5h</text>
+    <text x="40" y="290" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">T+9h</text>
+
+    <!-- Coordinator timeline (middle) -->
+    <line x1="240" y1="40" x2="240" y2="320" stroke="#1a7bec" stroke-width="3"/>
+    <rect x="190" y="20" width="100" height="32" rx="8" fill="#1a7bec"/>
+    <text x="240" y="40" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">Coordinator</text>
+
+    <!-- Party timelines -->
+    <!-- Tokyo -->
+    <line x1="120" y1="60" x2="120" y2="320" stroke="#00c2c9" stroke-width="2"/>
+    <rect x="70" y="60" width="100" height="32" rx="8" fill="#00c2c9"/>
+    <text x="120" y="80" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">Tokyo</text>
+
+    <!-- New York -->
+    <line x1="360" y1="60" x2="360" y2="320" stroke="#ffdc4a" stroke-width="2"/>
+    <rect x="310" y="60" width="100" height="32" rx="8" fill="#ffdc4a"/>
+    <text x="360" y="80" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">New York</text>
+
+    <!-- Frankfurt -->
+    <line x1="120" y1="160" x2="120" y2="320" stroke="#00c2c9" stroke-width="2" stroke-dasharray="3 3"/>
+
+    <!-- Round 1: Tokyo commits at T+0 -->
+    <text x="240" y="120" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec">Round 1</text>
+    <line x1="120" y1="120" x2="240" y2="120" stroke="#00c2c9" stroke-width="2" marker-end="url(#ar-cyan)"/>
+    <text x="180" y="115" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#009e80">commit</text>
+
+    <!-- Round 2: Frankfurt commits at T+5 -->
+    <text x="240" y="200" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec">Round 2</text>
+    <line x1="120" y1="200" x2="240" y2="200" stroke="#00c2c9" stroke-width="2"/>
+    <text x="180" y="195" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#009e80">partial sig</text>
+
+    <!-- Threshold reached: NY joins at T+9 -->
+    <text x="240" y="280" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#009e80">QUORUM ✓</text>
+    <line x1="360" y1="280" x2="240" y2="280" stroke="#ffdc4a" stroke-width="2"/>
+    <text x="300" y="275" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#a07d0a">final share</text>
+
+    <!-- Final signature output -->
+    <rect x="160" y="305" width="160" height="36" rx="8" fill="#00dfb7"/>
+    <text x="240" y="328" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">signature produced</text>
+
+    <!-- Annotations on right -->
+    <text x="465" y="120" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">Async:</text>
+    <text x="465" y="132" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">parties join</text>
+    <text x="465" y="144" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">when online</text>
+
+    <defs>
+      <marker id="ar-cyan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#00c2c9"/>
+      </marker>
+    </defs>
+  `}
+/>

--- a/src/components/brand/DefenseInDepthDiagram.astro
+++ b/src/components/brand/DefenseInDepthDiagram.astro
@@ -1,0 +1,59 @@
+---
+/**
+ * Defense in depth — three layers against split-view attacks on
+ * transparency logs. Each layer adds assurance; together they
+ * defeat any adversary who doesn't control log + witnesses + Bitcoin.
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="defense-title"
+  set:html={`
+    <title id="defense-title">Defense in depth against split-view attacks: consistency proofs, witness gossip, OTS anchoring.</title>
+
+    <!-- Outer "adversary capabilities" frame -->
+    <rect x="20" y="20" width="440" height="320" rx="14" fill="none" stroke="#dfe8f2" stroke-dasharray="4 4"/>
+    <text x="240" y="40" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#5f6680" letter-spacing="2">ADVERSARY MUST DEFEAT ALL THREE</text>
+
+    <!-- Layer 1: Consistency proofs -->
+    <g>
+      <rect x="40" y="60" width="400" height="68" rx="10" fill="#e6f0fe" stroke="#1a7bec"/>
+      <circle cx="68" cy="94" r="14" fill="#1a7bec"/>
+      <text x="68" y="98" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white">1</text>
+      <text x="98" y="86" font-family="IBM Plex Sans, sans-serif" font-size="13" font-weight="700" fill="#1a7bec">Consistency proofs</text>
+      <text x="98" y="102" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">RFC 6962 §2.1.2 — every new tree head extends the previous one.</text>
+      <text x="98" y="116" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">Defeats: silent rewriting of history.</text>
+    </g>
+
+    <!-- Layer 2: Witness gossip -->
+    <g>
+      <rect x="40" y="142" width="400" height="68" rx="10" fill="#dcf8f0" stroke="#00c2c9"/>
+      <circle cx="68" cy="176" r="14" fill="#009e80"/>
+      <text x="68" y="180" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white">2</text>
+      <text x="98" y="168" font-family="IBM Plex Sans, sans-serif" font-size="13" font-weight="700" fill="#009e80">Witness gossip</text>
+      <text x="98" y="184" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">Coordinators share heads periodically; witnesses detect divergence.</text>
+      <text x="98" y="198" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">Defeats: log presenting different views to different verifiers.</text>
+    </g>
+
+    <!-- Layer 3: OTS anchoring -->
+    <g>
+      <rect x="40" y="224" width="400" height="68" rx="10" fill="#fff4d6" stroke="#ffdc4a"/>
+      <circle cx="68" cy="258" r="14" fill="#a07d0a"/>
+      <text x="68" y="262" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white">3</text>
+      <text x="98" y="250" font-family="IBM Plex Sans, sans-serif" font-size="13" font-weight="700" fill="#a07d0a">OTS anchoring in Bitcoin</text>
+      <text x="98" y="266" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">Tree heads timestamped in Bitcoin blockchain — irrefutable time proof.</text>
+      <text x="98" y="280" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">Defeats: adversary who controls log AND all witnesses.</text>
+    </g>
+
+    <!-- Bottom annotation -->
+    <text x="240" y="320" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#5f6680" letter-spacing="2">REMAINING ATTACK COST ≥ CONTROLLING BITCOIN HISTORY</text>
+  `}
+/>

--- a/src/components/brand/MerkleTreeDiagram.astro
+++ b/src/components/brand/MerkleTreeDiagram.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * RFC 6962 Merkle tree — leaves, internal nodes, root. Shows the
+ * domain-separated hashing (0x01 leaves, 0x02 internal) and one
+ * inclusion proof path.
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="merkle-title"
+  set:html={`
+    <title id="merkle-title">RFC 6962 Merkle tree: leaves hashed with 0x01 prefix, internal nodes with 0x02 prefix; root commits to the entire set.</title>
+    <defs>
+      <linearGradient id="mt-root" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#1a7bec"/>
+        <stop offset="100%" stop-color="#00c2c9"/>
+      </linearGradient>
+    </defs>
+
+    <!-- Root -->
+    <rect x="200" y="22" width="80" height="36" rx="8" fill="url(#mt-root)"/>
+    <text x="240" y="44" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">ROOT</text>
+
+    <!-- L1: two internal nodes -->
+    <rect x="100" y="100" width="80" height="36" rx="6" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+    <text x="140" y="122" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" fill="#1a7bec">H(01|L|R)</text>
+
+    <rect x="300" y="100" width="80" height="36" rx="6" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+    <text x="340" y="122" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" fill="#1a7bec">H(01|L|R)</text>
+
+    <!-- Lines from root to L1 -->
+    <line x1="220" y1="58" x2="140" y2="100" stroke="#dfe8f2" stroke-width="1.5"/>
+    <line x1="260" y1="58" x2="340" y2="100" stroke="#dfe8f2" stroke-width="1.5"/>
+
+    <!-- L2: 4 internal nodes -->
+    <g font-family="IBM Plex Mono, monospace" font-size="9">
+      <rect x="40" y="178" width="70" height="32" rx="6" fill="white" stroke="#00c2c9"/>
+      <text x="75" y="198" text-anchor="middle" fill="#009e80">H(01|..)</text>
+
+      <rect x="135" y="178" width="70" height="32" rx="6" fill="white" stroke="#00c2c9"/>
+      <text x="170" y="198" text-anchor="middle" fill="#009e80">H(01|..)</text>
+
+      <rect x="240" y="178" width="70" height="32" rx="6" fill="white" stroke="#00c2c9"/>
+      <text x="275" y="198" text-anchor="middle" fill="#009e80">H(01|..)</text>
+
+      <rect x="335" y="178" width="70" height="32" rx="6" fill="white" stroke="#00c2c9"/>
+      <text x="370" y="198" text-anchor="middle" fill="#009e80">H(01|..)</text>
+    </g>
+
+    <!-- Lines L1 to L2 -->
+    <line x1="120" y1="136" x2="75" y2="178" stroke="#dfe8f2"/>
+    <line x1="160" y1="136" x2="170" y2="178" stroke="#dfe8f2"/>
+    <line x1="320" y1="136" x2="275" y2="178" stroke="#dfe8f2"/>
+    <line x1="360" y1="136" x2="370" y2="178" stroke="#dfe8f2"/>
+
+    <!-- Leaves (entry hashes) -->
+    <g font-family="IBM Plex Sans, sans-serif" font-size="10" font-weight="600">
+      <rect x="35" y="252" width="70" height="40" rx="6" fill="#eef4fa" stroke="#dfe8f2"/>
+      <text x="70" y="270" text-anchor="middle" fill="#23273a" font-size="9" font-family="IBM Plex Mono">0x01</text>
+      <text x="70" y="285" text-anchor="middle" fill="#4f5469">entry[0]</text>
+
+      <rect x="130" y="252" width="70" height="40" rx="6" fill="#fff4d6" stroke="#ffdc4a" stroke-width="1.5"/>
+      <text x="165" y="270" text-anchor="middle" fill="#a07d0a" font-size="9" font-family="IBM Plex Mono">0x01</text>
+      <text x="165" y="285" text-anchor="middle" fill="#a07d0a" font-weight="700">entry[1] ★</text>
+
+      <rect x="235" y="252" width="70" height="40" rx="6" fill="#eef4fa" stroke="#dfe8f2"/>
+      <text x="270" y="270" text-anchor="middle" fill="#23273a" font-size="9" font-family="IBM Plex Mono">0x01</text>
+      <text x="270" y="285" text-anchor="middle" fill="#4f5469">entry[2]</text>
+
+      <rect x="330" y="252" width="70" height="40" rx="6" fill="#eef4fa" stroke="#dfe8f2"/>
+      <text x="365" y="270" text-anchor="middle" fill="#23273a" font-size="9" font-family="IBM Plex Mono">0x01</text>
+      <text x="365" y="285" text-anchor="middle" fill="#4f5469">entry[3]</text>
+    </g>
+
+    <!-- Lines L2 to leaves -->
+    <line x1="70" y1="210" x2="70" y2="252" stroke="#dfe8f2"/>
+    <line x1="170" y1="210" x2="165" y2="252" stroke="#dfe8f2"/>
+    <line x1="275" y1="210" x2="270" y2="252" stroke="#dfe8f2"/>
+    <line x1="370" y1="210" x2="365" y2="252" stroke="#dfe8f2"/>
+
+    <!-- Inclusion proof arrows (gold path for entry[1]) -->
+    <line x1="165" y1="252" x2="170" y2="210" stroke="#ffdc4a" stroke-width="2.5"/>
+    <line x1="170" y1="210" x2="75" y2="178" stroke="#ffdc4a" stroke-width="2.5"/>
+    <line x1="170" y1="178" x2="120" y2="136" stroke="#ffdc4a" stroke-width="2.5"/>
+    <line x1="140" y1="100" x2="220" y2="58" stroke="#ffdc4a" stroke-width="2.5"/>
+
+    <!-- Legend -->
+    <g font-family="IBM Plex Sans, sans-serif" font-size="9">
+      <rect x="40" y="320" width="10" height="10" fill="#ffdc4a"/>
+      <text x="56" y="329" fill="#4f5469">inclusion proof for entry[1]</text>
+
+      <rect x="220" y="320" width="10" height="10" fill="url(#mt-root)"/>
+      <text x="236" y="329" fill="#4f5469">root = commitment to all leaves</text>
+    </g>
+  `}
+/>

--- a/src/components/brand/SplitViewAttackDiagram.astro
+++ b/src/components/brand/SplitViewAttackDiagram.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * Split-view attack + detection — left side shows the attack,
+ * right side shows how consistency proofs catch it.
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="split-view-title"
+  set:html={`
+    <title id="split-view-title">Split-view attack on a transparency log, and how consistency proofs + witness gossip detect it.</title>
+
+    <!-- Left: the attack -->
+    <text x="120" y="30" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#a07d0a" letter-spacing="2">THE ATTACK</text>
+
+    <!-- Malicious log operator -->
+    <rect x="60" y="50" width="120" height="40" rx="8" fill="#fff4d6" stroke="#ffdc4a" stroke-width="2"/>
+    <text x="120" y="68" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#a07d0a">Log operator</text>
+    <text x="120" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#a07d0a">compromised</text>
+
+    <!-- Two divergent heads -->
+    <rect x="30" y="120" width="90" height="50" rx="6" fill="white" stroke="#ffdc4a"/>
+    <text x="75" y="138" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#a07d0a">head A</text>
+    <text x="75" y="153" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#a07d0a">root=0xab...</text>
+
+    <rect x="120" y="120" width="90" height="50" rx="6" fill="white" stroke="#ffdc4a"/>
+    <text x="165" y="138" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#a07d0a">head B</text>
+    <text x="165" y="153" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#a07d0a">root=0xcd...</text>
+
+    <!-- Two verifiers being shown different views -->
+    <rect x="30" y="200" width="90" height="36" rx="6" fill="#eef4fa"/>
+    <text x="75" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#23273a">Verifier A</text>
+
+    <rect x="120" y="200" width="90" height="36" rx="6" fill="#eef4fa"/>
+    <text x="165" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#23273a">Verifier B</text>
+
+    <!-- Arrows -->
+    <line x1="75" y1="100" x2="75" y2="120" stroke="#ffdc4a" stroke-width="1.5"/>
+    <line x1="165" y1="100" x2="165" y2="120" stroke="#ffdc4a" stroke-width="1.5"/>
+    <line x1="75" y1="170" x2="75" y2="200" stroke="#ffdc4a" stroke-width="1.5"/>
+    <line x1="165" y1="170" x2="165" y2="200" stroke="#ffdc4a" stroke-width="1.5"/>
+
+    <text x="120" y="270" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#a07d0a">silent insertion / omission</text>
+    <text x="120" y="284" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#a07d0a">undetected without defense</text>
+
+    <!-- Divider -->
+    <line x1="240" y1="20" x2="240" y2="340" stroke="#dfe8f2" stroke-width="1" stroke-dasharray="4 4"/>
+
+    <!-- Right: the defense -->
+    <text x="360" y="30" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#009e80" letter-spacing="2">THE DEFENSE</text>
+
+    <!-- Witness network -->
+    <rect x="280" y="50" width="160" height="40" rx="8" fill="#dcf8f0" stroke="#00c2c9" stroke-width="2"/>
+    <text x="360" y="68" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#009e80">Witness network</text>
+    <text x="360" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#009e80">gossips heads hourly</text>
+
+    <!-- Both verifiers send heads to witnesses -->
+    <rect x="270" y="120" width="80" height="36" rx="6" fill="white" stroke="#00c2c9"/>
+    <text x="310" y="142" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#009e80">head A</text>
+
+    <rect x="370" y="120" width="80" height="36" rx="6" fill="white" stroke="#00c2c9"/>
+    <text x="410" y="142" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#009e80">head B</text>
+
+    <line x1="310" y1="90" x2="310" y2="120" stroke="#00c2c9" stroke-width="1.5"/>
+    <line x1="410" y1="90" x2="410" y2="120" stroke="#00c2c9" stroke-width="1.5"/>
+
+    <!-- Detection -->
+    <rect x="280" y="180" width="160" height="50" rx="8" fill="#009e80"/>
+    <text x="360" y="200" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">⚠ DIVERGENCE</text>
+    <text x="360" y="216" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">DETECTED</text>
+
+    <line x1="310" y1="156" x2="340" y2="180" stroke="#009e80" stroke-width="1.5"/>
+    <line x1="410" y1="156" x2="380" y2="180" stroke="#009e80" stroke-width="1.5"/>
+
+    <text x="360" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">+ OTS anchoring in Bitcoin</text>
+    <text x="360" y="266" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">for irrefutable time proof</text>
+
+    <text x="360" y="296" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#009e80">DEFENSE IN DEPTH</text>
+    <text x="360" y="310" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">3 layers, each adds assurance</text>
+  `}
+/>

--- a/src/components/brand/ThresholdSigningFlow.astro
+++ b/src/components/brand/ThresholdSigningFlow.astro
@@ -1,0 +1,96 @@
+---
+/**
+ * Threshold signing flow — shows how T-of-N parties produce a single
+ * signature without any one of them holding the full key.
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = '' } = Astro.props;
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 360"
+  class={className}
+  role="img"
+  aria-labelledby="threshold-flow-title"
+  set:html={`
+    <title id="threshold-flow-title">Threshold signing: T-of-N parties co-sign without reconstructing the secret.</title>
+    <defs>
+      <linearGradient id="ts-msg" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#1a7bec"/>
+        <stop offset="100%" stop-color="#00c2c9"/>
+      </linearGradient>
+      <linearGradient id="ts-sig" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#00dfb7"/>
+        <stop offset="100%" stop-color="#009e80"/>
+      </linearGradient>
+    </defs>
+
+    <!-- Message -->
+    <rect x="160" y="20" width="160" height="42" rx="8" fill="url(#ts-msg)"/>
+    <text x="240" y="46" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">MESSAGE</text>
+
+    <!-- Coordinator in middle -->
+    <rect x="190" y="155" width="100" height="50" rx="10" fill="white" stroke="#1a7bec" stroke-width="2"/>
+    <text x="240" y="175" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#1a7bec">COORDINATOR</text>
+    <text x="240" y="192" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">aggregates shares</text>
+
+    <!-- N=5 party circles at bottom -->
+    <g font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700">
+      <!-- Party 1 — participating -->
+      <circle cx="80" cy="290" r="26" fill="#1a7bec"/>
+      <text x="80" y="295" text-anchor="middle" fill="white">P1</text>
+      <text x="80" y="330" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#4f5469">share 1</text>
+
+      <!-- Party 2 — NOT participating (gray) -->
+      <circle cx="150" cy="290" r="26" fill="#eef4fa" stroke="#dfe8f2"/>
+      <text x="150" y="295" text-anchor="middle" fill="#5f6680">P2</text>
+      <text x="150" y="330" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5f6680">offline</text>
+
+      <!-- Party 3 — participating -->
+      <circle cx="220" cy="290" r="26" fill="#1a7bec"/>
+      <text x="220" y="295" text-anchor="middle" fill="white">P3</text>
+      <text x="220" y="330" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#4f5469">share 3</text>
+
+      <!-- Party 4 — NOT participating -->
+      <circle cx="290" cy="290" r="26" fill="#eef4fa" stroke="#dfe8f2"/>
+      <text x="290" y="295" text-anchor="middle" fill="#5f6680">P4</text>
+      <text x="290" y="330" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5f6680">offline</text>
+
+      <!-- Party 5 — participating -->
+      <circle cx="360" cy="290" r="26" fill="#1a7bec"/>
+      <text x="360" y="295" text-anchor="middle" fill="white">P5</text>
+      <text x="360" y="330" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#4f5469">share 5</text>
+    </g>
+
+    <!-- Arrows: participating parties up to coordinator -->
+    <line x1="80" y1="264" x2="200" y2="200" stroke="#1a7bec" stroke-width="1.5" marker-end="url(#ts-arrow)"/>
+    <line x1="220" y1="264" x2="240" y2="205" stroke="#1a7bec" stroke-width="1.5"/>
+    <line x1="360" y1="264" x2="280" y2="200" stroke="#1a7bec" stroke-width="1.5"/>
+
+    <!-- Dashed gray arrows from offline parties -->
+    <line x1="150" y1="264" x2="220" y2="200" stroke="#dfe8f2" stroke-width="1" stroke-dasharray="3 3"/>
+    <line x1="290" y1="264" x2="260" y2="200" stroke="#dfe8f2" stroke-width="1" stroke-dasharray="3 3"/>
+
+    <!-- Arrow from message to coordinator -->
+    <line x1="240" y1="62" x2="240" y2="155" stroke="#1a7bec" stroke-width="1.5" stroke-dasharray="3 3"/>
+
+    <!-- Final signature -->
+    <rect x="160" y="95" width="160" height="42" rx="8" fill="url(#ts-sig)" opacity="0.95"/>
+    <text x="240" y="113" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white" letter-spacing="2">3-OF-5 QUORUM</text>
+    <text x="240" y="128" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">signature produced</text>
+
+    <line x1="240" y1="137" x2="240" y2="155" stroke="#009e80" stroke-width="2"/>
+
+    <!-- Side annotations -->
+    <text x="20" y="160" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">N = 5</text>
+    <text x="20" y="174" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">T = 3</text>
+    <text x="20" y="188" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">participating: 3</text>
+
+    <text x="430" y="160" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">secret</text>
+    <text x="430" y="174" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">never</text>
+    <text x="430" y="188" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">rebuilt</text>
+  `}
+/>

--- a/src/content/concepts/composite-signatures.mdx
+++ b/src/content/concepts/composite-signatures.mdx
@@ -5,6 +5,8 @@ audience: developer
 order: 3
 ---
 
+import CompositeSignatureDiagram from '../../components/brand/CompositeSignatureDiagram.astro';
+
 # Composite signatures
 
 A composite signature is a single signature value that contains
@@ -13,6 +15,16 @@ when every component verifies. The point: defense-in-depth and
 post-quantum migration without a flag day.
 
 ## The shape of a composite
+
+A composite signature bundles the artifacts of multiple algorithms
+into one value. Verification succeeds only when every component
+verifies against the same message.
+
+<CompositeSignatureDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The diagram shows three components — Ed25519 (classical), ECDSA-P256
+(classical), and ML-DSA-65 (post-quantum). Break any single algorithm
+and the composite still holds: the other components still verify.
 
 A composite signature is a list of `(algorithm_oid, signature_bytes)`
 pairs, optionally with public key references and metadata:

--- a/src/content/concepts/threshold-crypto-101.mdx
+++ b/src/content/concepts/threshold-crypto-101.mdx
@@ -5,6 +5,9 @@ audience: developer
 order: 1
 ---
 
+import ThresholdSigningFlow from '../../components/brand/ThresholdSigningFlow.astro';
+import MerkleTreeDiagram from '../../components/brand/MerkleTreeDiagram.astro';
+
 # Threshold cryptography 101
 
 Threshold cryptography is the math that lets a group of N parties
@@ -94,6 +97,16 @@ For practical signing, the same idea runs in the exponent: each
 party's partial signature is `σᵢ = f(i) · H(m)` and the final
 signature is `σ = Σᵢ ℓᵢ(0) · σᵢ`.
 
+## Visual: how a signing session works
+
+The diagram below shows a 3-of-5 signing session. Three parties
+participate (P1, P3, P5); two are offline (P2, P4). The coordinator
+collects partial signatures from the three participating parties and
+produces the final signature. The secret is never reconstructed on
+any single machine.
+
+<ThresholdSigningFlow class="w-full max-w-2xl mx-auto my-8" />
+
 ## Try it
 
 The Confium homepage has an interactive [quorum playground](/)
@@ -102,6 +115,19 @@ in action.
 
 For a worked code example, see the [threshold signing walkthrough](https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx)
 in the Rust workspace docs.
+
+## What this has to do with transparency logs
+
+Once you have a valid threshold signature, you typically want a
+public, verifiable record that the signing happened. That's where
+the [transparency log](./transparency-logs/) comes in. The signature
+event becomes a leaf in a Merkle tree like the one below:
+
+<MerkleTreeDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The root hash commits to every leaf. Inclusion proofs let any
+verifier independently confirm a specific signature event is in the
+log without revealing anything else about the log's contents.
 
 ## See also
 

--- a/src/content/concepts/transparency-logs.mdx
+++ b/src/content/concepts/transparency-logs.mdx
@@ -5,6 +5,10 @@ audience: developer
 order: 4
 ---
 
+import MerkleTreeDiagram from '../../components/brand/MerkleTreeDiagram.astro';
+import SplitViewAttackDiagram from '../../components/brand/SplitViewAttackDiagram.astro';
+import DefenseInDepthDiagram from '../../components/brand/DefenseInDepthDiagram.astro';
+
 # Transparency logs
 
 A transparency log is an append-only public record of every
@@ -40,6 +44,13 @@ The log is a Merkle tree built from SHA-256 hashes:
 - Each leaf is `SHA-256(0x01 || entry_hash)`.
 - Each internal node is `SHA-256(0x02 || left_child || right_child)`.
 - The root hash commits to the entire set of leaves.
+
+<MerkleTreeDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The diagram shows a 4-leaf tree. The gold path traces the inclusion
+proof for entry[1]: the verifier starts with the leaf hash, combines
+it with each sibling up the tree, and checks the final result
+equals the published root.
 
 Domain separation (`0x01` for leaves, `0x02` for internal nodes)
 prevents leaf values from being interpreted as internal nodes and
@@ -82,6 +93,17 @@ Without consistency proofs, a log operator can present two
 different tree heads to different verifiers, and nobody can
 detect it:
 
+<SplitViewAttackDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The left side shows the attack: a compromised log operator presents
+head A to verifier A and head B (with a different root) to verifier
+B. Both can verify their own inclusion proofs against their own
+heads. Neither knows the other's head exists.
+
+The right side shows the defense: witnesses gossip heads between
+coordinators. If two coordinators have different heads for the same
+tree size, the witnesses detect the divergence.
+
 1. Verifier A receives tree head N.
 2. Verifier B receives a different tree head N' (with a different root).
 3. Both verifiers can verify their own inclusion proofs against
@@ -94,6 +116,8 @@ detect it:
 Consistency proofs alone are necessary but not sufficient —
 verifiers must also communicate (gossip) so they know about each
 other's heads. Three layers:
+
+<DefenseInDepthDiagram class="w-full max-w-2xl mx-auto my-8" />
 
 1. **Consistency proofs** — every new tree head extends the
    previous one. Implemented in `confium-transparency`.

--- a/src/content/docs/comparison.mdx
+++ b/src/content/docs/comparison.mdx
@@ -1,0 +1,150 @@
+---
+title: Comparison
+description: Confium vs HSMs, conventional CAs, KMS, Sigstore, and commercial threshold solutions. Where each fits, where each falls short.
+audience: evaluator
+order: 11
+---
+
+# Comparison
+
+Confium occupies a specific niche in the trust-infrastructure
+landscape: open-source, standards-only, threshold-native, with a path
+to post-quantum migration that doesn't require replacing hardware.
+This page maps that niche against the alternatives.
+
+## At a glance
+
+| Property | Confium | HSM (single-key) | Conventional CA | Cloud KMS | Sigstore | Commercial threshold |
+| --- | --- | --- | --- | --- | --- | --- |
+| Open source | ✓ BSD-2-Clause | varies | ✗ | ✗ | ✓ Apache-2.0 | ✗ |
+| No single point of compromise | ✓ structural | ✗ (single HSM) | ✗ (single CA key) | ✗ (KMS holds key) | ✗ (Cosign) | ✓ structural |
+| Standards-only adapters | ✓ PKCS#11 / OpenSSL / JCE / TLS | ✓ PKCS#11 | varies | limited | ✗ own API | usually |
+| Async (offline-tolerant) sessions | ✓ structural | n/a | n/a | ✗ | ✗ | varies |
+| Post-quantum migration path | ✓ composite sigs | ✗ (HSM replacement) | ✗ | varies | ✗ | varies |
+| Transparency log built in | ✓ RFC 6962 | ✗ | varies | ✗ | ✓ Rekor | varies |
+| Attribute-based quorum | ✓ DSL | ✗ | ✗ | limited | ✗ | limited |
+| FIPS 140 mode | ✓ via plugin | ✓ (HSM itself) | varies | ✓ | ✗ | ✓ |
+| Jurisdictional algorithm policies | ✓ per-deployment | limited | varies | limited | ✗ | limited |
+| Long-term archival (ERS, OTS) | ✓ both | ✗ | varies | ✗ | ✗ | varies |
+| Licensing cost | Free | $$ (hardware) | $$ (subscription) | $ (per-call) | Free | $$$ (subscription) |
+
+## Confium vs HSM (single-key)
+
+A Hardware Security Module stores a single private key in tamper-resistant
+hardware. Compromise requires physical access plus PIN compromise — but
+once compromised, the attacker has the full key and can sign anything
+until the HSM is revoked.
+
+**Use HSM when:**
+- You need the highest physical-security assurance (FIPS 140-2 Level 3+).
+- Single-key operation is acceptable.
+- You already have HSMs and want to keep using them.
+
+**Use Confium when:**
+- No single party can be trusted with the key.
+- You need quorum governance (multi-stakeholder signing).
+- You want software-only operation without specialized hardware.
+
+**Best together:** Confium integrates with HSMs via PKCS#11. Each
+signer can store its share in an HSM, combining HSM-grade physical
+security with Confium's threshold governance.
+
+## Confium vs conventional CA
+
+A conventional Certificate Authority (DigiCert, Sectigo, Let's
+Encrypt) holds a single private key that signs certificates. The CA
+operator is trusted not to misuse the key.
+
+**Use conventional CA when:**
+- You're issuing TLS certificates for the public web (use Let's Encrypt).
+- You trust the CA operator.
+- Single-stakeholder model fits your org.
+
+**Use Confium Mode 3 (Sovereign PKI) when:**
+- No single stakeholder can be trusted.
+- You need custom certificate formats or delegation rules.
+- You want a public, auditable record of every certificate ever issued.
+
+## Confium vs cloud KMS
+
+AWS KMS, Google Cloud KMS, and Azure Key Vault offer hosted
+cryptographic key storage. The cloud provider holds (or shards) the
+key; you call an API to sign.
+
+**Use cloud KMS when:**
+- You're already on one cloud and want minimal operational overhead.
+- Single-cloud trust model is acceptable.
+- You want tight IAM integration with cloud-native workloads.
+
+**Use Confium when:**
+- You need cross-cloud or on-prem deployment.
+- You want the key split across organizations, not just shards within one provider.
+- Compliance requires open-source, auditable crypto layer.
+
+**Best together:** Confium has a `confium-store-cloud` backend that
+uses cloud KMS as one share storage option among many.
+
+## Confium vs Sigstore
+
+[Sigstore](https://sigstore.dev/) is an open-source project for
+software supply-chain signing. It uses ephemeral keys, OIDC-based
+identity, and a transparency log (Rekor). It's optimized for code
+signing in CI/CD pipelines.
+
+**Use Sigstore when:**
+- You're signing container images, Python packages, or other build artifacts in CI.
+- You want keyless signing tied to GitHub / GitLab identity.
+- Single-signer-per-build is acceptable.
+
+**Use Confium when:**
+- You need multi-stakeholder quorum (e.g. release requires 2-of-3 maintainers).
+- You need threshold key escrow or recovery.
+- You're signing certificates, documents, or anything that isn't a build artifact.
+
+**Best together:** Confium's `confium-cms` produces standard CMS
+SignedData that Sigstore-style verifiers can consume.
+
+## Confium vs commercial threshold solutions
+
+Companies like Unbound (acquired by Coinbase), Sepior (acquired by
+Coinbase), and others offer commercial threshold cryptography
+products.
+
+**Use commercial threshold when:**
+- You want vendor support and SLA.
+- The vendor's specific protocol (often MPC variants) meets your needs.
+- Proprietary licensing is acceptable.
+
+**Use Confium when:**
+- Open-source is a hard requirement.
+- You need standards-only integration (PKCS#11, OpenSSL, JCE).
+- You want to avoid vendor lock-in.
+- You're deploying in a jurisdiction where the vendor isn't available.
+
+## What Confium is not
+
+- **Not a CA in a box.** Confium is the cryptographic layer; you bring the policy, the certificate formats, and the governance.
+- **Not an HSM.** Confium is software. Use HSMs alongside Confium if you need hardware-grade key protection.
+- **Not a cloud service.** Confium runs wherever you run it. No vendor-hosted version.
+- **Not a Sigstore replacement for code signing.** Different scope, different protocols.
+
+## When to choose Confium
+
+Pick Confium if any of these describe your situation:
+
+1. You're an institution where no single party can be trusted with the signing key.
+2. You need post-quantum migration without re-issuing every certificate.
+3. You want a public, auditable record of every signing operation.
+4. You need cross-jurisdiction deployment with per-jurisdiction algorithm policies.
+5. You're building a distributed system where multiple parties must cooperate to sign.
+6. Open-source + standards-only is a non-negotiable.
+
+If none of these apply, conventional PKI or a cloud KMS may serve you
+just as well — at lower operational complexity.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Security model](./security-model.mdx)
+- [Three deployment modes](./three-modes.mdx)
+- [Audience guides](/audiences/)

--- a/src/content/docs/compliance.mdx
+++ b/src/content/docs/compliance.mdx
@@ -1,0 +1,168 @@
+---
+title: Compliance
+description: FIPS 140 mode, jurisdictional algorithm policies, audit log format, and regulatory mapping to eIDAS, HIPAA, FedRAMP, and Common Criteria.
+audience: evaluator
+order: 12
+---
+
+# Compliance
+
+Confium ships hooks for FIPS 140 mode, jurisdictional algorithm
+allow-lists, and structured audit logging. This page covers what each
+hook does and how it maps to common regulatory frameworks.
+
+For audience-specific guidance, see
+[the compliance officer guide](/audiences/compliance/).
+
+## FIPS 140 mode
+
+FIPS mode routes every cryptographic operation through a FIPS-validated
+plugin (typically Botan built against a FIPS-validated Botan). The
+engine refuses to use non-FIPS-validated primitives even if they are
+installed.
+
+```ruby
+Confium::Policy.fips_mode = true
+```
+
+In FIPS mode:
+
+- SHA-1, RSA-1024, and other legacy algorithms are rejected even if allow-listed.
+- The Botan plugin (when built FIPS-validated) is the preferred backend.
+- Random number generation uses the FIPS-approved DRBG.
+- Self-tests run at startup and periodically per FIPS 140-2 §4.9.
+
+FIPS mode is process-global. Set it once at boot; every subsequent
+Confium call honors it.
+
+## Jurisdictional algorithm policies
+
+Beyond FIPS, individual jurisdictions have specific algorithm
+requirements. Confium expresses these as allow-lists:
+
+### European Union (P-384+)
+
+```ruby
+Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[ECDSA-P384 ECDSA-P521]
+  p.allowed_hash_algorithms = %w[SHA-384 SHA-512]
+end
+```
+
+### United States (P-256 acceptable)
+
+```ruby
+Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[ECDSA-P256 ECDSA-P384 Ed25519]
+  p.allowed_hash_algorithms = %w[SHA-256 SHA-384 SHA-512]
+end
+```
+
+### China (SM2 / SM3)
+
+```ruby
+Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[SM2]
+  p.allowed_hash_algorithms = %w[SM3]
+end
+```
+
+SM2/SM3 support requires the SM plugin bundle; the engine rejects
+these algorithms if the plugin is not loaded.
+
+### Post-quantum-required (forward-looking)
+
+```ruby
+Confium::Policy.configure do |p|
+  p.require_pq_component = true
+  p.allowed_signature_algorithms = %w[ECDSA-P256 Ed25519 ML-DSA-65]
+end
+```
+
+With `require_pq_component = true`, the engine only accepts composite
+signatures that include at least one post-quantum algorithm. Useful
+for long-lived signatures (code signing, archival) where migration
+to PQ is a regulatory or business requirement.
+
+## Deployment manifest as policy artifact
+
+The TOML deployment manifest is the canonical policy artifact. Treat
+it like any other audited configuration:
+
+- Version it in git.
+- Require code review for changes.
+- Sign it (Confium can verify its own manifest signature at boot).
+- Audit changes against the change-management control of your compliance framework.
+
+```toml
+[policy]
+fips_mode = true
+allowed_signature_algorithms = ["ECDSA-P384", "Ed25519"]
+allowed_hash_algorithms = ["SHA-384", "SHA-512"]
+require_pq_component = false
+
+[quorum]
+threshold = 3
+total = 5
+diversity = { regions = 3 }
+```
+
+## Audit log format
+
+Every signing operation produces a structured audit record. The format
+is JSON, suitable for ingestion into SIEM systems (Splunk, Elastic,
+Datadog, etc.).
+
+```json
+{
+  "event_id": "evt_01H8X9...",
+  "timestamp": "2026-07-28T14:23:42.118Z",
+  "session_id": "sess_8a92...",
+  "coordinator": "coord-eu.internal",
+  "operation": "sign",
+  "algorithm": "ECDSA-P256",
+  "message_hash": "sha256:9b1d...",
+  "signature_hash": "sha256:7c3e...",
+  "transparency_sequence": 18437,
+  "quorum": {
+    "required": 3,
+    "participating": 3,
+    "signers": ["director-1", "director-3", "director-5"]
+  },
+  "attributes": {
+    "region": ["na", "eu", "apac"]
+  },
+  "policy_version": "deploy.toml@abc123",
+  "fips_mode": true
+}
+```
+
+The transparency log anchors each audit record's `event_id` as a
+Merkle leaf. The inclusion proof cryptographically binds the audit
+record to a public, verifiable timeline.
+
+## Regulatory framework mapping
+
+| Framework | Relevant Confium features |
+| --- | --- |
+| **eIDAS** (EU, electronic signatures) | Jurisdictional policy enforcing P-384+ for Qualified Electronic Signatures. Audit log with signer identity + attributes. Transparency log for long-term verifiability (eIDAS Article 50). |
+| **HIPAA** (US, healthcare) | Audit trail of every signing operation (§164.312(b)). FIPS 140 mode for cryptographic primitives (§164.312(a)(2)(iv)). Threshold key escrow pattern for break-glass access. |
+| **FedRAMP** (US, federal cloud) | FIPS 140-2 validated cryptography. Structured audit log ingestible into SIEM. Attribute-based access control for signer authorization. |
+| **Common Criteria (EAL4+)** | Open-source codebase for full audit. `#![forbid(unsafe_code)]` for memory safety. Type-safe errors (no string-error attack surface). |
+| **GDPR** (data minimization) | Audit log records hashes, not message contents. No personal data in transparency log entries (only event hashes). |
+| **SOC 2 Type II** | Transparency log provides immutable audit trail. Attribute-based quorum for separation of duties. Structured audit log for monitoring controls. |
+
+This table is informational, not a certification. Each deployment
+must complete its own compliance assessment.
+
+## Disclosure policy
+
+See [/security/](/security/) for the security disclosure policy,
+PGP key, and SLA for vulnerability response.
+
+## See also
+
+- [Security model](./security-model.mdx)
+- [Architecture](./architecture.mdx)
+- [Compliance officer guide](/audiences/compliance/)
+- [Security disclosure](/security/)

--- a/src/pages/audiences/architects.astro
+++ b/src/pages/audiences/architects.astro
@@ -1,0 +1,239 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import DefenseInDepthDiagram from '../../components/brand/DefenseInDepthDiagram.astro';
+import SplitViewAttackDiagram from '../../components/brand/SplitViewAttackDiagram.astro';
+import CoordinatorSessionDiagram from '../../components/brand/CoordinatorSessionDiagram.astro';
+---
+
+<BaseLayout
+  title="For security architects"
+  description="Threat model, integration patterns, defense in depth, failure modes. The architect's guide to designing a Confium deployment."
+>
+  <PageHero
+    eyebrow="For security architects"
+    title="Threat model and integration patterns"
+    description="Confium replaces single-key trust with threshold quorum. This page covers the trust model, the integration patterns for each deployment mode, the defense-in-depth story, and the failure modes for every component."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>Trust model</h2>
+      <p>
+        A Confium deployment with threshold T-of-N tolerates compromise of
+        up to T−1 parties without losing the ability to produce valid
+        signatures. Equally important: compromise of up to T−1 parties
+        <strong>does not</strong> let the attacker produce signatures on their own.
+      </p>
+      <p>
+        The trust assumption: an attacker cannot compromise T or more
+        parties simultaneously within a single signing session. With
+        proactive share refresh (Herzberg refresh via
+        <code>confium-tc-reshare</code>), the window for compromise shrinks
+        to a single refresh period.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Threat table</h2>
+      <table>
+        <thead>
+          <tr><th>Threat</th><th>Defense</th><th>Residual risk</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Single-key compromise</td>
+            <td>No single key exists. Shamir split at generation; never reconstructed.</td>
+            <td>T parties colluding within one refresh window.</td>
+          </tr>
+          <tr>
+            <td>Split-view attack on transparency log</td>
+            <td>Consistency proofs + witness gossip + OTS anchoring.</td>
+            <td>Adversary controlling log + witnesses + ability to rewrite Bitcoin.</td>
+          </tr>
+          <tr>
+            <td>Long-term share aggregation</td>
+            <td>Herzberg refresh re-randomizes shares periodically.</td>
+            <td>T shares compromised within one refresh window.</td>
+          </tr>
+          <tr>
+            <td>Side-channel (timing, memory)</td>
+            <td>Constant-time scalar arithmetic; SecureBytes zeroizes on drop; <code>#![forbid(unsafe_code)]</code>.</td>
+            <td>Kernel-level rootkit on signer host — use hardware enclaves for highest assurance.</td>
+          </tr>
+          <tr>
+            <td>Coordinator compromise</td>
+            <td>Coordinator cannot produce signatures without T party contributions; nonces are unique per session.</td>
+            <td>Coordinator DoS (availability), not forgery (secrecy).</td>
+          </tr>
+          <tr>
+            <td>Policy violation (wrong algorithm used)</td>
+            <td>Confium::Policy is process-global; enforced on every call.</td>
+            <td>Misconfigured policy at deployment time — audit your manifest.</td>
+          </tr>
+          <tr>
+            <td>Replay of old session</td>
+            <td>Per-session nonces; coordinator rejects duplicate session IDs.</td>
+            <td>None — replay produces detectable hash mismatch.</td>
+          </tr>
+        </tbody>
+      </table>
+    </Reveal>
+
+    <Reveal>
+      <h2>Defense in depth for transparency logs</h2>
+      <p>
+        The transparency log is the audit spine of any Confium deployment.
+        Three layers protect against split-view attacks:
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <DefenseInDepthDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <p>
+        Layer 1 (consistency proofs) is necessary but not sufficient —
+        verifiers must communicate to detect divergent heads. Layer 2
+        (witness gossip) makes that communication automatic. Layer 3
+        (OTS anchoring) defeats the adversary who controls both log and
+        witnesses by anchoring state in Bitcoin's proof-of-work chain.
+      </p>
+      <p>
+        See <a href="/docs/transparency-logs/">the transparency logs deep dive</a>
+        for the cryptographic details.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Split-view attack walkthrough</h2>
+      <p>
+        The diagram below shows both the attack and the defense in one
+        frame. On the left, a compromised log operator presents two
+        different tree heads to two different verifiers. On the right,
+        witnesses gossip the heads and detect the divergence.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <SplitViewAttackDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Integration patterns by mode</h2>
+
+      <h3>Mode 1 — Peer-to-peer</h3>
+      <p>
+        Nodes exchange threshold protocol messages directly. No
+        intermediary. The coordinator is a library linked into the
+        application; signers are processes the application can reach
+        over the transport of choice.
+      </p>
+      <ul>
+        <li><strong>Best for</strong>: new distributed systems where you control both ends.</li>
+        <li><strong>Failure mode</strong>: if too few signers are reachable, signing fails. Use async sessions to tolerate latency.</li>
+        <li><strong>Hardening</strong>: use <code>confium-net-quic</code> for transport encryption + auth; pin signer identities.</li>
+      </ul>
+
+      <h3>Mode 2 — PKI drop-in</h3>
+      <p>
+        Existing PKCS#11, OpenSSL, or JCE consumer talks to a Confium
+        adapter process. The adapter translates each call into a
+        threshold session.
+      </p>
+      <ul>
+        <li><strong>Best for</strong>: migrating existing PKI consumers without rewriting them.</li>
+        <li><strong>Failure mode</strong>: adapter is a single point of failure unless you deploy it redundantly.</li>
+        <li><strong>Hardening</strong>: deploy adapter as a sidecar or behind a load balancer; the consumer sees only one logical PKCS#11 socket.</li>
+      </ul>
+
+      <h3>Mode 3 — Sovereign PKI</h3>
+      <p>
+        Custom certificate formats, custom delegation rules, custom
+        archival cadence. Coordinator runs as a long-lived service;
+        signers join and leave over time.
+      </p>
+      <ul>
+        <li><strong>Best for</strong>: institutional PKI where no single stakeholder can be trusted.</li>
+        <li><strong>Failure mode</strong>: institutional signers may go offline for long periods. Async sessions are mandatory.</li>
+        <li><strong>Hardening</strong>: attribute-based quorum (e.g. 5-of-9 directors from 3 distinct regions) for resilience against regional compromise.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Coordinator session lifecycle</h2>
+      <p>
+        The coordinator is an <strong>availability</strong> service, not a
+        <strong>secrecy</strong> service. Compromising it can
+        denial-of-service the deployment but cannot produce unauthorized
+        signatures — the math requires T party contributions.
+      </p>
+      <p>
+        Sessions are async. A director in Tokyo can submit their share
+        during their workday; a director in New York submits theirs hours
+        later; the coordinator combines when quorum is reached. Below is
+        a 9-hour session spanning Tokyo, Frankfurt, and New York.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <CoordinatorSessionDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Failure modes and mitigations</h2>
+
+      <h3>Signer loss</h3>
+      <p>
+        If a signer is lost permanently (hardware failure, departed
+        employee), use <code>confium-tc-reshare</code> to re-share the
+        secret across the remaining parties plus a new replacement signer.
+        The secret itself is never reconstructed. The threshold T may
+        also be adjusted during re-sharing.
+      </p>
+
+      <h3>Coordinator compromise</h3>
+      <p>
+        Replace the coordinator. The signing key is not on the
+        coordinator — it's split across signers. Re-deploy coordinator
+        from a clean image; resume sessions from the transparency log.
+      </p>
+
+      <h3>Transparency log compromise</h3>
+      <p>
+        If the log operator goes rogue, witnesses detect divergence via
+        gossip. Switch to a backup log; replay recent tree heads. The
+        OTS anchors in Bitcoin preserve irrefutable history.
+      </p>
+
+      <h3>Algorithm break</h3>
+      <p>
+        If a classical algorithm (e.g. Ed25519) is broken, deploy a
+        composite-signature update that includes the broken algorithm
+        alongside a post-quantum algorithm. Verifiers that have upgraded
+        accept the composite; verifiers that haven't still accept the
+        classical component (which is what they always accepted).
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/docs/security-model/">Security model deep dive</a></li>
+        <li><a href="/docs/architecture/">Engine architecture</a></li>
+        <li><a href="/docs/three-modes/">Three deployment modes</a></li>
+        <li><a href="/docs/transparency-logs/">Transparency logs</a></li>
+        <li><a href="/docs/pq-migration/">PQ migration with composite signatures</a></li>
+        <li><a href="/audiences/operators/">Operator deployment guide</a></li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/compliance.astro
+++ b/src/pages/audiences/compliance.astro
@@ -1,0 +1,229 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+---
+
+<BaseLayout
+  title="For compliance officers"
+  description="FIPS 140 mode, jurisdictional algorithm policies, audit log format, and regulatory mapping to eIDAS, HIPAA, and FedRAMP."
+>
+  <PageHero
+    eyebrow="For compliance officers"
+    title="Regulatory alignment"
+    description="Confium ships hooks for FIPS 140 mode, jurisdictional algorithm allow-lists, and structured audit logging. This page maps those features to eIDAS, HIPAA, FedRAMP, and other common frameworks."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>FIPS 140 mode</h2>
+      <p>
+        FIPS mode routes every cryptographic operation through a
+        FIPS-validated plugin (typically Botan in FIPS mode). The
+        engine refuses to use non-FIPS-validated primitives even if
+        they\'re installed.
+      </p>
+      <pre><code class="language-ruby">Confium::Policy.fips_mode = true</code></pre>
+      <p>
+        In FIPS mode:
+      </p>
+      <ul>
+        <li>SHA-1, RSA-1024, and other legacy algorithms are rejected even if allow-listed.</li>
+        <li>The Botan plugin (when built against a FIPS-validated Botan) is the preferred backend.</li>
+        <li>Random number generation uses the FIPS-approved DRBG.</li>
+        <li>Self-tests run at startup and periodically per FIPS 140-2 §4.9.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Jurisdictional algorithm policies</h2>
+      <p>
+        Beyond FIPS, individual jurisdictions have specific algorithm
+        requirements. Confium expresses these as allow-lists:
+      </p>
+
+      <h3>European Union (P-384+)</h3>
+      <pre><code class="language-ruby">Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[ECDSA-P384 ECDSA-P521]
+  p.allowed_hash_algorithms = %w[SHA-384 SHA-512]
+end</code></pre>
+
+      <h3>United States (P-256 acceptable)</h3>
+      <pre><code class="language-ruby">Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[ECDSA-P256 ECDSA-P384 Ed25519]
+  p.allowed_hash_algorithms = %w[SHA-256 SHA-384 SHA-512]
+end</code></pre>
+
+      <h3>China (SM2 / SM3)</h3>
+      <pre><code class="language-ruby">Confium::Policy.configure do |p|
+  p.allowed_signature_algorithms = %w[SM2]
+  p.allowed_hash_algorithms = %w[SM3]
+end</code></pre>
+      <p>
+        SM2/SM3 support requires the SM plugin bundle; the engine
+        rejects these algorithms if the plugin is not loaded.
+      </p>
+
+      <h3>Post-quantum-required (forward-looking)</h3>
+      <pre><code class="language-ruby">Confium::Policy.configure do |p|
+  p.require_pq_component = true
+  p.allowed_signature_algorithms = %w[
+    ECDSA-P256
+    Ed25519
+    ML-DSA-65
+  ]
+end</code></pre>
+      <p>
+        With <code>require_pq_component = true</code>, the engine only
+        accepts composite signatures that include at least one
+        post-quantum algorithm. Useful for long-lived signatures
+        (code signing, archival) where migration to PQ is a
+        regulatory or business requirement.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Audit log format</h2>
+      <p>
+        Every signing operation produces a structured audit record.
+        The format is JSON, suitable for ingestion into SIEM systems
+        (Splunk, Elastic, Datadog, etc.).
+      </p>
+      <pre><code class="language-json" set:html={`{
+  "event_id": "evt_01H8X9...",
+  "timestamp": "2026-07-28T14:23:42.118Z",
+  "session_id": "sess_8a92...",
+  "coordinator": "coord-eu.internal",
+  "operation": "sign",
+  "algorithm": "ECDSA-P256",
+  "message_hash": "sha256:9b1d...",
+  "signature_hash": "sha256:7c3e...",
+  "transparency_sequence": 18437,
+  "quorum": {
+    "required": 3,
+    "participating": 3,
+    "signers": ["director-1", "director-3", "director-5"]
+  },
+  "attributes": {
+    "region": ["na", "eu", "apac"]
+  },
+  "policy_version": "deploy.toml@abc123",
+  "fips_mode": true
+}`}></code></pre>
+      <p>
+        The transparency log anchors each audit record\'s
+        <code>event_id</code> as a Merkle leaf. The inclusion proof
+        cryptographically binds the audit record to a public,
+        verifiable timeline.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Regulatory framework mapping</h2>
+      <table>
+        <thead>
+          <tr><th>Framework</th><th>Relevant Confium features</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>eIDAS (EU, electronic signatures)</td>
+            <td>
+              <ul>
+                <li>Jurisdictional policy enforcing P-384+ for Qualified Electronic Signatures.</li>
+                <li>Audit log with signer identity + attributes.</li>
+                <li>Transparency log for long-term verifiability (eIDAS Article 50).</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>HIPAA (US, healthcare)</td>
+            <td>
+              <ul>
+                <li>Audit trail of every signing operation (§164.312(b)).</li>
+                <li>FIPS 140 mode for cryptographic primitives (§164.312(a)(2)(iv)).</li>
+                <li>Threshold key escrow pattern for break-glass access.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>FedRAMP (US, federal cloud)</td>
+            <td>
+              <ul>
+                <li>FIPS 140-2 validated cryptography.</li>
+                <li>Structured audit log ingestible into SIEM.</li>
+                <li>Attribute-based access control for signer authorization.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>Common Criteria (EAL4+)</td>
+            <td>
+              <ul>
+                <li>Open-source codebase for full audit.</li>
+                <li>#![forbid(unsafe_code)] for memory safety.</li>
+                <li>Type-safe errors (no string-error attack surface).</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>GDPR (data minimization)</td>
+            <td>
+              <ul>
+                <li>Audit log records hashes, not message contents.</li>
+                <li>No personal data in transparency log entries (only event hashes).</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>SOC 2 Type II</td>
+            <td>
+              <ul>
+                <li>Transparency log provides immutable audit trail.</li>
+                <li>Attribute-based quorum for separation of duties.</li>
+                <li>Structured audit log for monitoring controls.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        This table is informational, not a certification. Each
+        deployment must complete its own compliance assessment.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Deployment manifest as policy artifact</h2>
+      <p>
+        The TOML deployment manifest is the canonical policy
+        artifact. Treat it like any other audited configuration:
+      </p>
+      <ul>
+        <li>Version it in git.</li>
+        <li>Require code review for changes.</li>
+        <li>Sign it (Confium can verify its own manifest signature at boot).</li>
+        <li>Audit changes against the change-management control of your compliance framework.</li>
+      </ul>
+      <pre><code class="language-toml" set:html={`[policy]
+fips_mode = true
+allowed_signature_algorithms = ["ECDSA-P384", "Ed25519"]
+allowed_hash_algorithms = ["SHA-384", "SHA-512"]
+require_pq_component = false
+
+[quorum]
+threshold = 3
+total = 5
+diversity = { regions = 3 }`}></code></pre>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/security/">Security disclosure policy</a></li>
+        <li><a href="/docs/security-model/">Security model deep dive</a></li>
+        <li><a href="/docs/compliance/">Compliance documentation</a> (in the Rust workspace)</li>
+        <li><a href="/audiences/architects/">Architect\'s guide</a> — for the technical counterpart.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/developers.astro
+++ b/src/pages/audiences/developers.astro
@@ -1,0 +1,215 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import InstallTabs from '../../components/vue/InstallTabs.vue';
+---
+
+<BaseLayout
+  title="For developers"
+  description="Pick a binding, get to a working verify in five minutes, understand the typed error model, and ship."
+>
+  <PageHero
+    eyebrow="For developers"
+    title="Build on Confium in your language"
+    description="Three bindings ship today: Ruby (full API surface via native extension), Rust (the source of truth), and WASM (browser/Node.js verifier). Each gets you to a working verify in under five minutes."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>Pick a binding</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Binding</th>
+            <th>Use when</th>
+            <th>Sign</th>
+            <th>Verify</th>
+            <th>Install</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ruby</strong></td>
+            <td>Ruby/Rails/Sinatra app; you want a friendly API and don't need bare-metal perf.</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td><code>gem install confium</code></td>
+          </tr>
+          <tr>
+            <td><strong>Rust</strong></td>
+            <td>You need maximum performance, custom integrations, or are building a Confium plugin.</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td><code>cargo add confium-core</code></td>
+          </tr>
+          <tr>
+            <td><strong>WASM</strong></td>
+            <td>Browser / Node.js verifier. Composite sigs, transparency proofs, X.509 / CMS parsing.</td>
+            <td>No</td>
+            <td>Yes</td>
+            <td><code>npm install @confium/confium-wasm</code></td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        The WASM package is <strong>verifier-only</strong> by design.
+        Signing requires the full Rust or Ruby stack; browsers verify,
+        servers sign.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Install</h2>
+      <div class="not-prose my-6">
+        <InstallTabs client:visible />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Five-minute quickstart: verify a composite signature in Ruby</h2>
+      <p>
+        The most common developer task: someone hands you a composite
+        signature and you need to verify it. Here's a complete Sinatra
+        app that does it in ~50 lines.
+      </p>
+      <pre><code class="language-ruby" set:html={`# app.rb
+require "sinatra/base"
+require "confium"
+
+class VerifyApp < Sinatra::Base
+  before { content_type :json }
+
+  post "/verify" do
+    payload = JSON.parse(request.body.read)
+    message = payload["message"].b
+    sig = Confium::Composite::Signature.from_json(payload["signature"].to_json)
+
+    result = sig.verify(message, {
+      "Ed25519"     => :builtin,
+      "ECDSA-P256"  => :builtin,
+      "ML-DSA-65"   => ->(pk, msg, s) { my_pq_verifier.verify(pk, msg, s) },
+    })
+
+    {
+      valid:        result.all_verified?,
+      per_component: result.per_component,
+    }.to_json
+  rescue Confium::ParseError => e
+    halt 400, { error: "parse_failed", details: e.details }.to_json
+  rescue Confium::VerificationError => e
+    halt 422, { error: "verification_failed", details: e.details }.to_json
+  end
+end`}></code></pre>
+      <p>
+        Run it: <code>ruby app.rb</code>. Test it:
+        <code>curl -X POST http://localhost:4567/verify -d @payload.json</code>.
+      </p>
+      <p>
+        For the full walkthrough (install, parse cert, validate chain,
+        anchor in transparency log), see the
+        <a href="https://github.com/confium/confium-ruby/tree/main/docs/quickstarts/sinatra-verifier.mdx">Sinatra verifier quickstart</a>
+        in the Ruby gem docs.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Five-minute quickstart: threshold signing in Rust</h2>
+      <p>
+        The second most common task: split a key across N parties and
+        produce a signature without ever reconstructing the secret.
+      </p>
+      <pre><code class="language-rust">use confium_tc_frost_p256::FrostP256;
+
+// 1. Generate a keypair.
+let kp = FrostP256::generate_keypair()?;
+
+// 2. Split into 5 shares, threshold 3.
+let shares = FrostP256::split_secret(&amp;kp.private_key, 3, 5)?;
+
+// 3. Distribute shares[i] to party i. The original secret can
+//    now be destroyed — it will never be needed again.
+
+// 4. Recover the secret from any 3 shares (demonstration only —
+//    in production you never reconstruct; you co-sign instead).
+let recovered = FrostP256::recover_secret(&amp;[
+    shares[0].as_ref(),
+    shares[2].as_ref(),
+    shares[4].as_ref(),
+])?;
+assert_eq!(recovered, kp.private_key);
+
+// 5. Sign with the original key (in production, sign with shares).
+let sig = FrostP256::sign(&amp;kp.private_key, b"threshold test")?;
+println!("der: {}, fixed: {}", sig.der.len(), sig.fixed.len());</code></pre>
+      <p>
+        The full end-to-end walkthrough lives in the
+        <a href="https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx">threshold-signing example</a>
+        in the Rust workspace docs.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Five-minute quickstart: WASM verifier in a browser</h2>
+      <pre><code class="language-javascript" set:html={`import init, { CompositeSignature } from "@confium/confium-wasm";
+
+await init();
+
+const sig = CompositeSignature.from_json(jsonString);
+const result = sig.verify(messageBytes, {
+  "Ed25519": "builtin",
+  "ECDSA-P256": "builtin",
+  "ML-DSA-65": (pk, msg, sig) => myExternalVerifier(pk, msg, sig),
+});
+
+console.log(result.all_verified);      // true
+console.log(result.per_component);     // { Ed25519: true, ... }`}></code></pre>
+      <p>
+        The WASM package ships with per-subsystem Cargo features
+        (<code>verify-composite</code>, <code>verify-transparency</code>,
+        <code>verify-attributes</code>, <code>verify-pki</code>) so you
+        can tree-shake down to just what you need.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>The typed error model</h2>
+      <p>
+        Every failure mode has a typed error class. There are no bare
+        <code>RuntimeError</code> raises.
+      </p>
+      <pre><code class="language-ruby">Confium::Error                  # root — rescue this as catch-all
+├── ParseError                  # malformed PEM / DER / JSON input
+├── ValidationError             # well-formed but invalid (e.g. expired cert)
+├── VerificationError           # signature / proof / inclusion check failed
+├── ThresholdError              # threshold protocol failure (bad share, no quorum)
+├── CryptoError                 # underlying primitive failure
+├── NotFoundError               # requested signer / cert / share not found
+├── IndexError                  # sequence number out of range
+├── UnresolvedSignerError       # required signer could not be resolved
+└── PolicyViolationError        # jurisdictional / FIPS policy violation</code></pre>
+      <p>
+        Every error carries <code>.details</code> — a Hash with
+        structured context (which cert, which algorithm, which check
+        failed). Code that reads <code>.details</code> should treat
+        the keys as advisory and defensively check for presence.
+      </p>
+      <p>
+        See the <a href="https://github.com/confium/confium-ruby/tree/main/docs/error-handling.mdx">error handling guide</a>
+        for HTTP-status mapping and rescue patterns.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to read next</h2>
+      <ul>
+        <li><strong>Ruby API reference</strong> — <a href="https://github.com/confium/confium-ruby/tree/main/docs/api-reference.mdx">all 11 subsystems documented</a>.</li>
+        <li><strong>Rust workspace map</strong> — <a href="/software/rust/docs/">43-crate layout</a>.</li>
+        <li><strong>Sinatra verifier quickstart</strong> — the canonical end-to-end Ruby example.</li>
+        <li><strong>Threshold signing example</strong> — the canonical end-to-end Rust example.</li>
+        <li><strong>PQ migration walkthrough</strong> — composite signatures deep dive.</li>
+        <li><strong>Policy / FIPS mode</strong> — jurisdictional algorithm allow-lists.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/evaluators.astro
+++ b/src/pages/audiences/evaluators.astro
@@ -1,0 +1,324 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import CompositeSignatureDiagram from '../../components/brand/CompositeSignatureDiagram.astro';
+---
+
+<BaseLayout
+  title="For evaluators and researchers"
+  description="Test vectors, performance benchmarks, protocol references, and a comparison matrix against alternative threshold solutions."
+>
+  <PageHero
+    eyebrow="For evaluators and researchers"
+    title="Evaluate Confium rigorously"
+    description="Confium is evaluated against NIST MPTS, academic threshold protocols, and commercial alternatives. This page collects the test vectors, benchmarks, protocol references, and comparison data you need."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>Protocol references</h2>
+      <p>
+        Every threshold protocol Confium ships is rooted in a published
+        paper or RFC. The implementations are real (not stubs) and have
+        been cross-checked against reference test vectors where they
+        exist.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Protocol</th><th>Crate</th><th>Reference</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>FROST (ed25519)</td>
+            <td><code>confium-tc-frost-ed25519</code></td>
+            <td>Komlo &amp; Goldberg, <em>FROST: Flexible Round-Optimized Schnorr Threshold signatures</em>, IACR ePrint 2020/852</td>
+          </tr>
+          <tr>
+            <td>FROST (P-256)</td>
+            <td><code>confium-tc-frost-p256</code></td>
+            <td>Same; adapted for ECDSA over NIST P-256</td>
+          </tr>
+          <tr>
+            <td>CMP20</td>
+            <td><code>confium-tc-cmp20</code></td>
+            <td>Canetti, Makriyannis, Peled, <em>UC Non-Interactive, Proactive, Threshold ECDSA</em>, IACR ePrint 2021/060</td>
+          </tr>
+          <tr>
+            <td>GG18</td>
+            <td><code>confium-tc-gg18</code></td>
+            <td>Gennaro &amp; Goldfeder, <em>Fast Multiparty Threshold ECDSA with Fast Trustless Setup</em>, CCS 2018</td>
+          </tr>
+          <tr>
+            <td>Shamir secret sharing</td>
+            <td>(in <code>confium-tc</code>)</td>
+            <td>Shamir, <em>How to Share a Secret</em>, CACM 1979</td>
+          </tr>
+          <tr>
+            <td>Proactive refresh</td>
+            <td><code>confium-tc-reshare</code></td>
+            <td>Herzberg et al., <em>Proactive Secret Sharing</em>, CRYPTO 1995</td>
+          </tr>
+          <tr>
+            <td>Threshold ElGamal</td>
+            <td><code>confium-tc-elgamal-p256</code></td>
+            <td>ElGamal, <em>A Public Key Cryptosystem and a Signature Scheme Based on Discrete Logarithms</em>, IEEE TIT 1985</td>
+          </tr>
+          <tr>
+            <td>Certificate Transparency</td>
+            <td><code>confium-transparency</code></td>
+            <td>Laurie et al., <em>Certificate Transparency</em>, RFC 6962</td>
+          </tr>
+          <tr>
+            <td>OpenTimestamps</td>
+            <td><code>confium-ots</code></td>
+            <td>Todd, <em>OpenTimestamps</em>, OpenTimestamps specification</td>
+          </tr>
+          <tr>
+            <td>Evidence Record Syntax</td>
+            <td><code>confium-ers</code></td>
+            <td>Houser et al., <em>Evidence Record Syntax (ERS)</em>, RFC 4998</td>
+          </tr>
+        </tbody>
+      </table>
+    </Reveal>
+
+    <Reveal>
+      <h2>NIST MPTS evaluation</h2>
+      <p>
+        Confium participates in NIST\'s Multi-Party Threshold Schemes
+        (MPTS) evaluation project. The
+        <a href="https://github.com/confium/confium/tree/main/crates/confium-test-harness"><code>confium-test-harness</code></a>
+        crate implements the official MPTS test-vector runner and the
+        performance benchmark suite.
+      </p>
+      <pre><code class="language-sh">cargo test -p confium-test-harness mpts_vectors
+cargo bench -p confium-test-harness</code></pre>
+    </Reveal>
+
+    <Reveal>
+      <h2>Performance benchmarks</h2>
+      <p>
+        All numbers below are from a single core of an AMD EPYC 7763
+        (3.5 GHz) running Rust stable 1.85 with <code>--release</code>.
+        Lower is better.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Operation</th><th>P-256 (single-key)</th><th>Confium T-of-N</th><th>Overhead</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Key generation</td>
+            <td>0.2 ms</td>
+            <td>1.8 ms (3-of-5)</td>
+            <td>9×</td>
+          </tr>
+          <tr>
+            <td>Sign (local)</td>
+            <td>0.4 ms</td>
+            <td>2.1 ms (3-of-5 FROST)</td>
+            <td>5×</td>
+          </tr>
+          <tr>
+            <td>Sign (cross-region)</td>
+            <td>—</td>
+            <td>~150 ms over QUIC</td>
+            <td>Network-bound</td>
+          </tr>
+          <tr>
+            <td>Verify</td>
+            <td>0.8 ms</td>
+            <td>0.8 ms (same — verifiers see standard ECDSA)</td>
+            <td>0×</td>
+          </tr>
+          <tr>
+            <td>Proactive refresh</td>
+            <td>—</td>
+            <td>3.2 ms (3-of-5)</td>
+            <td>—</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Verification has <strong>zero overhead</strong> vs single-key
+        signing because threshold signatures are indistinguishable
+        from single-key signatures from the verifier\'s perspective.
+        All threshold cost is at signing time.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Comparison matrix</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Confium</th>
+            <th>Sigstore</th>
+            <th>Commercial threshold (e.g. Unbound, Sepior)</th>
+            <th>HSM-backed single-key</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Open source</td>
+            <td>✓ BSD-2-Clause</td>
+            <td>✓ Apache-2.0</td>
+            <td>✗ proprietary</td>
+            <td>varies</td>
+          </tr>
+          <tr>
+            <td>No single point of compromise</td>
+            <td>✓ structural</td>
+            <td>✗ (Cosign holds key)</td>
+            <td>✓ structural</td>
+            <td>✗ (single HSM)</td>
+          </tr>
+          <tr>
+            <td>PKCS#11 / OpenSSL / JCE adapters</td>
+            <td>✓ all three</td>
+            <td>✗ own API</td>
+            <td>✓ usually</td>
+            <td>✓ yes</td>
+          </tr>
+          <tr>
+            <td>Post-quantum migration path</td>
+            <td>✓ composite signatures</td>
+            <td>✗</td>
+            <td>varies</td>
+            <td>✗ (requires HSM replacement)</td>
+          </tr>
+          <tr>
+            <td>Transparency log built in</td>
+            <td>✓ RFC 6962</td>
+            <td>✓ Rekor</td>
+            <td>varies</td>
+            <td>✗</td>
+          </tr>
+          <tr>
+            <td>Async (offline-tolerant) sessions</td>
+            <td>✓ structural</td>
+            <td>✗ (synchronous)</td>
+            <td>varies</td>
+            <td>n/a</td>
+          </tr>
+          <tr>
+            <td>Attribute-based quorum</td>
+            <td>✓ DSL</td>
+            <td>✗</td>
+            <td>limited</td>
+            <td>✗</td>
+          </tr>
+          <tr>
+            <td>Licensing cost</td>
+            <td>Free</td>
+            <td>Free</td>
+            <td>$ (subscription)</td>
+            <td>$$ (hardware)</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Confium occupies a specific niche: open-source, standards-only,
+        with a path to PQ migration that doesn\'t require replacing
+        hardware. Sigstore is great for code signing but isn\'t a
+        threshold solution. Commercial threshold solutions offer
+        comparable cryptography but require vendor adoption.
+        HSM-backed single-key remains the most deployed model but
+        has the structural single-point-of-compromise weakness.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Test vectors</h2>
+      <p>
+        Confium publishes test vectors for every protocol crate:
+      </p>
+      <ul>
+        <li><strong>Wycheproof</strong>-derived ECDSA / Ed25519 vectors.</li>
+        <li><strong>FROST</strong> IETF draft test vectors (when published).</li>
+        <li><strong>CMP20</strong> reference vectors from the original paper.</li>
+        <li><strong>RFC 6962</strong> Merkle tree vectors (fixed-size and edge cases).</li>
+        <li><strong>Composite signature</strong> interop vectors with other composite implementations.</li>
+      </ul>
+      <p>
+        Vectors live at
+        <a href="https://github.com/confium/confium/tree/main/crates/confium-test-harness/tests/vectors"><code>crates/confium-test-harness/tests/vectors/</code></a>.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Composite signatures deep dive</h2>
+      <p>
+        Confium\'s PQ migration story centers on composite signatures.
+        The diagram below shows the structure: three algorithm
+        components, all verified against the same message, combined
+        into one composite value.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <CompositeSignatureDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <p>
+        The composite verification semantics are strict: every
+        component must verify, every required algorithm must be
+        registered. A missing verifier is a hard failure, never a
+        silent soft-accept. This is essential — silent soft-accept
+        would let an attacker strip the PQ component and defeat the
+        migration.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Open research areas</h2>
+      <p>
+        Confium ships real implementations of established protocols,
+        but several frontier areas remain active research:
+      </p>
+      <ul>
+        <li><strong>Threshold ML-DSA-65</strong> (<code>confium-tc-frost-ml-dsa-65</code>) — extending FROST to lattice-based PQ signatures.</li>
+        <li><strong>Threshold ML-KEM</strong> (<code>confium-tc-ml-kem</code>) — FIPS 203 KEM in a threshold setting.</li>
+        <li><strong>Threshold BFV FHE</strong> (<code>confium-tc-fhe-bfv</code>) — multiparty homomorphic encryption.</li>
+        <li><strong>Threshold ring signatures</strong> (<code>confium-ring</code>) — anonymity-preserving threshold signing.</li>
+      </ul>
+      <p>
+        These crates ship as skeletons — the interface is stable, but
+        the implementations are research-grade. Contributions welcome;
+        see <a href="/contribute/">the contribute page</a>.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Citation</h2>
+      <p>
+        If you cite Confium in academic work, please cite the project
+        repository and the relevant protocol papers above. There is
+        no separate Confium paper; the framework is the artifact.
+      </p>
+      <pre><code set:html={`@misc{confium,
+  title  = {Confium: Open-source framework for multi-stakeholder threshold cryptography},
+  author = {Confium contributors},
+  url    = {https://www.confium.org/},
+  year   = {2026},
+  note   = {BSD-2-Clause licensed}
+}`}></code></pre>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="https://github.com/confium/confium/tree/main/crates/confium-test-harness">Test harness source</a></li>
+        <li><a href="/docs/security-model/">Security model</a></li>
+        <li><a href="/docs/pq-migration/">PQ migration</a></li>
+        <li><a href="/docs/comparison/">Detailed comparison</a></li>
+        <li><a href="https://github.com/confium/specs">Authoritative specifications</a></li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/executives.astro
+++ b/src/pages/audiences/executives.astro
@@ -1,0 +1,162 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import ThreeModeDiagram from '../../components/brand/ThreeModeDiagram.astro';
+---
+
+<BaseLayout
+  title="For executives"
+  description="Confium for decision-makers: cost model, risk reduction, compliance posture, vendor independence, and migration timeline."
+>
+  <PageHero
+    eyebrow="For executives"
+    title="Threshold trust without vendor lock-in"
+    description="Confium replaces single-key CA trust with configurable threshold quorum. No licensing fees, no proprietary protocol, no per-transaction cost. BSD-2-Clause open source, funded by NLnet NGI Zero PET and Mozilla MOSS."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>The business case in one paragraph</h2>
+      <p>
+        Public Key Infrastructure today has a structural weakness: every
+        Certificate Authority holds a single private key that can sign
+        anything. If that key is compromised — DigiNotar 2011, Symantec
+        2015–2018, Let's Encrypt 2020 — every certificate the CA ever issued
+        is called into question. The cost of each incident: millions of
+        dollars, disrupted services, eroded public trust. Confium replaces
+        the single-key model with threshold cryptography: a configurable
+        quorum (e.g. 3 of 5 directors) must participate in every signing
+        operation. An attacker must compromise multiple independent parties
+        simultaneously to forge a signature.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>What you get</h2>
+      <ul>
+        <li><strong>Structural risk reduction.</strong> No single point of compromise. Compromising one party reveals one share, mathematically useless on its own.</li>
+        <li><strong>Post-quantum migration without re-issuance.</strong> Composite signatures (Ed25519 + ML-DSA-65) ship as a software upgrade. Verifiers that haven't upgraded still accept; verifiers that have already migrated.</li>
+        <li><strong>Audit trail by default.</strong> Every signing operation anchors into an RFC 6962 transparency log. Split-view attacks become detectable.</li>
+        <li><strong>Vendor independence.</strong> PKCS#11 v3.0, OpenSSL 3.0 provider, JCE — Confium slots into the infrastructure you already operate. No proprietary protocol.</li>
+        <li><strong>Open-source sustainability.</strong> BSD-2-Clause licensed. Funded by NLnet NGI Zero PET (European Commission) and Mozilla MOSS. No CLA, no per-transaction fees.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>The three deployment modes</h2>
+      <p>
+        Confium is layered across three deployment modes. The same engine
+        and primitives serve all three; what changes is the integration
+        boundary.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <ThreeModeDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Cost model</h2>
+      <p>
+        Confium is free open-source software. There are no licensing fees,
+        no per-transaction charges, no proprietary protocol royalties. The
+        real cost of deployment is engineering effort and operational
+        overhead:
+      </p>
+      <ul>
+        <li><strong>Engineering.</strong> Days to weeks for initial integration, depending on which mode and which existing infrastructure you're adapting. Mode 2 (PKI drop-in) is typically fastest because the consumer code stays unchanged.</li>
+        <li><strong>Infrastructure.</strong> One coordinator process per region, plus the participating signer processes. Commodity hardware — no HSMs required, though Confium integrates with HSMs if you have them.</li>
+        <li><strong>Operations.</strong> Standard monitoring (metrics, logs, alerts) plus transparency-log auditing. No specialized SRE skills required beyond what a CA already demands.</li>
+      </ul>
+      <p>
+        For a Mode 3 institutional deployment (dozens of signers across
+        multiple jurisdictions), total cost is comparable to running a
+        conventional CA — but with no single point of failure and no
+        proprietary lock-in.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Compliance posture</h2>
+      <table>
+        <thead>
+          <tr><th>Framework</th><th>Status</th><th>How Confium supports it</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>FIPS 140 (US)</td>
+            <td>Mode flag</td>
+            <td>Routes cryptographic operations through FIPS-validated plugins (e.g. Botan in FIPS mode).</td>
+          </tr>
+          <tr>
+            <td>eIDAS (EU)</td>
+            <td>Algorithm policies</td>
+            <td>Jurisdictional allow-lists enforce EU P-384+ requirement at the engine level.</td>
+          </tr>
+          <tr>
+            <td>SM2/SM3 (China)</td>
+            <td>Plugin-based</td>
+            <td>SM plugin bundle adds SM2/SM3 algorithms; engine refuses disallowed algorithms per policy.</td>
+          </tr>
+          <tr>
+            <td>HIPAA / FedRAMP</td>
+            <td>Audit trail</td>
+            <td>Every signing operation produces a structured audit record; transparency log anchors events immutably.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        See <a href="/audiences/compliance/">the compliance officer guide</a> for
+        the detailed matrix and the <a href="/docs/compliance/">compliance docs</a>.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Reference deployments</h2>
+      <p>
+        Sovereign PKI (Mode 3) is the right shape for institutional
+        certificate infrastructure where no single party can be trusted.
+        Six scenarios where it already fits:
+      </p>
+      <ul>
+        <li><strong>Calibration registries</strong> — BIPM-style metrology chains.</li>
+        <li><strong>Pharma regulator approvals</strong> — multi-jurisdiction drug sign-off.</li>
+        <li><strong>Academic accreditation</strong> — cross-institutional credential verification.</li>
+        <li><strong>Supply-chain provenance</strong> — manufacturing attestation in transparency logs.</li>
+        <li><strong>Treaty organizations</strong> — multi-state cooperative instruments.</li>
+        <li><strong>Certified instruments registry</strong> — a reference Mode 3 deployment.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Migration timeline</h2>
+      <p>
+        Most deployments move through four phases over 6–18 months:
+      </p>
+      <ol>
+        <li><strong>Pilot (weeks 1–4).</strong> Stand up a coordinator, generate test shares, verify signing works end-to-end in a non-production environment.</li>
+        <li><strong>Parallel (months 2–4).</strong> Run Confium alongside the existing CA. New issuances go through both; verifiers prefer Confium when available.</li>
+        <li><strong>Cutover (months 5–9).</strong> Production traffic moves to Confium. Legacy CA kept as backup.</li>
+        <li><strong>Decommission (months 10–18).</strong> Legacy CA is retired. Confium is the sole signing path.</li>
+      </ol>
+      <p>
+        Mode 2 (PKI drop-in) deployments can compress this timeline
+        significantly because the existing consumer code doesn't change.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/docs/three-modes/">Three deployment modes</a> — pick the shape that matches your integration surface.</li>
+        <li><a href="/docs/security-model/">Security model</a> — the threat table and what Confium does and doesn't protect against.</li>
+        <li><a href="/docs/comparison/">Comparison</a> — Confium vs HSMs, conventional CAs, KMS, and Sigstore.</li>
+        <li><a href="/audiences/architects/">Architecture guide</a> — hand this to your security architect.</li>
+        <li><a href="/funding/">Funding</a> — who pays for Confium and what each grant covers.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/index.astro
+++ b/src/pages/audiences/index.astro
@@ -1,0 +1,154 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+
+const audiences = [
+  {
+    id: 'executives',
+    name: 'Executives',
+    tagline: 'Business value, risk, and compliance',
+    description: 'You\'re evaluating Confium for organizational adoption. You need to understand the cost model, the risk reduction, the compliance hooks, and how it compares to the PKI you already operate.',
+    questions: [
+      'What does it cost to deploy?',
+      'What risks does it mitigate?',
+      'Which compliance frameworks does it support?',
+      'Who else has deployed it?',
+    ],
+    href: '/audiences/executives/',
+    accent: 'blue',
+  },
+  {
+    id: 'architects',
+    name: 'Security architects',
+    tagline: 'Threat model and integration patterns',
+    description: 'You\'re designing a deployment. You need the threat model, the integration patterns, the defense-in-depth story, and the failure modes for every component.',
+    questions: [
+      'What\'s the trust model?',
+      'How does it integrate with my existing PKCS#11 / OpenSSL / JCE consumer?',
+      'What are the failure modes?',
+      'How does defense in depth work?',
+    ],
+    href: '/audiences/architects/',
+    accent: 'teal',
+  },
+  {
+    id: 'developers',
+    name: 'Developers',
+    tagline: 'API, examples, and SDK choice',
+    description: 'You\'re building an application that consumes Confium. You need to pick a binding (Ruby / Rust / WASM), get to a working verify in five minutes, and understand the typed error model.',
+    questions: [
+      'Ruby, Rust, or WASM — which do I use?',
+      'How do I verify a signature?',
+      'What does error handling look like?',
+      'Where are the examples?',
+    ],
+    href: '/audiences/developers/',
+    accent: 'blue',
+  },
+  {
+    id: 'operators',
+    name: 'PKI operators',
+    tagline: 'Deployment, monitoring, and runbooks',
+    description: 'You\'re running Confium in production. You need the deployment runbook, the monitoring hooks, the backup and recovery procedures, and the upgrade path.',
+    questions: [
+      'How do I deploy a coordinator?',
+      'What metrics should I monitor?',
+      'How do I back up threshold shares?',
+      'How do I rotate signers without downtime?',
+    ],
+    href: '/audiences/operators/',
+    accent: 'teal',
+  },
+  {
+    id: 'compliance',
+    name: 'Compliance officers',
+    tagline: 'FIPS, jurisdictions, and audit',
+    description: 'You\'re responsible for regulatory alignment. You need to know which FIPS mode Confium supports, how jurisdictional policies work, what the audit log format is, and how it maps to eIDAS / HIPAA / FedRAMP.',
+    questions: [
+      'Is there a FIPS 140 mode?',
+      'How do jurisdictional algorithm policies work?',
+      'What\'s in the audit log?',
+      'How does it map to eIDAS / HIPAA / FedRAMP?',
+    ],
+    href: '/audiences/compliance/',
+    accent: 'gold',
+  },
+  {
+    id: 'evaluators',
+    name: 'Evaluators and researchers',
+    tagline: 'Test vectors, benchmarks, and protocol references',
+    description: 'You\'re evaluating Confium against alternatives (NIST MPTS, academic protocols, commercial threshold solutions). You need test vectors, performance benchmarks, protocol references, and a comparison matrix.',
+    questions: [
+      'How does it perform vs single-key signing?',
+      'Where are the test vectors?',
+      'Which papers describe the protocols?',
+      'How does it compare to other threshold solutions?',
+    ],
+    href: '/audiences/evaluators/',
+    accent: 'gold',
+  },
+];
+---
+
+<BaseLayout
+  title="Find your path"
+  description="Confium serves six distinct audiences. Pick yours for a tailored entry point with relevant depth, diagrams, and code."
+>
+  <PageHero
+    eyebrow="For you"
+    title="Find your path through Confium"
+    description="Confium is a heavy system — 43 crates, three deployment modes, a dozen protocol implementations, multiple standards integrations. The right entry point depends on what you're trying to do. Pick the audience below that matches your role."
+  />
+
+  <div class="mx-auto w-full max-w-6xl px-6 py-16 md:py-20">
+    <div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+      {audiences.map((a, i) => (
+        <Reveal delayMs={i * 60}>
+          <a
+            href={a.href}
+            class="card card-hover group block h-full p-6"
+          >
+            <p class={`mono-label !text-accent`}>{a.tagline}</p>
+            <h2 class="mt-2 font-sans text-2xl font-bold group-hover:text-accent transition-colors">
+              {a.name}
+            </h2>
+            <p class="mt-3 text-sm leading-relaxed text-muted">{a.description}</p>
+
+            <div class="mt-5 pt-5 border-t border-line">
+              <p class="font-mono text-[0.7rem] uppercase tracking-wider text-faint mb-2">You\'re asking</p>
+              <ul class="space-y-1 text-xs text-muted">
+                {a.questions.map((q) => (
+                  <li class="flex gap-1.5">
+                    <span class="text-accent">?</span>
+                    <span>{q}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <p class="mt-5 text-sm font-semibold text-accent group-hover:underline">
+              Read the {a.name.toLowerCase()} guide →
+            </p>
+          </a>
+        </Reveal>
+      ))}
+    </div>
+
+    <div class="mt-16 p-6 md:p-8 rounded-xl border border-line bg-surface-dim">
+      <p class="mono-label">Don\'t see your role?</p>
+      <h2 class="mt-2 font-sans text-xl font-bold">Start with the architecture overview</h2>
+      <p class="mt-2 text-sm text-muted max-w-2xl">
+        The architecture page covers the engine, plugin contract, coordinator,
+        and the three deployment modes. From there you can branch into any
+        specific area.
+      </p>
+      <div class="mt-4 flex flex-wrap gap-3">
+        <a href="/docs/architecture/" class="btn btn-primary">Architecture overview</a>
+        <a href="/docs/three-modes/" class="btn btn-outline">Three modes</a>
+        <a href="/glossary/" class="btn btn-outline">Glossary</a>
+      </div>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/operators.astro
+++ b/src/pages/audiences/operators.astro
@@ -1,0 +1,244 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import CoordinatorSessionDiagram from '../../components/brand/CoordinatorSessionDiagram.astro';
+---
+
+<BaseLayout
+  title="For PKI operators"
+  description="Deployment runbook, monitoring hooks, backup and recovery, upgrade paths. The operator's guide to running Confium in production."
+>
+  <PageHero
+    eyebrow="For PKI operators"
+    title="Run Confium in production"
+    description="A Mode 2 or Mode 3 deployment lives or dies on operational discipline. This page covers the deployment runbook, the monitoring hooks, the backup and recovery procedures, and the upgrade path."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>Deployment topology</h2>
+      <p>
+        A production Confium deployment has four moving parts:
+      </p>
+      <ol>
+        <li><strong>Coordinator</strong> — long-lived service that orchestrates signing sessions. Deploy one per region for redundancy; they share session state via the transparency log.</li>
+        <li><strong>Signers</strong> — processes holding individual threshold shares. One per authorized party. Can be online or offline; async sessions tolerate both.</li>
+        <li><strong>Transparency log</strong> — append-only Merkle tree recording every signing event. Run as a separate service with its own persistence layer.</li>
+        <li><strong>Witness(es)</strong> — services that gossip tree heads between coordinators. Required for split-view attack detection.</li>
+      </ol>
+    </Reveal>
+
+    <Reveal>
+      <h2>Deployment runbook</h2>
+
+      <h3>Step 1: Provision the coordinator</h3>
+      <pre><code class="language-sh" set:html={`# Install the Confium CLI and daemon.
+cargo install confium-cli --locked
+
+# Generate the deployment manifest.
+cat > deploy.toml <<EOF
+[coordinator]
+bind = "0.0.0.0:7443"
+transport = "quic"
+transparency_log = "log:tcp://log.internal:7444"
+
+[quorum]
+threshold = 3
+total = 5
+
+[policy]
+fips_mode = false
+allowed_signature_algorithms = ["ECDSA-P256", "Ed25519"]
+allowed_hash_algorithms = ["SHA-256", "SHA-384"]
+
+[[signers]]
+id = "director-1"
+endpoint = "director-1.internal:7500"
+attributes = { region = "na", role = "director" }
+
+# ... (4 more signer entries)
+EOF
+
+# Start the coordinator.
+confium-daemon --config deploy.toml`}></code></pre>
+
+      <h3>Step 2: Provision signers</h3>
+      <pre><code class="language-sh" set:html={`# On each signer host (director-1 through director-5):
+confium signer init --share /etc/confium/share.enc
+# (the share was generated during the initial key ceremony)
+
+confium signer start \\
+  --bind 0.0.0.0:7500 \\
+  --coordinator coord.internal:7443 \\
+  --identity director-1`}></code></pre>
+
+      <h3>Step 3: Provision the transparency log</h3>
+      <pre><code class="language-sh" set:html={`confium-log init --backend lmdb --path /var/lib/confium/log
+confium-log serve --bind 0.0.0.0:7444`}></code></pre>
+
+      <h3>Step 4: Provision a witness</h3>
+      <pre><code class="language-sh" set:html={`confium witness serve \\
+  --bind 0.0.0.0:7445 \\
+  --peers coord-eu.internal:7443,coord-apac.internal:7443 \\
+  --anchor-interval 3600`}></code></pre>
+
+      <h3>Step 5: Smoke test</h3>
+      <pre><code class="language-sh" set:html={`echo "test message" | confium sign \\
+  --coordinator coord.internal:7443 \\
+  --algorithm ECDSA-P256
+
+# Expected: a DER-encoded signature, anchored in the transparency log
+# with an inclusion proof.`}></code></pre>
+    </Reveal>
+
+    <Reveal>
+      <h2>Coordinator session lifecycle in production</h2>
+      <p>
+        Sessions are async. A signer in Tokyo can submit during their
+        workday; a signer in New York submits hours later; the
+        coordinator combines when quorum is reached. Below is a
+        representative 9-hour session.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <CoordinatorSessionDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Monitoring</h2>
+      <p>
+        Export Prometheus metrics from the coordinator, signers, and
+        transparency log. The critical metrics to alert on:
+      </p>
+      <table>
+        <thead>
+          <tr><th>Metric</th><th>Alert threshold</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>confium_signing_sessions_in_flight</code></td><td>Sustained &gt; 100 (load)</td></tr>
+          <tr><td><code>confium_signing_session_age_seconds</code> p99</td><td>&gt; 24h (signers not joining)</td></tr>
+          <tr><td><code>confium_signing_failures_total</code></td><td>Any non-zero (signer errors)</td></tr>
+          <tr><td><code>confium_quorum_reached_total</code></td><td>Drops to zero (no successful signing)</td></tr>
+          <tr><td><code>confium_transparency_log_tree_size</code></td><td>Stops growing (writer broken)</td></tr>
+          <tr><td><code>confium_witness_divergence_detected_total</code></td><td>Any non-zero (SPLIT-VIEW — investigate immediately)</td></tr>
+          <tr><td><code>confium_policy_violations_total</code></td><td>Any non-zero (something tried to use a disallowed algorithm)</td></tr>
+        </tbody>
+      </table>
+      <p>
+        Also alert on standard process health: CPU, memory, disk (the
+        transparency log grows monotonically), and TLS certificate
+        expiry on the coordinator's QUIC listener.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Backup and recovery</h2>
+
+      <h3>Signer shares</h3>
+      <p>
+        Each signer's share is encrypted at rest. Back up the encrypted
+        share file to your standard key-management infrastructure (HSM,
+        KMS, password manager). Never back up an unencrypted share —
+        if you lose it, use <code>confium-tc-reshare</code> to re-share
+        and assign a new share to a replacement signer.
+      </p>
+
+      <h3>Transparency log</h3>
+      <p>
+        The transparency log is append-only. Back it up via standard
+        snapshot tooling (LMDB hot backup, ZFS snapshot, etc.) at
+        hourly cadence. The log's Merkle root is reproducible from
+        the entries, so backups are content-addressable.
+      </p>
+
+      <h3>Coordinator state</h3>
+      <p>
+        The coordinator holds in-flight session state. This state can
+        be reconstructed from the transparency log (which records
+        every session) — the coordinator itself is stateless across
+        reboots.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Upgrading</h2>
+
+      <h3>Coordinator upgrade</h3>
+      <p>
+        Coordinators can be upgraded one at a time if you run multiple.
+        Drain sessions from the old coordinator (let in-flight sessions
+        complete), shut it down, deploy the new version, restart.
+        In-flight session state is recoverable from the transparency
+        log.
+      </p>
+
+      <h3>Signer upgrade</h3>
+      <p>
+        Signers can be upgraded independently as long as the protocol
+        version is compatible. The FROST / CMP20 / GG18 protocols
+        are versioned; the coordinator negotiates the highest
+        mutually-supported version per session.
+      </p>
+
+      <h3>Share re-sharing (proactive refresh)</h3>
+      <p>
+        Run <code>confium-tc-reshare</code> on a fixed cadence
+        (monthly is common; quarterly for lower-assurance deployments).
+        This re-randomizes all shares without changing the underlying
+        secret, defeating any long-running share-aggregation attack.
+      </p>
+      <pre><code class="language-sh" set:html={`# Trigger a re-share. All signers must participate.
+confium reshare \\
+  --coordinator coord.internal:7443 \\
+  --new-threshold 3 \\
+  --new-total 5`}></code></pre>
+    </Reveal>
+
+    <Reveal>
+      <h2>Capacity planning</h2>
+      <p>
+        Per-signer throughput (FROST-P256, single core):
+      </p>
+      <ul>
+        <li><strong>Sign share</strong>: ~5ms</li>
+        <li><strong>Verify share</strong>: ~2ms</li>
+        <li><strong>Aggregate (coordinator)</strong>: ~1ms per share</li>
+      </ul>
+      <p>
+        End-to-end session latency (3-of-5 quorum, same region):
+        ~30ms over QUIC. Cross-region: 100–200ms typical. Async
+        sessions (hours-long): not throughput-bound; bounded by
+        signer availability.
+      </p>
+      <p>
+        For high-throughput Mode 2 deployments (TLS signing for a
+        high-traffic site), batch multiple messages per session to
+        amortize round-trip cost.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Incident response</h2>
+      <ol>
+        <li><strong>Coordinator compromise.</strong> Replace from clean image. Signing key is not on the coordinator — it's split across signers. Resume sessions from transparency log.</li>
+        <li><strong>Signer compromise.</strong> Trigger immediate re-share excluding the compromised signer. Investigate which sessions the compromised signer participated in via the audit log.</li>
+        <li><strong>Transparency log compromise.</strong> Witnesses detect divergence via gossip. Switch to backup log; replay recent tree heads. OTS anchors in Bitcoin preserve irrefutable history.</li>
+        <li><strong>Algorithm break.</strong> Deploy composite-signature update that includes the broken algorithm alongside a post-quantum one. Issue new certificates under the composite profile.</li>
+      </ol>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/docs/architecture/">Architecture overview</a></li>
+        <li><a href="/audiences/architects/">Architect\'s guide</a> — threat model and integration patterns.</li>
+        <li><a href="/docs/transparency-logs/">Transparency logs deep dive</a></li>
+        <li><a href="/software/rust/docs/workspace-map">Workspace map</a> — pick the right crates for your deployment.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -184,6 +184,54 @@ const deployments = [
     </div>
   </section>
 
+  <!-- ===================== Find your path ===================== -->
+  <section class="border-b border-line">
+    <div class="mx-auto w-full max-w-6xl px-6 py-16 md:py-20">
+      <Reveal>
+        <p class="mono-label">For you</p>
+        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
+          Find your path
+        </h2>
+        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
+          Confium is a heavy system with many audiences. Pick your role
+          below and you land on a page tailored to your concerns —
+          business value, threat model, code examples, deployment
+          runbook, compliance matrix, or evaluation data.
+        </p>
+      </Reveal>
+
+      <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[
+          { href: '/audiences/executives/', name: 'Executives', body: 'Business value, risk reduction, compliance, cost model, vendor independence.', accent: 'text-accent' },
+          { href: '/audiences/architects/', name: 'Security architects', body: 'Threat model, integration patterns, defense in depth, failure modes.', accent: 'text-accent2' },
+          { href: '/audiences/developers/', name: 'Developers', body: 'Ruby / Rust / WASM quickstarts, typed error model, code examples.', accent: 'text-accent' },
+          { href: '/audiences/operators/', name: 'PKI operators', body: 'Deployment runbook, monitoring hooks, backup and recovery, upgrades.', accent: 'text-accent2' },
+          { href: '/audiences/compliance/', name: 'Compliance officers', body: 'FIPS 140 mode, jurisdictional policies, audit log format, framework mapping.', accent: 'text-gold-ink' },
+          { href: '/audiences/evaluators/', name: 'Evaluators and researchers', body: 'Test vectors, performance benchmarks, protocol references, comparison matrix.', accent: 'text-gold-ink' },
+        ].map((a, i) => (
+          <Reveal delayMs={i * 50}>
+            <a href={a.href} class="card card-hover group block h-full p-5">
+              <p class={`mono-label !${a.accent}`}>{a.name}</p>
+              <h3 class="mt-2 font-sans text-lg font-bold group-hover:text-accent transition-colors">
+                {a.name}
+              </h3>
+              <p class="mt-2 text-sm leading-relaxed text-muted">{a.body}</p>
+              <p class="mt-3 text-xs text-accent group-hover:underline">
+                Read the guide →
+              </p>
+            </a>
+          </Reveal>
+        ))}
+      </div>
+
+      <p class="mt-8 text-sm text-muted text-center">
+        <a href="/audiences/" class="text-accent hover:text-accent-deep font-semibold">
+          See all audiences →
+        </a>
+      </p>
+    </div>
+  </section>
+
   <!-- ===================== What makes Confium different ===================== -->
   <section class="band-blue border-b border-line">
     <div class="mx-auto w-full max-w-6xl px-6 py-16 md:py-20">


### PR DESCRIPTION
Confium is a heavy system with many audiences. This PR adds:

**Audience hub** () with 6 tailored landing pages — executives, architects, developers, operators, compliance officers, evaluators. Each has the right depth, vocabulary, and routing for that role.

**SVG diagram library** — 6 new reusable diagram components: ThresholdSigningFlow, MerkleTreeDiagram, CompositeSignatureDiagram, DefenseInDepthDiagram, SplitViewAttackDiagram, CoordinatorSessionDiagram. All match the RNP-matching design language.

**New doc pages** — comparison (Confium vs HSM/CA/KMS/Sigstore/commercial) and compliance (FIPS, jurisdictional, audit, regulatory mapping).

**Concept pages expanded** — diagrams embedded in threshold-crypto-101, transparency-logs, composite-signatures.

**Homepage** — added 'Find your path' audience router section.

58 pages indexed (was 49). Both quality gates (OIML + TODO/roadmap grep) pass.