### PR TITLE
feat(content): 10 new use cases + 3 audiences + 4 diagrams + FAQ

### DIFF
--- a/src/components/brand/AdapterPatternDiagram.astro
+++ b/src/components/brand/AdapterPatternDiagram.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Adapter pattern — how Mode 2 adapters wrap PKCS#11 / OpenSSL / JCE
+ * consumers without changing their code.
+ */
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="adapter-title" set:html={`
+  <title id="adapter-title">Mode 2 adapter pattern: existing PKCS#11 / OpenSSL / JCE consumers connect unchanged to a threshold backend.</title>
+
+  <!-- Existing consumer (unchanged) -->
+  <rect x="40" y="40" width="160" height="80" rx="10" fill="white" stroke="#1a7bec" stroke-width="2"/>
+  <text x="120" y="62" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#1a7bec" letter-spacing="2">EXISTING CONSUMER</text>
+  <text x="120" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="600" fill="#23273a">nginx · Apache</text>
+  <text x="120" y="96" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="600" fill="#23273a">Java · Node · Go</text>
+  <text x="120" y="110" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">unchanged code</text>
+
+  <!-- Standard API bubble -->
+  <rect x="220" y="65" width="80" height="30" rx="6" fill="#e6f0fe"/>
+  <text x="260" y="78" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec">C_Sign()</text>
+  <text x="260" y="89" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#1a7bec">EVP_PKEY</text>
+
+  <line x1="200" y1="80" x2="220" y2="80" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- Adapter -->
+  <rect x="320" y="40" width="120" height="80" rx="10" fill="#dcf8f0" stroke="#00c2c9" stroke-width="2"/>
+  <text x="380" y="62" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#009e80" letter-spacing="2">ADAPTER</text>
+  <text x="380" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" font-weight="600" fill="#23273a">PKCS#11 server</text>
+  <text x="380" y="96" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" font-weight="600" fill="#23273a">OpenSSL provider</text>
+  <text x="380" y="110" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" font-weight="600" fill="#23273a">JCE provider</text>
+
+  <line x1="300" y1="80" x2="320" y2="80" stroke="#00c2c9" stroke-width="2"/>
+
+  <!-- Coordinator -->
+  <rect x="160" y="160" width="160" height="60" rx="10" fill="url(#ap-grad)"/>
+  <defs>
+    <linearGradient id="ap-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+  </defs>
+  <text x="240" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white" letter-spacing="2">COORDINATOR</text>
+  <text x="240" y="200" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">threshold session</text>
+  <text x="240" y="212" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">async · multi-region</text>
+
+  <line x1="380" y1="120" x2="280" y2="160" stroke="#009e80" stroke-width="2"/>
+
+  <!-- Signers -->
+  <g font-family="IBM Plex Mono, monospace" font-size="9">
+    <rect x="50" y="260" width="80" height="40" rx="6" fill="white" stroke="#1a7bec"/>
+    <text x="90" y="278" text-anchor="middle" font-weight="700" fill="#1a7bec">Signer 1</text>
+    <text x="90" y="290" text-anchor="middle" fill="#5f6680">share 1</text>
+
+    <rect x="145" y="260" width="80" height="40" rx="6" fill="white" stroke="#1a7bec"/>
+    <text x="185" y="278" text-anchor="middle" font-weight="700" fill="#1a7bec">Signer 2</text>
+    <text x="185" y="290" text-anchor="middle" fill="#5f6680">share 2</text>
+
+    <rect x="255" y="260" width="80" height="40" rx="6" fill="white" stroke="#1a7bec"/>
+    <text x="295" y="278" text-anchor="middle" font-weight="700" fill="#1a7bec">Signer 3</text>
+    <text x="295" y="290" text-anchor="middle" fill="#5f6680">share 3</text>
+
+    <rect x="350" y="260" width="80" height="40" rx="6" fill="#eef4fa" stroke="#dfe8f2"/>
+    <text x="390" y="278" text-anchor="middle" font-weight="700" fill="#5f6680">Signer N</text>
+    <text x="390" y="290" text-anchor="middle" fill="#5f6680">share N</text>
+  </g>
+
+  <!-- Lines from coordinator to signers -->
+  <line x1="200" y1="220" x2="90" y2="260" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="220" y1="220" x2="185" y2="260" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="260" y1="220" x2="295" y2="260" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="280" y1="220" x2="390" y2="260" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+
+  <!-- Annotations -->
+  <text x="240" y="330" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">consumer code unchanged · single PKCS#11 socket · threshold behind the scenes</text>
+  <text x="240" y="344" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" font-weight="700" fill="#009e80" letter-spacing="2">SIGNATURE INDISTINGUISHABLE FROM SINGLE-KEY</text>
+`}/>

--- a/src/components/brand/ArchitectureStackDiagram.astro
+++ b/src/components/brand/ArchitectureStackDiagram.astro
@@ -1,0 +1,71 @@
+---
+/**
+ * Architecture stack — layers from consumers down through adapters,
+ * engine, plugins, and the underlying OS / hardware.
+ */
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="arch-stack-title" set:html={`
+  <title id="arch-stack-title">Confium layered architecture: consumers, adapters, engine, plugins, hardware.</title>
+  <defs>
+    <linearGradient id="as-eng" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+    <linearGradient id="as-cons" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00dfb7"/><stop offset="100%" stop-color="#009e80"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Consumers -->
+  <rect x="30" y="20" width="420" height="48" rx="8" fill="url(#as-cons)" opacity="0.95"/>
+  <text x="240" y="42" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white" letter-spacing="2">CONSUMERS</text>
+  <text x="240" y="58" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" fill="white">TLS terminators · Code signers · KMS · Web apps · Wallets</text>
+
+  <!-- Adapters (Mode 2) -->
+  <rect x="30" y="80" width="420" height="42" rx="6" fill="white" stroke="#00c2c9" stroke-width="1.5"/>
+  <text x="240" y="100" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#009e80" letter-spacing="2">MODE 2 ADAPTERS</text>
+  <text x="240" y="115" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">PKCS#11 v3.0 · OpenSSL 3.0 provider · JCE · TLS 1.3 signer</text>
+
+  <!-- Engine -->
+  <rect x="30" y="135" width="420" height="60" rx="10" fill="url(#as-eng)"/>
+  <text x="240" y="158" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">CONFIUM ENGINE</text>
+  <text x="240" y="175" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" fill="white">Plugin loader · Registry · Coordinator · FFI (cfm_*)</text>
+  <text x="240" y="188" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white" opacity="0.85">10 versioned interfaces: hash · cipher · aead · kdf · rng · signature · kem · key_fmt</text>
+
+  <!-- Plugins -->
+  <rect x="30" y="210" width="135" height="50" rx="6" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+  <text x="97" y="230" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#1a7bec">PLUGINS</text>
+  <text x="97" y="246" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">FROST · CMP20</text>
+  <text x="97" y="256" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Botan · OpenSSL</text>
+
+  <rect x="172" y="210" width="135" height="50" rx="6" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+  <text x="240" y="230" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#1a7bec">CONFIDENCE</text>
+  <text x="240" y="246" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Transparency log</text>
+  <text x="240" y="256" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">OTS · ERS archival</text>
+
+  <rect x="315" y="210" width="135" height="50" rx="6" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+  <text x="382" y="230" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#1a7bec">ATTRIBUTES</text>
+  <text x="382" y="246" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Predicate DSL</text>
+  <text x="382" y="256" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Quorum policy</text>
+
+  <!-- Hardware -->
+  <rect x="30" y="278" width="420" height="40" rx="6" fill="#0f1326"/>
+  <text x="240" y="296" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#a8aec9" letter-spacing="2">HARDWARE / OS</text>
+  <text x="240" y="310" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#a8aec9">HSM · TPM 2.0 · OpenPGP card · Cloud KMS · CPU</text>
+
+  <!-- Arrows -->
+  <line x1="240" y1="68" x2="240" y2="80" stroke="#009e80" stroke-width="1.5" marker-end="url(#as-arr)"/>
+  <line x1="240" y1="122" x2="240" y2="135" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="240" y1="195" x2="240" y2="210" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="240" y1="260" x2="240" y2="278" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+
+  <text x="240" y="338" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#5f6680">standards-only · no vendor SDK · BSD-2-Clause</text>
+
+  <defs>
+    <marker id="as-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#009e80"/>
+    </marker>
+  </defs>
+`}/>

--- a/src/components/brand/KeyLifecycleDiagram.astro
+++ b/src/components/brand/KeyLifecycleDiagram.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Threshold key lifecycle — from generation through active use,
+ * proactive refresh, rotation, and eventual retirement.
+ */
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="key-lifecycle-title" set:html={`
+  <title id="key-lifecycle-title">Threshold key lifecycle: generate, distribute, use, refresh, rotate, retire.</title>
+
+  <!-- Center timeline -->
+  <line x1="40" y1="180" x2="440" y2="180" stroke="#1a7bec" stroke-width="3"/>
+
+  <!-- Stage 1: Key generation -->
+  <circle cx="80" cy="180" r="22" fill="#1a7bec"/>
+  <text x="80" y="185" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">1</text>
+  <text x="80" y="148" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#1a7bec">Generate</text>
+  <text x="80" y="220" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">DKG ceremony</text>
+  <text x="80" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">(no dealer)</text>
+
+  <!-- Stage 2: Distribution -->
+  <circle cx="160" cy="180" r="22" fill="#00c2c9"/>
+  <text x="160" y="185" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">2</text>
+  <text x="160" y="148" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#009e80">Distribute</text>
+  <text x="160" y="220" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Shares to N</text>
+  <text x="160" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">parties</text>
+
+  <!-- Stage 3: Active use -->
+  <circle cx="240" cy="180" r="26" fill="#00dfb7"/>
+  <text x="240" y="185" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="#14172b">3</text>
+  <text x="240" y="146" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="12" font-weight="700" fill="#009e80">Use</text>
+  <text x="240" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">T-of-N signing</text>
+  <text x="240" y="234" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">sessions</text>
+
+  <!-- Stage 4: Refresh (loop) -->
+  <circle cx="320" cy="180" r="22" fill="#ffdc4a"/>
+  <text x="320" y="185" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#14172b">4</text>
+  <text x="320" y="148" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#a07d0a">Refresh</text>
+  <text x="320" y="220" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Herzberg</text>
+  <text x="320" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">monthly</text>
+
+  <!-- Stage 5: Rotate / re-share -->
+  <circle cx="400" cy="180" r="22" fill="#a07d0a"/>
+  <text x="400" y="185" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">5</text>
+  <text x="400" y="148" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#a07d0a">Rotate</text>
+  <text x="400" y="220" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">Re-share</text>
+  <text x="400" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#4f5469">+ new party</text>
+
+  <!-- Loop arrow: refresh back to use -->
+  <path d="M 320 158 Q 280 110 240 154" stroke="#a07d0a" stroke-width="1.5" stroke-dasharray="3 3" fill="none" marker-end="url(#kl-arr)"/>
+  <text x="280" y="105" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#a07d0a" font-style="italic">defeats long-term</text>
+  <text x="280" y="115" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#a07d0a" font-style="italic">share aggregation</text>
+
+  <!-- Bottom annotations -->
+  <text x="80" y="290" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">secret created</text>
+  <text x="80" y="302" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">then destroyed</text>
+
+  <text x="240" y="290" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">secret never</text>
+  <text x="240" y="302" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">reconstructed</text>
+
+  <text x="400" y="290" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">add/remove</text>
+  <text x="400" y="302" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">signers</text>
+
+  <text x="240" y="340" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec" letter-spacing="2">ALL STATES AUDITED IN TRANSPARENCY LOG</text>
+
+  <defs>
+    <marker id="kl-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a07d0a"/>
+    </marker>
+  </defs>
+`}/>

--- a/src/components/brand/PQMigrationTimelineDiagram.astro
+++ b/src/components/brand/PQMigrationTimelineDiagram.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * PQ migration timeline — 4-phase migration from classical to
+ * post-quantum signatures via composite signatures.
+ */
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="pq-timeline-title" set:html={`
+  <title id="pq-timeline-title">Post-quantum migration: four phases from classical-only to PQ-only signatures.</title>
+
+  <!-- Time axis -->
+  <line x1="40" y1="280" x2="440" y2="280" stroke="#5f6680" stroke-width="2" marker-end="url(#pq-arrow)"/>
+  <polygon points="40,280 50,276 50,284" fill="#5f6680"/>
+  <text x="20" y="284" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#5f6680">today</text>
+  <text x="445" y="284" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#5f6680">future →</text>
+
+  <!-- Phase 1: Classical only -->
+  <g>
+    <rect x="50" y="60" width="80" height="200" rx="8" fill="#1a7bec"/>
+    <text x="90" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">PHASE 1</text>
+    <text x="90" y="106" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">Classical</text>
+    <text x="90" y="120" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">only</text>
+    <text x="90" y="160" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">Ed25519</text>
+    <text x="90" y="174" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">or</text>
+    <text x="90" y="188" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">ECDSA-P256</text>
+    <text x="90" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="white" opacity="0.85">baseline</text>
+  </g>
+
+  <!-- Phase 2: Hybrid -->
+  <g>
+    <rect x="150" y="40" width="80" height="220" rx="8" fill="#00c2c9"/>
+    <text x="190" y="62" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">PHASE 2</text>
+    <text x="190" y="86" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="white">Hybrid</text>
+    <text x="190" y="124" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white">classical</text>
+    <text x="190" y="138" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white">+</text>
+    <text x="190" y="152" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white">PQ</text>
+    <text x="190" y="194" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">Ed25519</text>
+    <text x="190" y="208" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">+</text>
+    <text x="190" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.85">ML-DSA-65</text>
+    <text x="190" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="white" opacity="0.95">migration begins</text>
+  </g>
+
+  <!-- Phase 3: PQ required -->
+  <g>
+    <rect x="250" y="60" width="80" height="200" rx="8" fill="#00dfb7"/>
+    <text x="290" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#14172b">PHASE 3</text>
+    <text x="290" y="106" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">PQ</text>
+    <text x="290" y="120" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">required</text>
+    <text x="290" y="160" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">policy</text>
+    <text x="290" y="174" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">tightens:</text>
+    <text x="290" y="194" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">PQ component</text>
+    <text x="290" y="208" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">mandatory</text>
+    <text x="290" y="232" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#14172b">no classical-only</text>
+  </g>
+
+  <!-- Phase 4: PQ only -->
+  <g>
+    <rect x="350" y="60" width="80" height="200" rx="8" fill="#ffdc4a"/>
+    <text x="390" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#14172b">PHASE 4</text>
+    <text x="390" y="106" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">PQ</text>
+    <text x="390" y="120" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="11" font-weight="700" fill="#14172b">only</text>
+    <text x="390" y="160" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">classical</text>
+    <text x="390" y="174" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">component</text>
+    <text x="390" y="188" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">removed</text>
+    <text x="390" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">retained for</text>
+    <text x="390" y="236" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#14172b">archival verify</text>
+  </g>
+
+  <!-- Bottom legend -->
+  <text x="240" y="312" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#4f5469">software upgrade · no HSM replacement · no certificate re-issuance flag day</text>
+  <text x="240" y="330" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec" letter-spacing="2">LEGACY VERIFIERS ACCEPT THROUGHOUT</text>
+  <text x="240" y="346" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#5f6680">they fall back to classical component · upgraded verifiers check both</text>
+
+  <defs>
+    <marker id="pq-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5f6680"/>
+    </marker>
+  </defs>
+`}/>

--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -1,0 +1,306 @@
+---
+title: FAQ
+description: Common questions about Confium — what it is, how it works, when to use it, and the limits of threshold-native trust infrastructure.
+audience: developer
+order: 13
+---
+
+import MerkleTreeDiagram from '../../components/brand/MerkleTreeDiagram.astro';
+import CompositeSignatureDiagram from '../../components/brand/CompositeSignatureDiagram.astro';
+
+# FAQ
+
+Frequently-asked questions about Confium. If your question isn't
+here, ask on [GitHub Discussions](https://github.com/confium/confium/discussions).
+
+## What Confium is
+
+### What is Confium, in one sentence?
+
+Confium is an open-source framework for multi-stakeholder threshold
+cryptography — the same relationship a TLS library has to transport
+security, applied to threshold signing.
+
+### Is Confium a CA?
+
+No. Conventional CAs issue certificates; Confium is the
+cryptographic framework that organizations use to build *their
+own* CA-like infrastructure with custom certificate formats,
+custom delegation rules, and multi-stakeholder governance. See
+[Sovereign PKI](./mode3-sovereign-pki.mdx).
+
+### Is Confium an HSM?
+
+No. HSMs store keys in tamper-resistant hardware. Confium
+integrates with HSMs via PKCS#11 — each signer can store its
+share in an HSM, combining HSM-grade physical security with
+Confium's threshold governance. See [comparison](./comparison.mdx).
+
+### Is Confium a crypto library like OpenSSL?
+
+No. Crypto libraries provide primitives (hash, sign, encrypt).
+Confium loads those primitives via plugins and orchestrates them
+across multiple parties for threshold operations. See [the TLS
+analogy](/concepts/tls-analogy/).
+
+### Is Confium a blockchain?
+
+No. Confium is cryptographic infrastructure that *can* be used in
+blockchain settings (custody, multi-sig replacement), but the
+framework itself is not a blockchain and does not have a native
+token.
+
+## How it works
+
+### How is the signing key split?
+
+Using Shamir secret sharing (or the equivalent in the chosen
+threshold protocol — FROST, CMP20, GG18). The secret exists at
+key generation time as a polynomial of degree T−1 over the
+scalar field; each party gets a share that's a point on the
+polynomial. Any T shares uniquely determine the polynomial (and
+thus the secret); fewer than T shares reveal nothing. See
+[threshold crypto 101](/concepts/threshold-crypto-101/).
+
+### How do parties sign without reconstructing the secret?
+
+The threshold protocols (FROST, CMP20, GG18) operate "in the
+exponent". Each party computes a partial signature using their
+share; the partial signatures combine into the final signature
+without ever reconstructing the secret. See [threshold crypto
+101](/concepts/threshold-crypto-101/) for the math.
+
+### What does a transparency log entry look like?
+
+An entry is a leaf in a Merkle tree. The leaf hash is
+`SHA-256(0x01 || entry_hash)`; internal nodes are
+`SHA-256(0x02 || left_child || right_child)`. The root commits
+to the entire set of entries.
+
+<MerkleTreeDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+### How do composite signatures work?
+
+A composite signature bundles the artifacts of multiple algorithms
+(Ed25519, ECDSA-P256, ML-DSA-65) into one value. Verification
+succeeds only when every component verifies against the same
+message.
+
+<CompositeSignatureDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+See [composite signatures concept](/concepts/composite-signatures/)
+and [PQ migration docs](./pq-migration.mdx).
+
+## Performance
+
+### How fast is threshold signing?
+
+Per-signer signing latency on a single core (FROST-P256):
+
+- Sign share: ~5ms
+- Verify share: ~2ms
+- Aggregate (coordinator): ~1ms per share
+
+End-to-end session latency (3-of-5 quorum):
+
+- Same region: ~30ms over QUIC
+- Cross-region: ~150ms typical
+- Async (offline-tolerant): bounded by signer availability, not throughput
+
+Verification: zero overhead vs single-key signing because the
+output is a standard signature.
+
+### What's the throughput?
+
+A single coordinator handles ~1000 signing sessions per second on
+commodity hardware. Higher throughput: deploy multiple coordinators
+behind a load balancer.
+
+### How much bandwidth does signing use?
+
+Per signing session, ~10KB over the wire (protocol messages
+included). At 1000 sessions/sec, that's ~10 MB/s — well within
+standard network capacity.
+
+## Security
+
+### What happens if a signer is compromised?
+
+The compromised signer's share is exposed, but the share alone is
+useless. An attacker still needs T−1 more shares to forge a
+signature. Trigger an immediate re-share via `confium-tc-reshare`
+to invalidate the compromised share.
+
+### What if the coordinator is compromised?
+
+The coordinator is an *availability* service, not a *secrecy*
+service. Compromising it can denial-of-service the deployment
+but cannot produce unauthorized signatures — the math requires
+T party contributions. Replace the coordinator from a clean
+image; resume sessions from the transparency log.
+
+### What if a transparency log operator goes rogue?
+
+Witness gossip detects divergence via consistency proofs. Switch
+to a backup log; replay recent tree heads. OTS anchors in Bitcoin
+preserve irrefutable history. See
+[transparency logs concept](/concepts/transparency-logs/).
+
+### What about side-channel attacks?
+
+Constant-time scalar arithmetic via the `p256` crate's `CtOption`
+API. `SecureBytes` zeroizes on drop. Every crate carries
+`#![forbid(unsafe_code)]`. For highest assurance, store shares
+in hardware enclaves (HSM, TPM, OpenPGP card).
+
+### What happens if FROST is broken?
+
+Switch to CMP20 or GG18 (or vice versa). The protocol layer is
+pluggable; the rest of the system (coordinator, transparency
+log, audit) is unaffected.
+
+## Deployment
+
+### What's the minimum viable deployment?
+
+For development / testing:
+
+- 1 coordinator process
+- 3 signer processes (for 2-of-3 threshold)
+- 1 transparency log process
+- 1 witness (optional in dev)
+
+For production, multiply by redundancy requirements per region.
+
+### Can I run Confium on Kubernetes?
+
+Yes. The coordinator, signers, and transparency log are stateless
+or stateful services that run as standard K8s deployments. Helm
+charts are community-contributed.
+
+### What hardware do I need?
+
+Commodity hardware. No HSMs required (though supported via
+PKCS#11). For a 1000-session/sec deployment:
+
+- Coordinator: 4 vCPU, 8GB RAM
+- Each signer: 1 vCPU, 1GB RAM
+- Transparency log: 4 vCPU, 32GB RAM (depends on log size and
+  backend — LMDB vs RocksDB)
+
+### How do I back up threshold shares?
+
+Each share is encrypted at rest. Back up the encrypted share file
+via your standard key-management infrastructure (HSM, KMS,
+password manager). Never back up unencrypted shares. If you lose
+a share, use `confium-tc-reshare` to re-share.
+
+## Standards
+
+### Which RFCs does Confium implement?
+
+- **RFC 3161**: Time-Stamp Protocol
+- **RFC 4998**: Evidence Record Syntax (long-term archival)
+- **RFC 5652**: Cryptographic Message Syntax (CMS)
+- **RFC 6962**: Certificate Transparency (Merkle transparency log)
+- **RFC 8017**: PKCS#1 (RSA)
+- **FIPS 204**: ML-DSA (Module-Lattice-Based Digital Signature
+  Algorithm)
+
+### Which standards does Confium integrate with?
+
+- **PKCS#11 v3.0**: HSM / token interface
+- **OpenSSL 3.0 provider**: provider API for OpenSSL consumers
+- **JCE (Java Cryptography Extension)**: Java provider
+- **TLS 1.3**: signature callback for TLS libraries
+- **X.509**: certificate and CSR types
+- **XMLDSig**: XML signature + Exclusive C14N
+
+### What post-quantum algorithms does Confium support?
+
+- **ML-DSA-65** (FIPS 204): via composite signatures + caller-
+  supplied verifier callback today; native support when a
+  suitable pure-Rust verifier crate is published.
+- **ML-KEM** (FIPS 203, formerly Kyber): threshold KEM research
+  in `confium-tc-ml-kem`.
+- **SLH-DSA** (FIPS 205, formerly SPHINCS+): planned.
+
+## Comparison
+
+### How does Confium compare to Sigstore?
+
+Different scope. Sigstore is great for code signing in CI/CD
+pipelines (keyless, OIDC-identity-based, with a Rekor
+transparency log). Confium is a general threshold cryptography
+framework. Use Sigstore for container / package signing in CI;
+use Confium for multi-stakeholder quorum, threshold key escrow,
+or institutional PKI. See [comparison](./comparison.mdx).
+
+### How does Confium compare to a cloud KMS?
+
+Cloud KMS (AWS, GCP, Azure) holds your keys for you. Single-cloud,
+single-provider trust model. Confium runs wherever you run it —
+no vendor lock-in. See [comparison](./comparison.mdx).
+
+### How does Confium compare to commercial threshold solutions
+(Unbound, Sepior, etc.)?
+
+Same core cryptography (threshold protocols), different
+deployment model. Confium is open-source BSD-2-Clause; commercial
+solutions are proprietary with subscription pricing. Confium
+supports standards-only adapters; commercial solutions have their
+own APIs. See [comparison](./comparison.mdx).
+
+## Limits
+
+### What can't Confium do?
+
+- **Cannot replace all single-key PKI.** Some use cases (Let's
+  Encrypt TLS certs) don't need threshold governance.
+- **Cannot verify signatures faster than the underlying primitive.**
+  Verification is the same as single-key; signing has ~5× overhead.
+- **Cannot operate without the coordinator.** The coordinator is
+  required for orchestrating sessions. Make it redundant for HA.
+- **Cannot retroactively threshold existing keys.** You need a
+  key ceremony to split a new key; existing keys must be re-issued.
+
+### When shouldn't I use Confium?
+
+- **Public web TLS.** Let's Encrypt is fine.
+- **Single-stakeholder, low-stakes signing.** If one party owns
+  the key and the cost of compromise is low, threshold adds
+  complexity without value.
+- **Highest-assurance physical security.** HSMs at FIPS 140-2
+  Level 3+ have physical tamper-evidence that software-only
+  Confium doesn't replace. Use HSMs alongside Confium if you need
+  this.
+
+## Project
+
+### Who develops Confium?
+
+The Confium project collective. Funded by NLnet NGI Zero PET
+(European Commission) and Mozilla MOSS. Developed in the open at
+[github.com/confium](https://github.com/confium).
+
+### Is there a CLA?
+
+No. BSD-2-Clause contributions are accepted on the standard
+license terms; contributors retain copyright.
+
+### What's the release cadence?
+
+Patch releases as needed. Minor releases monthly. Major releases
+as the architecture evolves. Releases are automated via
+release-plz from conventional commits.
+
+### How do I cite Confium in academic work?
+
+See [the evaluators guide](/audiences/evaluators/) for BibTeX.
+
+## See also
+
+- [Architecture](./architecture.mdx)
+- [Security model](./security-model.mdx)
+- [Comparison](./comparison.mdx)
+- [Troubleshooting](./troubleshooting.mdx)

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -1,0 +1,301 @@
+---
+title: Troubleshooting
+description: Operational gotchas, common errors, and their fixes for Confium deployments and consumers.
+audience: developer
+order: 14
+---
+
+# Troubleshooting
+
+Common operational issues and their fixes. If your issue isn't
+here, check [the FAQ](./faq.mdx) or ask on
+[GitHub Discussions](https://github.com/confium/confium/discussions).
+
+## Installation
+
+### `gem install confium` fails to build the native extension
+
+The Ruby gem compiles a Rust native extension at install time.
+You need:
+
+- Ruby ≥ 3.1
+- Rust stable 1.85+ (`rustup default stable`)
+- A C toolchain (`cc`, `make`)
+
+Verify:
+```sh
+ruby --version    # >= 3.1
+rustc --version   # >= 1.85
+cc --version
+```
+
+If you see `error: linking with cc failed`, install Xcode CLI
+tools (macOS) or `build-essential` (Debian/Ubuntu).
+
+### `cargo add confium-core` pulls an old version
+
+The workspace version is pinned in `Cargo.toml`. If you need the
+latest, use the git dependency:
+
+```toml
+[dependencies]
+confium-core = { git = "https://github.com/confium/confium.git", branch = "main" }
+```
+
+### WASM package fails to load in the browser
+
+The `@confium/confium-wasm` package targets `wasm32-unknown-unknown`
+with `wasm-bindgen`. Make sure you:
+
+1. Initialize before use: `await init();`.
+2. Use the right import form for your bundler:
+   ```javascript
+   import init, { CompositeSignature } from "@confium/confium-wasm";
+   ```
+3. Add the right Content-Type headers if self-hosting:
+   `application/wasm`.
+
+## Ruby
+
+### `Confium::ParseError` when loading a PEM
+
+Most common causes:
+
+- The PEM has Windows line endings (`\r\n`) but is being read
+  with `File.read` in text mode (which can re-translate). Read in
+  binary mode: `File.open(path, "rb", &:read)`.
+- The PEM is missing begin/end markers. Verify:
+  ```
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+  ```
+- The PEM is concatenated incorrectly. Each PEM block needs its
+  own begin/end markers.
+
+### `Confium::VerificationError` from path validation
+
+```ruby
+result = Confium::PKI::PathValidator.validate(
+  leaf: cert, intermediates: [inter], root: root,
+)
+result.valid?   # => false
+result.errors   # => [{ chain_index: 0, check: "signature", ... }]
+```
+
+Read `result.errors` — each error has `chain_index`, `check`,
+and `details`. Common causes:
+
+- `check: "signature"` — wrong root, expired cert, or revoked
+  cert. Check the chain order: leaf, intermediates, root.
+- `check: "validity"` — cert is expired or not-yet-valid.
+- `check: "name_constraints"` — cert violates name constraints
+  defined in root.
+
+### `Confium::ThresholdError: insufficient quorum`
+
+The coordinator couldn't reach threshold T. Check:
+
+- Are enough signers online? `confium list-signers`.
+- Are signers' shares valid? Run `confium signer self-test` on
+  each.
+- Is the policy correct? Read the deployment manifest's
+  `[quorum]` section.
+
+### `Confium::PolicyViolationError: disallowed algorithm`
+
+The policy allow-list doesn't include the algorithm. Update
+`Confium::Policy.allowed_signature_algorithms` or the deployment
+manifest's `[policy]` section.
+
+## Rust
+
+### `error[E0599]: no method named X found on type Y`
+
+Confium's public API is concentrated in trait definitions. If a
+method isn't found, you may be missing a trait import:
+
+```rust
+use confium_composite::VerifierCallback;  // bring the trait in
+```
+
+### Compile errors with `Scalar::from_repr`
+
+`p256::Scalar::from_repr` returns `CtOption<Scalar>`, not
+`Option<Scalar>`. Convert explicitly:
+
+```rust
+let scalar = Option::<Scalar>::from(Scalar::from_repr(bytes))
+    .ok_or_else(|| MyError::InvalidScalar)?;
+```
+
+### `cargo test` is slow
+
+Some integration tests spawn coordinators and signers, which
+adds startup time. Run unit tests only:
+
+```sh
+cargo test --workspace --lib
+```
+
+## WASM
+
+### `RuntimeError: unreachable` in browser console
+
+The WASM module panics. Most common cause: missing
+initialization. Make sure `await init();` runs before any other
+Confium call.
+
+### Bundle size is too large
+
+The `@confium/confium-wasm` package has per-subsystem Cargo
+features. Tree-shake to just what you need:
+
+```toml
+# Cargo.toml (if you're building yourself)
+[features]
+verify-composite = []
+verify-transparency = []
+verify-attributes = []
+verify-pki = []
+default = ["verify-composite", "verify-transparency", "verify-attributes", "verify-pki"]
+```
+
+In npm, use the pre-built subset packages
+(`@confium/confium-wasm-composite`, etc.) when available.
+
+## Operations
+
+### Coordinator can't reach signers
+
+Check connectivity:
+```sh
+confium ping-signer --coordinator coord.internal:7443 --id director-1
+```
+
+Common causes:
+
+- Firewall blocking the coordinator's QUIC port (default 7443).
+- Signer identity mismatch (the signer's `--identity` doesn't
+  match the coordinator's configured signer ID).
+- TLS certificate issues. The coordinator verifies signer
+  certificates; if they're expired or wrong-CA, signing fails.
+
+### Transparency log is growing unboundedly
+
+That's by design — the log is append-only. Add storage, or
+configure log rotation (which preserves the cryptographic chain
+by snapshotting roots periodically).
+
+### Signers joining late
+
+The coordinator holds session state for in-flight sessions. If
+signers join after a session starts, they can still participate
+in subsequent rounds. Sessions time out after a configurable
+interval (default: 24 hours).
+
+### Witness detects divergence
+
+This is the split-view attack detection firing. Investigate
+immediately:
+
+1. Compare tree heads between coordinators.
+2. Identify the divergent entries.
+3. Determine whether the divergence is malicious (operator
+   compromise) or operational (split-brain, network partition).
+4. If malicious: switch to backup log; replay recent tree heads;
+   initiate incident response.
+
+### Audit log shows unexpected signer identity
+
+If `signers` in the audit record contains an identity you don't
+recognize, the deployment manifest's `[[signers]]` section may
+have a stale entry. Audit the manifest, remove the stale signer,
+and re-share to invalidate any share that signer may hold.
+
+## Plugin authoring
+
+### `cfmp_*` symbols missing from built library
+
+Ensure `crate-type = ["cdylib"]` in `[lib]`:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+Then verify exports:
+```sh
+nm -D target/release/libmy_plugin.so | grep cfmp
+```
+
+### Plugin loads but `InterfaceNotSupported`
+
+The interface name in `cfmp_query_interfaces` doesn't match
+what the host requested, or the version byte is higher than the
+host supports. Check:
+
+- Interface name spelling (case-sensitive).
+- Version byte — start with 0 and bump only when the contract
+  changes.
+
+### `PluginDependencyUnmet` on load
+
+A declared dependency is missing or out of range. Run
+`confium list` to see loaded plugins; check the version range in
+your `Dependency::provider(...)` call.
+
+## Build / CI
+
+### Site build fails with MDX errors
+
+If you're using `@astrojs/mdx`, JSX-trigger characters in content
+can break parsing. Specifically:
+
+- `<word ...>` in content is parsed as a JSX tag.
+- `cfmp_<interface>_*` in inline code triggers tag parsing.
+
+Fix: escape `<` and `>` in code-block-adjacent content, or
+reword to avoid the pattern. See the [MDX migration notes](https://mdxjs.com/migrating/v2/).
+
+### `globLoader is not a function` in Astro 7
+
+The loader import changed in Astro 7. Use:
+
+```ts
+import { glob } from 'astro/loaders';
+```
+
+Not:
+```ts
+import { globLoader } from 'astro:content';
+```
+
+### `Could not resolve import` for `@layouts/*`
+
+The path alias must be declared in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@layouts/*": ["src/layouts/*"]
+    }
+  }
+}
+```
+
+## Where to get more help
+
+- [GitHub Discussions](https://github.com/confium/confium/discussions) — for questions.
+- [GitHub Issues](https://github.com/confium/confium/issues) — for bugs.
+- [/security/](/security/) — for security disclosures.
+- [Audience guides](/audiences/) — role-specific deep dives.
+
+## See also
+
+- [FAQ](./faq.mdx)
+- [Architecture](./architecture.mdx)
+- [Security model](./security-model.mdx)
+- [Conventions](https://github.com/confium/confium/tree/main/docs/conventions.mdx)
+  (Rust workspace)

--- a/src/content/use_cases/academic-credentials.mdx
+++ b/src/content/use_cases/academic-credentials.mdx
@@ -1,0 +1,168 @@
+---
+title: Academic credentials
+description: Verifiable diplomas, transcripts, and certifications issued under multi-stakeholder governance. No single administrator holds the issuing key.
+mode: 3
+order: 14
+---
+
+# Academic credentials
+
+Diplomas, transcripts, and professional certifications are
+increasingly issued as verifiable digital credentials (W3C VC,
+Open Badges, Blockcerts). The signing authority — a university,
+a certification body, a professional society — issues credentials
+that relying parties (employers, other institutions, government
+agencies) verify. The signing key is a high-value target: a
+compromised key lets an attacker issue fake credentials en masse.
+
+Confium splits the issuing authority across multiple stakeholders
+(registrar + department + academic senate, or certification body +
+exam authority + oversight committee). No single party can issue
+credentials alone.
+
+## When to choose this use case
+
+- You issue verifiable credentials (diplomas, transcripts,
+  certifications, badges) and the issuing authority is too sensitive
+  for any single administrator.
+- You need cross-institutional credential verification (academic
+  mobility, professional licensing).
+- You want a public, auditable record of every credential ever
+  issued by your institution.
+- You're deploying a sovereign digital credential framework.
+
+## How Confium solves it
+
+A Mode 3 (Sovereign PKI) deployment with:
+
+- **Custom credential profile** matching W3C Verifiable Credentials
+  (JSON-LD) or Open Badges (JSON).
+- **Attribute-based quorum**: "2-of-3 registrar + 1-of-1 department
+  head + 1-of-1 academic senate oversight".
+- **Transparency log** recording every credential issuance. Anyone
+  can audit; the institution cannot silently issue or revoke.
+- **Long-term archival**: diplomas must remain verifiable for the
+  holder's lifetime (50–80 years typical).
+
+## Verifiable Credentials integration
+
+W3C Verifiable Credentials use a proof field for the issuer's
+signature. Confium produces a standard Ed25519Signature2018 /
+JsonWebSignature2020 proof that any conformant VC verifier accepts:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.example.edu/credentials/v1"
+  ],
+  "id": "https://example.edu/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "did:web:example.edu",
+  "issuanceDate": "2026-07-28T14:23:42Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science in Computer Science"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2026-07-28T14:23:42Z",
+    "verificationMethod": "did:web:example.edu#confium-key-1",
+    "proofValue": "..."
+  }
+}
+```
+
+The `proofValue` is produced by a Confium threshold signing session;
+the verifier sees only a standard signature.
+
+## Multi-stakeholder issuance
+
+Real credential issuance requires multiple approvals:
+
+- Registrar verifies the student completed requirements.
+- Department head confirms the degree classification.
+- Academic senate (or equivalent) attests to the institutional
+  authority.
+
+```toml
+[quorum]
+threshold = 3
+total = 4
+
+[[signers]]
+id = "registrar"
+attributes = { role = "registrar", department = "..." }
+
+[[signers]]
+id = "department-head"
+attributes = { role = "faculty", department = "..." }
+
+[[signers]]
+id = "academic-senate"
+attributes = { role = "governance" }
+
+[[signers]]
+id = "oversight"
+attributes = { role = "audit" }
+```
+
+## Revocation
+
+Credentials can be revoked (academic misconduct discovered post-
+issuance, degree rescinded). Confium's transparency log records
+revocation events alongside issuance events. Relying parties
+check both:
+
+```ruby
+# Verify a credential is issued AND not revoked.
+proof = Confium::PKI::VerifiableCredential.from_json(credential_json)
+
+issuer_root = Confium::Transparency.current_root
+inclusion = Confium::Transparency.verify_inclusion(
+  entry: proof.entry,
+  proof: proof.inclusion_proof,
+  root: issuer_root,
+)
+
+revocation_check = Confium::Transparency.check_revocation(
+  credential_id: proof.id,
+)
+
+puts "Valid" if inclusion.valid? && !revocation_check.revoked?
+```
+
+## Cross-institutional mobility
+
+A diploma issued by University A should be verifiable by Employer B
+and University C without contacting University A. Confium's
+transparency log provides this: B and C query the public log (or
+a cached copy) and verify the inclusion proof.
+
+Multiple institutions can share a transparency log (consortium
+model) or run independent logs (federated model). The framework
+supports both.
+
+## Lifelong verifiability
+
+Academic credentials must remain verifiable for the holder's
+lifetime. This is a 50–80 year horizon — far longer than any
+specific cryptographic algorithm's projected lifetime. Confium
+addresses this with:
+
+- **RFC 4998 ERS archival**: re-timestamps evidence as algorithms
+  evolve.
+- **Composite signatures with PQ component**: ensures the
+  credential still verifies after quantum computers arrive.
+- **Transparency log anchoring in Bitcoin via OTS**: irrefutable
+  time proof that survives institutional collapse.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Sovereign PKI use case](/use-cases/sovereign-pki/)
+- [Supply-chain provenance](/use-cases/supply-chain/)
+- [Compliance officer guide](/audiences/compliance/)

--- a/src/content/use_cases/document-signing.mdx
+++ b/src/content/use_cases/document-signing.mdx
@@ -1,0 +1,114 @@
+---
+title: Document signing
+description: Multi-stakeholder signing of contracts, PDFs, Office documents, and legal records. No single party holds the signing key.
+mode: 3
+order: 7
+---
+
+import CompositeSignatureDiagram from '../../components/brand/CompositeSignatureDiagram.astro';
+
+# Document signing
+
+A signed document — a contract, a regulatory filing, a clinical trial
+report — typically requires multiple stakeholders to approve. Today
+this is done by having one party collect signatures serially, or by
+trusting a single signing service. Confium replaces both with
+threshold signing: T-of-N authorized signers must co-sign; the
+output is a single standard signature any verifier accepts.
+
+## When to choose this use case
+
+- You sign contracts that require sign-off from multiple parties
+  (legal, finance, operations).
+- You sign regulated documents where the signing authority itself
+  should be multi-stakeholder (e.g. FDA drug approvals, SEC filings).
+- You want a single verifiable signature on the final document
+  rather than N separate signature blocks.
+- You need long-term verifiability (decades) and want post-quantum
+  readiness from day one.
+
+## How Confium solves it
+
+Each signing party runs a Confium signer process. The document
+hash is submitted to the coordinator; the coordinator collects
+partial signatures from the participating parties; the final
+signature is published alongside the document. The signing key
+never exists on any single machine.
+
+The output signature is a standard CMS / PAdES / XAdES signature.
+Existing PDF readers, Office applications, and signature verifiers
+accept it without modification.
+
+<CompositeSignatureDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+For long-lived documents (regulatory filings, contracts in force for
+decades), the composite signature includes both classical (Ed25519,
+ECDSA-P256) and post-quantum (ML-DSA-65) components. Today both
+verify; tomorrow, when classical algorithms fall to quantum attack,
+the PQ component still holds.
+
+## Architecture
+
+```
+[ Document authoring tool ]
+            |
+            | submit document hash
+            v
+[ Confium coordinator ] --------------------+
+   |             |             |             |
+   v             v             v             v
+[Legal]      [Finance]     [Operations]   [Compliance]
+   |             |             |             |
+   +------ T-of-N signers -------------------+
+            |
+            v
+   [ Composite signature + inclusion proof ]
+            |
+            v
+   [ Transparency log anchors the event ]
+```
+
+## Code sketch
+
+Submit a document for threshold signing:
+
+```ruby
+doc_hash = Confium::Transparency.compute_artifact_hash(
+  artifact_type: :document,
+  content: File.read("contract.pdf"),
+)
+
+session = Confium::TC::Session.start(
+  coordinator: "docs.internal:7443",
+  message: doc_hash,
+  algorithm: "ECDSA-P256",
+  quorum: { t: 3, n: 5 },
+)
+
+# Authorized signers join asynchronously and submit partial sigs.
+# Coordinator combines when quorum reached.
+
+final_sig = session.wait_for_completion
+puts "signature: #{final_sig[:der].size} bytes (DER)"
+```
+
+The resulting signature embeds into the PDF via standard PAdES,
+into Office docs via XAdES, or attaches as a detached CMS
+SignedData.
+
+## Compliance hooks
+
+- **eIDAS** (EU): Qualified Electronic Signatures require P-384+;
+  Confium's jurisdictional policy enforces this at the engine level.
+- **21 CFR Part 11** (FDA, pharma): Audit trail with signer identity
+  + attributes; transparency log anchors each signing event.
+- **HIPAA**: Audit trail of every signing operation (§164.312(b)).
+- **ESIGN Act** (US): Electronic signature validity; Confium's
+  signatures meet the technical requirements.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Composite signatures concept](/concepts/composite-signatures/)
+- [PQ migration use case](/use-cases/pq-migration/)
+- [Compliance officer guide](/audiences/compliance/)

--- a/src/content/use_cases/email-security.mdx
+++ b/src/content/use_cases/email-security.mdx
@@ -1,0 +1,116 @@
+---
+title: Email security (S/MIME)
+description: Multi-stakeholder S/MIME signing for high-value email. Threshold key per mailbox; no single party holds the private key.
+mode: 2
+order: 8
+---
+
+# Email security (S/MIME)
+
+Email signing today means a single private key stored on each
+device. If the device is lost, stolen, or compromised, every email
+signed from it until revocation is suspect. For high-value email
+(executive communications, legal notices, regulator correspondence)
+this single-key model is a structural risk.
+
+Confium replaces it with threshold S/MIME: the signing key is split
+across N parties (the user's devices plus an organizational escrow);
+T-of-N must participate. A lost laptop reveals one share, not the
+key.
+
+## When to choose this use case
+
+- Your organization sends signed email that must remain verifiable
+  for years (legal notices, contract communications, regulator
+  filings).
+- A single compromised device should not invalidate every signature
+  the user ever produced.
+- You need break-glass access: if the user loses all their devices,
+  the organization can recover access via threshold key escrow.
+- You want S/MIME compliance (e.g. FedRAMP, eIDAS QES) without
+  trusting a single party with the private key.
+
+## How Confium solves it
+
+Each mailbox gets a threshold key split across:
+
+- The user's primary device (1 share).
+- The user's secondary device (1 share).
+- An organizational key escrow service running Confium (N−2 shares).
+
+A 2-of-N quorum lets the user sign from any of their devices (their
+device + one escrow share). Break-glass recovery requires the
+escrow to participate with multiple shares plus one user device —
+or, in extremis, the full escrow quorum.
+
+The S/MIME signature produced is a standard CMS SignedData.
+Existing email clients (Apple Mail, Outlook, Thunderbird) verify
+it without modification.
+
+## Architecture
+
+```
+[ Email client (MUA) ]
+       |
+       | compose + sign request
+       v
+[ Local Confium signer ]
+       |
+       v
+[ Coordinator ]
+   |          |
+   v          v
+[User dev] [Org escrow]
+   |          |
+   +---- 2-of-N quorum ----+
+              |
+              v
+   [ CMS SignedData (standard S/MIME) ]
+              |
+              v
+   [ Embedded in MIME message ]
+```
+
+## PKCS#11 integration
+
+The local Confium signer exposes a PKCS#11 v3.0 socket. The email
+client thinks it's talking to a smartcard or HSM; under the hood
+every `C_Sign()` call dispatches to the threshold coordinator.
+
+```ruby
+# Configure the MUA to use Confium as its PKCS#11 module:
+#   Module path: /usr/lib/confium/confium-pkcs11.so
+#   Slot ID: 0
+#   Token label: "alice@example.com"
+
+# The MUA's standard S/MIME signing flow works unchanged:
+#   Message → C_Sign(hash) → Confium threshold session → CMS signature
+```
+
+## Break-glass recovery
+
+If Alice loses all her devices:
+
+1. Alice contacts the organizational escrow (security team).
+2. Escrow initiates a recovery session: T-of-N escrow shares
+   participate to produce a recovery signature.
+3. Alice is issued a new device with a fresh share.
+4. `confium-tc-reshare` redistributes shares across the new device
+   set without changing the underlying key.
+
+The transparency log records every recovery event for audit.
+
+## Post-quantum readiness
+
+Long-lived email signatures are a prime candidate for composite
+signatures. A regulatory filing sent today should still verify in
+2040. By embedding both Ed25519 and ML-DSA-65 components from day
+one, the signature remains valid even after Ed25519 falls to
+quantum attack.
+
+## See also
+
+- [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)
+- [Distributed custody use case](/use-cases/distributed-custody/)
+- [PKI operators guide](/audiences/operators/)
+- [Compliance officer guide](/audiences/compliance/)

--- a/src/content/use_cases/financial-settlement.mdx
+++ b/src/content/use_cases/financial-settlement.mdx
@@ -1,0 +1,149 @@
+---
+title: Financial settlement
+description: Multi-party signing for trade settlement, SWIFT messages, and audit trails. No single operator holds the signing key.
+mode: 3
+order: 13
+---
+
+# Financial settlement
+
+Trade settlement, interbank transfers, and SWIFT messaging all
+rely on digital signatures to authorize movements of value. A
+compromised signing key at a bank, clearing house, or custodian
+can authorize fraudulent transfers worth billions. The historical
+defense — operational security around single keys stored in HSMs —
+has held, but each high-profile incident (Bangladesh Bank 2016,
+$81M stolen via SWIFT compromise) shows the model's limits.
+
+Confium adds structural defense: settlement signing requires
+multi-party quorum per transaction, with the threshold scaling
+to transaction value.
+
+## When to choose this use case
+
+- You operate a clearing, settlement, or custodial service where
+  signing authority is too sensitive for any single operator.
+- You need attribute-based quorum: low-value transactions auto-clear;
+  high-value transactions require multiple signers from different
+  departments.
+- You want a tamper-evident audit trail that satisfies regulators
+  (SEC, FINRA, FCA, MAS, BaFin).
+- You're modernizing legacy HSM-based signing and want to keep
+  the HSM but add threshold governance.
+
+## How Confium solves it
+
+### Tiered authorization
+
+Real settlement systems tier authorization by value and risk:
+
+```
+1-of-2 operations staff
+  for routine settlement < $1M
+
+2-of-3 operations + 1-of-2 risk
+  for $1M – $100M
+
+3-of-5 operations + 2-of-3 risk + 1-of-2 compliance
+  for $100M – $1B
+
+Board resolution + 5-of-7 senior officers
+  for > $1B
+```
+
+Confium's attribute DSL expresses these policies; the coordinator
+enforces them per transaction.
+
+### SWIFT message signing
+
+SWIFT messages (MT, MX/ISO 20022) require cryptographic signing
+to authenticate the sender. The signing key today lives in an
+HSM at the sending institution. Confium replaces this with
+threshold signing:
+
+- The signing key is split across operations, risk, and
+  compliance HSMs.
+- Each SWIFT message signing requires T-of-N quorum.
+- The output signature is standard PKCS#1 / PKCS#7, accepted by
+  SWIFT's infrastructure without modification.
+
+### Audit trail
+
+Every settlement event anchors into a transparency log. The log
+is queryable by:
+
+- Internal audit (full record).
+- External auditors (cryptographically verified subset).
+- Regulators (real-time feed via witness gossip).
+- Counterparties (inclusion proof per transaction).
+
+```ruby
+settlement_event = {
+  trade_id: "TRD-2026-001234",
+  counterparty: "CPTY-US-001",
+  amount_usd: 50_000_000,
+  value_date: Date.today + 2,
+  signers: ["ops-1", "ops-2", "risk-1"],
+}
+
+event_hash = Confium::Transparency.compute_artifact_hash(
+  artifact_type: :settlement,
+  content: settlement_event.to_json,
+)
+
+session = Confium::TC::Session.start(
+  coordinator: "settlement.internal:7443",
+  message: event_hash,
+  algorithm: "ECDSA-P384",  # EU-compatible; US also accepts P-256
+  quorum: { threshold: 3, attributes: { "operations" => 2, "risk" => 1 } },
+)
+
+final_sig = session.wait_for_completion
+
+# Anchor in transparency log; emit SIEM event.
+Confium::Audit.emit(
+  event: settlement_event,
+  signature: final_sig,
+  transparency_sequence: Confium::Transparency.append(event_hash),
+)
+```
+
+## Regulatory alignment
+
+| Regulator / framework | Confium support |
+| --- | --- |
+| **SOX** (US, financial reporting) | Audit trail with signer identity + timestamp; immutable transparency log |
+| **Dodd-Frank** (US, derivatives) | Per-trade signing with attribute-based quorum |
+| **MiFID II** (EU, markets) | P-384+ jurisdictional policy; structured audit log |
+| ** Basel III** (banking supervision) | Operational risk reduction via multi-party control |
+| **FINRA** (US, brokers) | Audit trail; signer identity |
+| **MAS** (Singapore, financial) | Threshold signing for custody; structured audit |
+| **FCA** (UK, financial) | Audit trail; transparency log anchors |
+
+## HSM coexistence
+
+Most financial institutions already have HSMs. Confium doesn't
+require ripping them out — it adds threshold governance on top:
+
+- Each HSM stores one share (via `confium-store-pkcs11`).
+- The coordinator orchestrates signing sessions across HSMs.
+- The HSMs retain their physical security guarantees.
+- Confium adds the threshold layer (no single HSM compromise
+  suffices to forge a signature).
+
+## Disaster recovery
+
+Settlement systems require business continuity. Confium supports:
+
+- **Multi-region coordinators** with shared transparency log state.
+- **Async sessions** that survive coordinator failover.
+- **Share backup** encrypted at rest, restorable to replacement HSMs.
+- **Periodic Herzberg refresh** to defeat long-running share
+  aggregation attacks.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Code signing use case](/use-cases/code-signing/) (similar pattern)
+- [Compliance officer guide](/audiences/compliance/)
+- [PKI operators guide](/audiences/operators/)

--- a/src/content/use_cases/government-identity.mdx
+++ b/src/content/use_cases/government-identity.mdx
@@ -1,0 +1,125 @@
+---
+title: Government identity
+description: National IDs, passports, eID, and visa stamping with multi-stakeholder signing. No single government agency holds the root key.
+mode: 3
+order: 11
+---
+
+import DefenseInDepthDiagram from '../../components/brand/DefenseInDepthDiagram.astro';
+
+# Government identity
+
+National identity systems — eID cards, passports, driver's licenses,
+visa stamps — are the most consequential PKI deployments in
+existence. A compromised root key lets an attacker forge identity
+for millions of citizens; a sub-CA compromise lets them forge
+specific identity classes. The standard defense is operational
+security around the root key, often with HSMs in physically
+secured facilities.
+
+Confium offers a structural defense: split the root signing
+authority across multiple government agencies, ministries, or
+independent overseers. No single agency can issue identity
+certificates alone; any issuance requires a configured quorum.
+
+## When to choose this use case
+
+- You operate a national identity system and the root signing
+  authority is too sensitive to entrust to any single agency.
+- You need cross-ministry governance (Interior + Foreign Affairs +
+  independent oversight body) for identity issuance.
+- You're deploying a sovereign digital identity framework (eIDAS
+  Qualified Trust Service, national eID, etc.).
+- You want public verifiability of identity issuance decisions.
+
+## How Confium solves it
+
+A Mode 3 (Sovereign PKI) deployment with:
+
+- **Custom certificate profile** matching the national identity
+  schema (X.509 with custom extensions, or a custom ASN.1 / CBOR
+  structure).
+- **Attribute-based quorum** specifying which agencies must
+  participate. Example: "2-of-3 Interior + 1-of-2 Foreign Affairs
+  + 1-of-1 Oversight".
+- **Transparency log** recording every identity certificate ever
+  issued. Citizens, relying parties, and journalists can audit.
+- **OTS anchoring** for irrefutable proof of when certificates
+  existed.
+
+<DefenseInDepthDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+## Sovereignty over formats
+
+National identity cards have unique requirements:
+
+- Custom data fields (national ID number, biometric hash, blood
+  type, organ donor status).
+- Custom encoding (CBOR for compactness on smartcards, or ASN.1
+  for X.509 compatibility).
+- Custom delegation (Ministry X can issue category Y but not
+  category Z).
+- Custom archival cadence (decades-long validity for passports).
+
+Confium's Mode 3 lets the deploying government define all of
+these. The framework provides the engine; the policy and format
+are sovereign.
+
+## Cross-border interop
+
+Many identity systems must interop across borders:
+
+- **eIDAS** (EU): cross-border recognition of national eIDs.
+- **ICAO** (passports): Machine Readable Travel Documents (MRTD).
+- **ISO/IEC 18013** (driver's licenses): mobile driver's license
+  (mDL).
+
+Confium produces standard X.509 / CMS / CBOR structures that
+interop with existing verifiers. The threshold-signing backend
+is invisible to relying parties.
+
+## Example: visa stamping
+
+A visa issuance authority wants 2-of-3 sign-off on every visa:
+
+- Consular officer at the issuing embassy.
+- Home-country foreign ministry.
+- Destination-country immigration authority (for reciprocal
+  agreements).
+
+```toml
+[quorum]
+threshold = 2
+total = 3
+
+[[signers]]
+id = "consular-officer"
+attributes = { role = "consular", embassy = "...", country = "..." }
+
+[[signers]]
+id = "foreign-ministry"
+attributes = { role = "ministry", country = "..." }
+
+[[signers]]
+id = "destination-immigration"
+attributes = { role = "immigration", country = "..." }
+```
+
+Each visa is anchored in the transparency log. Any verifier
+(airline, border control) can independently confirm the visa was
+validly issued.
+
+## Compliance
+
+- **eIDAS** Qualified Trust Service: P-384+ jurisdictional policy;
+  audit trail; long-term verifiability via ERS archival.
+- **ICAO PKI**: X.509 + custom visa extensions; threshold signing
+  at the visa root.
+- **FIPS 140-2/3**: route through FIPS-validated crypto plugin.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Sovereign PKI use case](/use-cases/sovereign-pki/)
+- [Compliance officer guide](/audiences/compliance/)
+- [Architecture](/docs/architecture/)

--- a/src/content/use_cases/healthcare-records.mdx
+++ b/src/content/use_cases/healthcare-records.mdx
@@ -1,0 +1,150 @@
+---
+title: Healthcare records
+description: HIPAA-compliant signing of medical records, prescriptions, and clinical trial data. Threshold signing per record.
+mode: 3
+order: 12
+---
+
+# Healthcare records
+
+Medical records, prescriptions, and clinical trial data have
+strict signing requirements: every entry must be attributable
+to a specific clinician; the record must remain verifiable for
+the patient's lifetime; audit trails must satisfy HIPAA, GCP
+(Good Clinical Practice), and 21 CFR Part 11. Today these
+requirements are met with single-key signing per clinician —
+which means a compromised clinician credential can be used to
+sign fraudulent records until discovered.
+
+Confium adds threshold governance on top:
+
+- Every clinical record requires the treating clinician plus a
+  co-signer (attending, supervisor, pharmacist) per policy.
+- The signing key is never on a single device; lost or stolen
+  devices reveal one share, not the key.
+- Every signing event anchors into a transparency log for
+  immutable audit.
+- Long-term archival via RFC 4998 Evidence Record Syntax.
+
+## When to choose this use case
+
+- You operate an EHR (Electronic Health Record) system where
+  record integrity is a HIPAA / regulatory requirement.
+- Clinical trial data must be signed and verifiable for decades.
+- Prescription signing must be attributable and tamper-evident.
+- A compromised clinician credential should not be enough to
+  inject fraudulent records.
+
+## How Confium solves it
+
+### Medical record signing
+
+Each record signing event requires:
+
+1. Treating clinician's partial signature.
+2. Co-signer (attending, supervisor, or pharmacist) per policy.
+3. Optional: institutional signing key (hospital, clinic).
+
+The coordinator combines the partial signatures into a single
+CMS SignedData on the record. The signature embeds in the EHR's
+standard record format (FHIR, HL7 v2, C-CDA).
+
+### Prescription signing
+
+Electronic prescriptions (e-prescribing) require the prescriber's
+signature plus, for controlled substances, a second signer (DEA
+EPCS requirements in the US). Confium's threshold model implements
+this natively:
+
+```toml
+[quorum]
+threshold = 2
+total = 2
+
+[[signers]]
+id = "prescriber"
+attributes = { role = "physician", dea_number = "...", specialty = "..." }
+
+[[signers]]
+id = "pharmacist-verify"
+attributes = { role = "pharmacist", pharmacy_id = "..." }
+```
+
+### Clinical trial data
+
+Clinical trial data signing has unique requirements:
+
+- **Long-term verifiability**: trial data may be audited 10+ years
+  after collection (FDA submission, post-market surveillance).
+- **Multi-party sign-off**: principal investigator + clinical
+  research associate + sponsor.
+- **Tamper-evidence**: every data point signed and anchored in a
+  transparency log.
+
+```ruby
+trial_data = {
+  subject_id: "SUBJ-001",
+  visit: "V3",
+  measurements: { weight_kg: 78.4, bp_sys: 118, bp_dia: 76 },
+  timestamp: Time.now.utc,
+}
+
+data_hash = Confium::Transparency.compute_artifact_hash(
+  artifact_type: :clinical_trial_data,
+  content: trial_data.to_json,
+)
+
+session = Confium::TC::Session.start(
+  coordinator: "trials.internal:7443",
+  message: data_hash,
+  algorithm: "ECDSA-P256",
+  quorum: {
+    threshold: 3,
+    attributes: {
+      "principal_investigator" => 1,
+      "clinical_associate" => 1,
+      "sponsor" => 1,
+    },
+  },
+)
+
+final_sig = session.wait_for_completion
+
+# Anchor in transparency log with long-term archival (RFC 4998 ERS).
+Confium::ERS.archive(
+  signature: final_sig,
+  data: trial_data.to_json,
+  archival_period: :perpetual,
+)
+```
+
+## HIPAA mapping
+
+| HIPAA requirement | How Confium supports it |
+| --- | --- |
+| §164.312(a)(1) — Access control | Attribute-based threshold; per-record signer identity |
+| §164.312(a)(2)(iv) — Encryption and decryption | FIPS 140 mode; threshold key split |
+| §164.312(b) — Audit controls | Structured audit log per signing event |
+| §164.312(c)(1) — Integrity | Transparency log anchors; consistency proofs |
+| §164.312(c)(2) — Authentication | Signer identity + attributes per session |
+| §164.312(d) — Person or entity authentication | Threshold quorum; no single-party signing |
+| §164.312(e)(1) — Transmission security | Standard TLS; threshold key for TLS termination |
+
+## Long-term archival
+
+Medical records and clinical trial data must remain verifiable
+for decades. RFC 4998 Evidence Record Syntax (ERS) maintains
+long-term evidence by re-timestamping as hash algorithms and
+signature algorithms evolve. Confium's `confium-ers` crate
+implements ERS archival.
+
+Composite signatures add post-quantum readiness: even after
+quantum computers break today's classical algorithms, the
+records still verify.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Compliance officer guide](/audiences/compliance/)
+- [Document signing use case](/use-cases/document-signing/)
+- [Transparency logs concept](/concepts/transparency-logs/)

--- a/src/content/use_cases/iot-attestation.mdx
+++ b/src/content/use_cases/iot-attestation.mdx
@@ -1,0 +1,131 @@
+---
+title: IoT device attestation
+description: Threshold firmware signing and device identity attestation for IoT deployments. Firmware updates require multi-party sign-off.
+mode: 2
+order: 10
+---
+
+# IoT device attestation
+
+IoT deployments face two structural security problems: firmware
+updates must be signed by someone the devices trust, and device
+identity must be attestable to relying parties. Both today rely on
+single-key signing operations that, if compromised, allow an
+attacker to push malicious firmware to millions of devices or
+impersonate any device.
+
+Confium replaces single-key firmware signing with threshold signing:
+T-of-N authorized signers (engineering, security, operations) must
+co-sign each release. Device identity attestation uses threshold
+signing per device-batch.
+
+## When to choose this use case
+
+- You ship firmware to embedded devices at scale (consumer electronics,
+  industrial sensors, automotive ECUs, medical devices).
+- A compromised signing key would let an attacker push malicious
+  firmware to your entire fleet.
+- You need defense in depth: a single rogue employee or compromised
+  build server should not be enough to ship signed firmware.
+- Your device identity attestation must be verifiable by third parties
+  (service providers, regulators) without trusting you alone.
+
+## How Confium solves it
+
+### Firmware signing
+
+Each firmware release goes through:
+
+1. Build produces a binary; its hash is computed.
+2. Hash is submitted to the Confium coordinator with a policy like
+   "2-of-3 engineering + 1-of-2 security".
+3. Authorized signers review and approve (or reject).
+4. Coordinator combines approvals into a single signature.
+5. Firmware + signature + transparency log proof published.
+
+Devices verify the signature against a threshold-attested root key
+before applying the update.
+
+### Device identity attestation
+
+Each device (or device batch) gets a threshold-signed identity
+certificate. The certificate's signing key is split across the
+manufacturer, an independent lab, and optionally a regulator.
+No single party can issue device certificates alone.
+
+```
+[ Device manufacturing line ]
+       |
+       | request identity cert (with device-unique public key)
+       v
+[ Coordinator ]
+   |          |          |
+   v          v          v
+[Manufacturer][Lab]  [Regulator]
+   |          |          |
+   +-- T-of-N quorum ----+
+              |
+                   v
+   [ Device identity certificate (standard X.509) ]
+              |
+                   v
+   [ Embedded in device; presented to relying parties ]
+```
+
+## Code sketch
+
+Sign a firmware release:
+
+```rust
+use confium_composite::CompositeSignature;
+use confium_tc_frost_p256::FrostP256;
+
+let fw_hash = sha256(firmware_bytes);
+
+let session = Coordinator::start_session(
+    message: &fw_hash,
+    algorithm: "ECDSA-P256",
+    quorum: QuorumPolicy {
+        threshold: 3,
+        attributes: Attributes::from([
+            ("engineering", 2),
+            ("security", 1),
+        ]),
+    },
+)?;
+
+// Signers review the firmware hash and approve.
+let final_sig = session.wait_for_completion()?;
+
+// Embed final_sig in the firmware manifest. Devices verify before update.
+```
+
+## Long-lived firmware
+
+IoT firmware in the field can run unchanged for 5–10 years (or
+longer for industrial / medical devices). Signatures on that
+firmware must remain verifiable for the device's entire lifespan.
+Composite signatures with a PQ component ensure that even after
+quantum computers break the classical algorithm, the firmware
+still verifies.
+
+## Supply-chain provenance
+
+Every firmware release and every device certificate anchors into a
+transparency log. Relying parties (other devices, cloud services,
+regulators) can independently verify the full history:
+
+- Which firmware was released, when, by whom.
+- Which devices were issued certificates, when, by which
+  manufacturing line.
+- Whether any firmware release was ever revoked.
+
+See [supply-chain provenance](/use-cases/supply-chain/) for the
+broader pattern.
+
+## See also
+
+- [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)
+- [Code signing use case](/use-cases/code-signing/)
+- [Supply-chain provenance](/use-cases/supply-chain/)
+- [PQ migration](/use-cases/pq-migration/)

--- a/src/content/use_cases/long-term-archival.mdx
+++ b/src/content/use_cases/long-term-archival.mdx
@@ -1,0 +1,160 @@
+---
+title: Long-term archival
+description: RFC 4998 Evidence Record Syntax with multi-stakeholder governance and OTS Bitcoin anchoring. Signatures verifiable for centuries.
+mode: 3
+order: 16
+---
+
+import KeyLifecycleDiagram from '../../components/brand/KeyLifecycleDiagram.astro';
+
+# Long-term archival
+
+Some signatures must remain verifiable for decades or centuries:
+government records, patent filings, court evidence, archival
+scientific data, treaty documents, mortgage filings. The
+challenge: every cryptographic algorithm has a finite expected
+lifetime. SHA-1 is broken; SHA-256 will eventually be broken;
+RSA and ECDSA will fall to quantum computers. How do you keep
+signatures verifiable across algorithm generations?
+
+Confium's answer combines three layers:
+
+1. **RFC 4998 Evidence Record Syntax (ERS)** — periodically
+   re-timestamp evidence with current algorithms.
+2. **Composite signatures** — include both classical and PQ
+   components from day one.
+3. **OTS anchoring** — irrefutable time proof via Bitcoin.
+
+## When to choose this use case
+
+- You maintain records that must remain verifiable for 25+ years
+  (regulatory archive, treaty documents, scientific data).
+- You're operating a sovereign archive (national archives, patent
+  offices, court systems).
+- You need to migrate archives as algorithms age without breaking
+  existing verifications.
+- You want irrefutable time proof that survives institutional /
+  jurisdictional change.
+
+## How Confium solves it
+
+<KeyLifecycleDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+A long-term archival deployment maintains evidence records that
+outlive any individual signing key. The lifecycle:
+
+1. **Original signature** at time T₀ with algorithm A (e.g.
+   Ed25519 + ML-DSA-65 composite).
+2. **Archival timestamps** at T₀, T₁, T₂, ... via RFC 3161 TSA.
+3. **Algorithm renewal**: when algorithm A is deprecated, the
+   archive re-timestamps all evidence with algorithm B (the new
+   standard). The original signature remains valid because we
+   can prove it existed before A was broken.
+4. **OTS anchoring** at every renewal: Bitcoin proof that the
+   re-timestamp happened at a specific time.
+
+## RFC 4998 Evidence Record
+
+The Evidence Record wraps the original signature with a chain
+of archival timestamps:
+
+```
+EvidenceRecord ::= SEQUENCE {
+    version                   INTEGER { v1(1) },
+    digestAlgorithms          SEQUENCE OF AlgorithmIdentifier,
+    cryptoInfos               [0] SEQUENCE OF CryptoInfo OPTIONAL,
+    encryptionInfo            [1] EncryptionInfo OPTIONAL,
+    archiveTimeStampSequence  ArchiveTimeStampSequence
+}
+
+ArchiveTimeStampSequence ::= SEQUENCE OF ArchiveTimeStampChain
+```
+
+Each `ArchiveTimeStampChain` covers a period; chains chain together
+to form the full evidence record. When the current chain's
+algorithm gets old, a new chain is added with the new algorithm.
+
+## Composite signatures from day one
+
+For new archival records, Confium produces composite signatures
+containing both classical (Ed25519, ECDSA-P256) and post-quantum
+(ML-DSA-65) components. Today both verify; tomorrow when classical
+falls to quantum, the PQ component still holds. No algorithm
+renewal needed for the quantum transition.
+
+## OTS anchoring
+
+For the strongest time proof, every archival batch anchors in
+Bitcoin:
+
+```ruby
+batch_root = Confium::Transparency.compute_root(recent_archives)
+
+ots_proof = Confium::OTS.submit(
+  hash: batch_root,
+  calendar: "https://btc.calendar.confium.org",
+)
+
+# Store the OTS proof alongside the archive. Future verifiers can
+# independently prove the batch existed at Bitcoin block height N.
+archive_record.attach_ots_proof(ots_proof)
+```
+
+Bitcoin's proof-of-work chain provides irrefutable time proof
+that survives institutional collapse, jurisdictional change, or
+even the dissolution of the issuing organization.
+
+## Algorithm renewal
+
+When an algorithm gets deprecated (e.g. SHA-1 was deprecated in
+2017, RSA-1024 in 2010):
+
+1. The archive computes a new hash of every record using the new
+   algorithm (SHA-384, SHA-512, or future hash).
+2. Each new hash is timestamped by the TSA.
+3. The timestamp is itself anchored in Bitcoin.
+4. The evidence record is extended with a new ArchiveTimeStampChain.
+
+The original record remains verifiable because we can prove:
+"At time T₀, this record existed with hash H using algorithm A.
+At time T_n, we renewed to hash H' using algorithm A'. The
+chain of custody is intact."
+
+## Sovereign archive example
+
+A national archive deploying Confium might configure:
+
+```toml
+[archive]
+backend = "lmdb"
+path = "/var/lib/confium/archive"
+
+[archive.signing]
+algorithm = "composite"
+components = ["ECDSA-P384", "Ed25519", "ML-DSA-65"]
+require_pq_component = true
+
+[archive.timestamping]
+tsa_endpoint = "tsa://tsa.confium.org"
+renewal_interval_days = 365
+hash_algorithm_future = "SHA-512"  # used at next renewal
+
+[archive.anchoring]
+ots_calendar = "https://btc.calendar.confium.org"
+anchor_interval_hours = 1
+
+[archive.quorum]
+threshold = 3
+total = 5
+attributes = { "archivist" => 2, "oversight" => 2, "regulator" => 1 }
+```
+
+Every archival event requires T-of-N quorum; every event anchors
+in transparency log + OTS.
+
+## See also
+
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Timestamping service use case](/use-cases/timestamping/)
+- [Compliance officer guide](/audiences/compliance/)
+- [PQ migration](/docs/pq-migration/)

--- a/src/content/use_cases/timestamping.mdx
+++ b/src/content/use_cases/timestamping.mdx
@@ -1,0 +1,143 @@
+---
+title: Timestamping service
+description: RFC 3161 timestamp authority with multi-stakeholder governance. No single operator can backdate or omit timestamps.
+mode: 3
+order: 15
+---
+
+import SplitViewAttackDiagram from '../../components/brand/SplitViewAttackDiagram.astro';
+
+# Timestamping service
+
+A timestamp authority (TSA) provides cryptographic proof that a
+given document existed at a specific time. The standard is RFC 3161,
+widely used in legal filings, patent applications, code signing,
+and long-term archival. Today's TSAs are operated by single
+organizations (Symantec/DigiCert, Sectigo, free services like
+Google's) which means the operator is trusted not to backdate or
+omit timestamps.
+
+Confium replaces this with a threshold-operated TSA: T-of-N
+servers run by independent operators must cooperate to issue a
+timestamp token. No single operator can backdate or selectively
+omit.
+
+## When to choose this use case
+
+- You operate a timestamp service and want to eliminate the single-
+  operator trust model.
+- You're building a consortium TSA where multiple organizations
+  (e.g. a standards body) cooperatively provide the service.
+- You want timestamps anchored in a public medium (Bitcoin via OTS)
+  for irrefutable time proof.
+- You're deploying a sovereign timestamp infrastructure for legal /
+  regulatory use (e.g. patent filing, court evidence).
+
+## How Confium solves it
+
+A threshold TSA deployment has:
+
+- **Multiple TSA servers** operated by independent organizations.
+- **Threshold key** split across the servers; T-of-N required per
+  timestamp.
+- **RFC 3161 compliant output**: standard TimeStampResp tokens
+  that any RFC 3161 client accepts.
+- **Transparency log** recording every issued timestamp.
+- **OTS anchoring** in Bitcoin for defense in depth.
+
+<SplitViewAttackDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The split-view attack on the left is exactly what a threshold TSA
+defeats. Without witness gossip and OTS anchoring, a single
+operator can present different timestamp histories to different
+verifiers. With Confium's three-layer defense, the attack
+collapses.
+
+## RFC 3161 compliance
+
+The output is a standard TimeStampResp:
+
+```
+TimeStampResp ::= SEQUENCE {
+    status                  PKIStatusInfo,
+    timeStampToken          TimeStampToken OPTIONAL
+}
+
+TimeStampToken ::= ContentInfo
+    -- contentType = id-signedData
+    -- content = SignedData
+    -- eContent = TSTInfo
+```
+
+The TSTInfo contains the message imprint (hash of the document
+being timestamped), the TSA's serial number, the time of
+timestamping, and policy information. The signature is produced
+by a Confium threshold signing session.
+
+## Client-side usage
+
+Standard RFC 3161 clients work unchanged. For example, with
+OpenSSL:
+
+```sh
+# Submit a hash to the TSA; get a timestamp token back.
+echo -n "data to timestamp" | openssl dgst -sha256 -binary \
+  | openssl ts -query -digest -sha256 -data - \
+  | curl -sS -H "Content-Type: application/timestamp-query" \
+         --data-binary @- \
+         https://tsa.confium.org/ \
+  > response.tsr
+
+# Verify the token against the TSA's certificate chain.
+openssl ts -verify -in response.tsr \
+  -queryfile query.tsq \
+  -CAfile tsa-ca.pem \
+  -untrusted tsa-cert.pem
+```
+
+The client sees a standard RFC 3161 TSA. It doesn't know the
+backend is threshold.
+
+## OTS anchoring
+
+For the strongest time proof, Confium anchors every batch of
+timestamps in Bitcoin via OpenTimestamps:
+
+1. Every hour (configurable), the TSA computes the Merkle root
+   of all timestamps issued in that period.
+2. The root hash is submitted to OpenTimestamps.
+3. OTS anchors the hash in a Bitcoin transaction (within ~10
+   minutes to a few hours).
+4. The OTS proof is stored alongside the timestamp.
+
+A verifier can independently prove: "this timestamp existed at
+Bitcoin block height N, which occurred at YYYY-MM-DD HH:MM:SS UTC".
+
+## Use cases
+
+- **Patent filing**: Prior art evidence. A threshold TSA operated
+  by a patent office consortium (USPTO, EPO, JPO) plus an
+  independent standards body.
+- **Court evidence**: Legal filings. Threshold TSA + OTS anchoring
+  for irrefutable time proof.
+- **Code signing**: Sigstore-style timestamping of release
+  signatures. Threshold operation eliminates the single-TSA trust.
+- **Long-term archival**: Re-timestamping as algorithms evolve
+  (RFC 4998 ERS).
+
+## Standards mapping
+
+- **RFC 3161**: Time-Stamp Protocol (TSP). Confium produces standard
+  TimeStampResp tokens.
+- **RFC 4998**: Evidence Record Syntax (ERS). Long-term archival
+  with periodic re-timestamping.
+- **RFC 6962**: Certificate Transparency. Used internally for the
+  TSA's transparency log.
+- **OpenTimestamps**: Bitcoin anchoring for irrefutable time proof.
+
+## See also
+
+- [Transparency logs concept](/concepts/transparency-logs/)
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/)
+- [Long-term archival use case](/use-cases/long-term-archival/)
+- [Architecture](/docs/architecture/)

--- a/src/content/use_cases/web3-custody.mdx
+++ b/src/content/use_cases/web3-custody.mdx
@@ -1,0 +1,120 @@
+---
+title: Web3 custody
+description: Multi-party computation wallets and threshold key custody for blockchain applications. No single party holds the wallet key.
+mode: 1
+order: 9
+---
+
+# Web3 custody
+
+Cryptocurrency wallets, DeFi protocol keys, and NFT marketplace
+custody all share a structural problem: whoever holds the private
+key holds the funds. Single-key custody is a known operational risk;
+multi-sig smart contracts help but are chain-specific and add
+on-chain overhead. Threshold cryptography gives you chain-agnostic
+multi-party custody with off-chain coordination.
+
+## When to choose this use case
+
+- You operate a cryptocurrency exchange, custody service, or wallet
+  infrastructure.
+- You need institutional-grade custody with no single point of
+  compromise.
+- You want to enforce multi-stakeholder approval for high-value
+  transactions (withdrawals, treasury moves, governance votes).
+- You need cross-chain custody without deploying separate multi-sig
+  contracts on each chain.
+
+## How Confium solves it
+
+A threshold ECDSA key (P-256 or secp256k1) is split across N
+custody parties. Each party runs a Confium signer process holding
+one share. To authorize a transaction:
+
+1. The wallet front-end submits the transaction hash to the
+   coordinator.
+2. The coordinator collects partial signatures from T-of-N custody
+   parties.
+3. The final signature is broadcast to the chain as a standard
+   transaction.
+
+The chain sees a normal ECDSA signature. No multi-sig contract
+needed; no on-chain overhead; no protocol change.
+
+## Architecture
+
+```
+[ Wallet front-end ]
+       |
+       | submit tx hash + policy
+       v
+[ Coordinator ] ---------------------------+
+   |          |          |                 |
+   v          v          v                 v
+[Custody 1][Custody 2][Custody 3]    [Custody N]
+   |          |          |                 |
+   +----------+---- T-of-N quorum --------+
+                       |
+                       v
+              [ Standard ECDSA signature ]
+                       |
+                       v
+              [ Broadcast to chain ]
+                       |
+                       v
+              [ Transparency log anchors event ]
+```
+
+## Attribute-based policy
+
+Real custody operations have nuanced policies. The Confium predicate
+DSL expresses them:
+
+```
+2-of-3 user devices
+  for transactions under $1,000
+
+3-of-5 security staff
+  for transactions $1,000 – $100,000
+
+5-of-7 board members
+  for transactions over $100,000
+
+7-of-9 (board + custody + auditor)
+  for cold-storage withdrawals
+```
+
+The coordinator evaluates the predicate per transaction.
+
+## Cross-chain
+
+The same threshold key infrastructure works for:
+
+- Bitcoin (ECDSA over secp256k1)
+- Ethereum (ECDSA over secp256k1)
+- Solana (Ed25519)
+- Aptos / Sui (Ed25519 / ECDSA)
+- Cardano (Ed25519)
+
+One custody stack, many chains.
+
+## HSM integration
+
+For the highest-assurance deployments, each custody share can be
+stored in a hardware HSM accessed via PKCS#11. Confium's
+`confium-store-pkcs11` backend wraps the HSM access; the share
+never leaves the HSM in plaintext.
+
+## Audit and compliance
+
+Every transaction is anchored in the transparency log. SIEM
+integration via structured JSON audit records supports
+SOC 2, NYDFS BitLicense (for US crypto businesses), and the EU's
+Markets in Crypto-Assets Regulation (MiCA).
+
+## See also
+
+- [Mode 1 — Peer-to-Peer TC](/docs/mode1-peer-tc/)
+- [Distributed custody use case](/use-cases/distributed-custody/)
+- [Attribute-based threshold concept](/concepts/attribute-based-threshold/)
+- [Compliance officer guide](/audiences/compliance/)

--- a/src/pages/audiences/contributors.astro
+++ b/src/pages/audiences/contributors.astro
@@ -1,0 +1,182 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import ArchitectureStackDiagram from '../../components/brand/ArchitectureStackDiagram.astro';
+---
+
+<BaseLayout
+  title="For contributors"
+  description="How to contribute to Confium: code, docs, design, security research. Open-source workflow, coding standards, plugin authoring."
+>
+  <PageHero
+    eyebrow="For contributors"
+    title="Help build Confium"
+    description="Confium is developed in the open. Code, documentation, design feedback, plugin authorship, and security research all welcome. This page covers where to start and what each contribution path looks like."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>Where to start</h2>
+      <p>
+        Pick a path that matches your skills and time:
+      </p>
+      <ul>
+        <li><strong>Code</strong> — Rust workspace, Ruby gem, or WASM package. <a href="https://github.com/confium/confium/labels/good%20first%20issue">good first issue</a> is the entry point.</li>
+        <li><strong>Documentation</strong> — these very pages. Every page has a "Edit this page" link.</li>
+        <li><strong>Design</strong> — SVG diagrams, UX patterns, accessibility review.</li>
+        <li><strong>Plugin authorship</strong> — write a Confium plugin for an algorithm or backend we don't ship.</li>
+        <li><strong>Security research</strong> — review the cryptography, the protocol implementations, the audit trail.</li>
+        <li><strong>Translation / localization</strong> — the site and the docs are English-first today.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Architecture overview</h2>
+      <p>
+        Before contributing code, you'll want a mental model of the
+        layered architecture. The diagram below shows how consumers,
+        adapters, the engine, plugins, and hardware stack.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <ArchitectureStackDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Development workflow</h2>
+      <p>
+        The Rust workspace uses Nix flakes for reproducibility:
+      </p>
+      <pre><code class="language-sh">git clone https://github.com/confium/confium.git
+cd confium
+nix develop              # reproducible dev shell
+cargo build --workspace  # build all 43 crates
+cargo test --workspace   # full test suite
+cargo clippy --workspace --all-targets -- -D warnings</code></pre>
+      <p>
+        Without Nix, install Rust stable 1.85+ via <a href="https://rustup.rs/">rustup</a>
+        and run the cargo commands directly.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Coding standards</h2>
+      <p>
+        Every crate in the workspace follows:
+      </p>
+      <ul>
+        <li><code>#![forbid(unsafe_code)]</code> — no unsafe Rust, period.</li>
+        <li><code>#![warn(missing_docs)]</code> — every public item documented.</li>
+        <li><code>thiserror</code> for typed errors (or <code>snafu</code> 0.8 in legacy crates).</li>
+        <li>Conventional commits (<code>feat:</code>, <code>fix:</code>, <code>docs:</code>, etc.) driving release-plz.</li>
+        <li>Tests use real instances; no <code>double()</code>-style mocks.</li>
+      </ul>
+      <p>
+        See <a href="/docs/architecture/">the architecture page</a> and the per-crate READMEs for the specific trait / error patterns.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Plugin authoring</h2>
+      <p>
+        Writing a Confium plugin lets you expose a new cryptographic
+        algorithm, key format, or backend to every consumer that
+        uses the engine. The plugin contract is a small set of
+        bootstrap symbols (<code>cfmp_interface_version</code>,
+        <code>cfmp_initialize</code>, <code>cfmp_query_interfaces</code>,
+        etc.) plus per-interface implementation functions.
+      </p>
+      <pre><code class="language-sh">cargo new --lib my-plugin
+cd my-plugin
+
+# Cargo.toml: crate-type = ["cdylib"]
+# Add deps: confium-api, confium-macros
+
+# Then implement via #[confium_plugin] and #[confium_interface]</code></pre>
+      <p>
+        The full walkthrough is in the
+        <a href="https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx">plugin author guide</a>
+        in the Rust workspace docs.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Documentation contributions</h2>
+      <p>
+        The website source lives at
+        <a href="https://github.com/confium/confium.github.io">confium/confium.github.io</a>.
+        Content is plain Markdown (.md) or Astro (.astro) — MDX was
+        considered but removed due to Astro 7 / rolldown-vite
+        interop issues.
+      </p>
+      <p>
+        Content rules:
+      </p>
+      <ul>
+        <li>No mention of the international metrology organization (CI gate).</li>
+        <li>No "TODO", "coming soon", "planned", "milestone", "roadmap" language (CI gate).</li>
+        <li>CNML is allowed as one example among many; never the sole reference.</li>
+        <li>Every page should explain <em>how things work</em>, not just <em>what they are</em>.</li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Design contributions</h2>
+      <p>
+        The site uses RNP's design language (sister project at
+        <a href="https://www.rnpgp.org">rnpgp.org</a>): blue/teal/gold
+        palette, IBM Plex typography, dual-token CSS variables for
+        light/dark mode, generous SVG diagrams.
+      </p>
+      <p>
+        SVG diagram components live in
+        <a href="https://github.com/confium/confium.github.io/tree/main/src/components/brand">src/components/brand/</a>.
+        They're Astro components that emit inline SVG with consistent
+        color palette and typography. New diagrams welcome.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Security research</h2>
+      <p>
+        Cryptographic code review is one of the highest-value
+        contributions you can make. We're especially interested in:
+      </p>
+      <ul>
+        <li>Constant-time analysis of the threshold protocols.</li>
+        <li>Side-channel analysis (timing, memory, power).</li>
+        <li>Protocol-level analysis of FROST, CMP20, GG18 implementations.</li>
+        <li>Transparency log analysis (split-view, gossip, OTS).</li>
+        <li>Plugin sandbox analysis (untrusted plugin isolation).</li>
+      </ul>
+      <p>
+        For responsible disclosure of vulnerabilities, see
+        <a href="/security/">the security page</a>. Do not open public
+        issues for security problems.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Code of conduct</h2>
+      <p>
+        The project follows the
+        <a href="https://contributor-covenant.org/version/2/1/code_of_conduct/">Contributor Covenant 2.1</a>.
+        Reports go to <code>conduct@confium.org</code>.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="https://github.com/confium/confium">Rust workspace</a> — start with good-first-issues.</li>
+        <li><a href="https://github.com/confium/confium-ruby">Ruby gem</a> — wrapper contributions.</li>
+        <li><a href="/docs/architecture/">Architecture</a> — understand the engine before contributing code.</li>
+        <li><a href="/audiences/developers/">Developer guide</a> — for using Confium (different from contributing).</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/ctos.astro
+++ b/src/pages/audiences/ctos.astro
@@ -1,0 +1,216 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+import ThreeModeDiagram from '../../components/brand/ThreeModeDiagram.astro';
+import PQMigrationTimelineDiagram from '../../components/brand/PQMigrationTimelineDiagram.astro';
+---
+
+<BaseLayout
+  title="For CTOs"
+  description="Strategic and technical overview for CTOs and engineering directors. Vendor independence, PQ readiness, team adoption, and risk posture."
+>
+  <PageHero
+    eyebrow="For CTOs"
+    title="Strategic adoption of threshold trust"
+    description="As a CTO or engineering director, you need to evaluate Confium on three axes: does it solve a real problem for your organization, is it safe to adopt, and what's the team investment. This page covers all three."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>The strategic case in two paragraphs</h2>
+      <p>
+        Single-key PKI is the trust infrastructure for most of the
+        internet. It works because we trust the operators. But
+        trust-based systems fail when the operator is compromised,
+        goes rogue, or makes an error. DigiNotar, Symantec, and
+        Let's Encrypt each had incidents that cost millions and
+        eroded public trust. The pattern is structural: as long as
+        one party holds the key, that party is the single point of
+        failure.
+      </p>
+      <p>
+        Confium eliminates the single point of failure structurally.
+        Threshold cryptography means no single party holds the
+        signing key; a configurable quorum must participate. This
+        is the same architectural shift that took us from "the
+        database is the system of record" to "consensus across
+        replicas is the system of record". The math is proven; the
+        protocols are published; the implementations are open
+        source. What was missing was a framework that made this
+        deployable in real PKI settings — Confium is that framework.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Three modes, one engine</h2>
+      <p>
+        Confium is layered across three deployment modes. The same
+        engine and the same primitives serve all three. Your
+        organization might use Mode 2 internally (migrate an
+        existing PKI consumer) and Mode 3 externally (deploy a
+        sovereign institutional PKI).
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <ThreeModeDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Why now</h2>
+      <p>
+        Three forces make this the right time to evaluate threshold
+        trust infrastructure:
+      </p>
+      <ol>
+        <li>
+          <strong>Post-quantum migration.</strong> NIST has
+          standardized ML-DSA (FIPS 204) and ML-KEM (FIPS 203).
+          Migration is no longer theoretical. Composite signatures
+          (classical + PQ) let you migrate without a flag day, but
+          only if your infrastructure can produce and verify them.
+          Confium is built around composite signatures.
+        </li>
+        <li>
+          <strong>Regulatory pressure on auditability.</strong>
+          SOX, eIDAS, FedRAMP, HIPAA, MiCA — every major regulatory
+          framework now demands audit trails that don't rely on
+          the operator's word. Transparency logs (RFC 6962) provide
+          cryptographic auditability. Confium has this built in.
+        </li>
+        <li>
+          <strong>Single-key incidents are accelerating.</strong>
+          DigiNotar (2011), Symantec (2015–2018), Let's Encrypt
+          (2020), and many unreported near-misses. The cost per
+          incident: $10M+ in direct response, plus reputational
+          damage. Threshold governance is the structural fix.
+        </li>
+      </ol>
+    </Reveal>
+
+    <Reveal>
+      <h2>PQ migration timeline</h2>
+      <p>
+        The composite-signature migration path lets you adopt PQ
+        incrementally. Today you can emit signatures that include
+        both classical and PQ components; legacy verifiers still
+        accept via the classical component, upgraded verifiers
+        check both. When classical algorithms break, the PQ
+        component holds. No flag day, no forklift upgrade.
+      </p>
+    </Reveal>
+
+    <Reveal delayMs={80}>
+      <div class="not-prose my-8">
+        <PQMigrationTimelineDiagram class="w-full max-w-2xl mx-auto" />
+      </div>
+    </Reveal>
+
+    <Reveal>
+      <h2>Vendor independence</h2>
+      <p>
+        Confium is BSD-2-Clause open source. There is no CLA, no
+        proprietary fork, no "open-core" upsell. The funding model
+        (NLnet NGI Zero PET + Mozilla MOSS) does not direct the
+        technical roadmap. If you deploy Confium today and decide
+        to fork it tomorrow, you have every right and every
+        technical capability to do so.
+      </p>
+      <p>
+        This matters strategically: threshold trust infrastructure
+        is the kind of thing you don't want to outsource. It's the
+        spine of your signing operations for decades. Owning your
+        deployment (or having the option to) is essential.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Team investment</h2>
+      <p>
+        Realistic team investment for a production deployment:
+      </p>
+      <table>
+        <thead>
+          <tr><th>Phase</th><th>Team</th><th>Duration</th><th>Outcome</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Evaluation</td>
+            <td>1 architect + 1 security engineer</td>
+            <td>2–4 weeks</td>
+            <td>Decision document + threat model.</td>
+          </tr>
+          <tr>
+            <td>Pilot</td>
+            <td>2–3 engineers</td>
+            <td>4–8 weeks</td>
+            <td>Working deployment in a non-production environment.</td>
+          </tr>
+          <tr>
+            <td>Production cutover</td>
+            <td>3–5 engineers + ops</td>
+            <td>3–6 months</td>
+            <td>Live traffic, monitoring, runbooks.</td>
+          </tr>
+          <tr>
+            <td>Ongoing operations</td>
+            <td>1–2 SREs part-time</td>
+            <td>continuous</td>
+            <td>Same cost as running a conventional CA.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        For Mode 2 (PKI drop-in), the cutover is significantly
+        faster because the consumer code stays unchanged. For
+        Mode 3 (Sovereign PKI), expect longer timelines due to
+        certificate profile design and policy work.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Risk posture</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Framework abandonment (Confium project ends)</td>
+            <td>BSD-2-Clause license + open source = the code remains usable indefinitely. Funded by NLnet / Mozilla = not dependent on a single commercial entity.</td>
+          </tr>
+          <tr>
+            <td>Protocol-level vulnerability (FROST, CMP20, etc.)</td>
+            <td>Protocols are published and peer-reviewed. Multiple protocols available; switch if one is broken.</td>
+          </tr>
+          <tr>
+            <td>Operational complexity</td>
+            <td>Coordinator is a single service; signers are processes; transparency log is a service. Standard ops.</td>
+          </tr>
+          <tr>
+            <td>Talent availability</td>
+            <td>Threshold cryptography is a niche today; growing. The Confium team and Discord are the support network.</td>
+          </tr>
+          <tr>
+            <td>Performance overhead</td>
+            <td>~5× signing latency vs single-key; zero verification overhead (signatures are standard).</td>
+          </tr>
+        </tbody>
+      </table>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/audiences/executives/">Executive guide</a> — for the business-case framing to share with peers.</li>
+        <li><a href="/audiences/architects/">Architect guide</a> — for your security architect's deep dive.</li>
+        <li><a href="/docs/comparison/">Comparison</a> — Confium vs HSM, CA, KMS, Sigstore, commercial threshold.</li>
+        <li><a href="/docs/three-modes/">Three modes</a> — pick the integration shape.</li>
+        <li><a href="/funding/">Funding</a> — who pays for Confium.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>

--- a/src/pages/audiences/index.astro
+++ b/src/pages/audiences/index.astro
@@ -89,6 +89,48 @@ const audiences = [
     href: '/audiences/evaluators/',
     accent: 'gold',
   },
+  {
+    id: 'ctos',
+    name: 'CTOs and engineering directors',
+    tagline: 'Strategic adoption and risk posture',
+    description: 'You\'re making the organizational adoption decision. You need strategic framing, vendor-independence analysis, team investment estimates, and a risk table.',
+    questions: [
+      'Why now?',
+      'What\'s the team investment?',
+      'What if the project is abandoned?',
+      'How does this compare to commercial alternatives?',
+    ],
+    href: '/audiences/ctos/',
+    accent: 'blue',
+  },
+  {
+    id: 'product-managers',
+    name: 'Product managers',
+    tagline: 'Scoping threshold-trust features',
+    description: 'You\'re scoping a threshold-trust feature for your product roadmap. You need to identify the trust boundary, map stakeholders, plan integration timelines, and craft customer-facing value props.',
+    questions: [
+      'What does this look like as a product feature?',
+      'How long does integration take?',
+      'How do I communicate the value?',
+      'What are the common PM pitfalls?',
+    ],
+    href: '/audiences/product-managers/',
+    accent: 'teal',
+  },
+  {
+    id: 'contributors',
+    name: 'Open source contributors',
+    tagline: 'Code, docs, plugins, security research',
+    description: 'You\'re contributing to Confium itself. You need the development workflow, coding standards, plugin author guide, and contribution paths for code, docs, design, and security research.',
+    questions: [
+      'Where do I start?',
+      'What are the coding standards?',
+      'How do I write a plugin?',
+      'How do I report a security issue?',
+    ],
+    href: '/audiences/contributors/',
+    accent: 'gold',
+  },
 ];
 ---
 

--- a/src/pages/audiences/product-managers.astro
+++ b/src/pages/audiences/product-managers.astro
@@ -1,0 +1,206 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/astro/PageHero.astro';
+import Reveal from '../../components/vue/Reveal.vue';
+---
+
+<BaseLayout
+  title="For product managers"
+  description="PM-focused view: what features Confium unlocks, integration timelines, and how to scope a threshold-trust feature for your roadmap."
+>
+  <PageHero
+    eyebrow="For product managers"
+    title="Scope threshold-trust features"
+    description="Adding threshold governance to a product is a feature decision with technical, compliance, and UX implications. This page helps you scope it, plan the integration, and communicate the value."
+  />
+
+  <div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20 prose dark:prose-invert">
+    <Reveal>
+      <h2>What "Confium" means for a product</h2>
+      <p>
+        For most products, Confium shows up as one of three feature
+        shapes:
+      </p>
+      <ol>
+        <li>
+          <strong>Multi-stakeholder approvals.</strong> Your product
+          already has approval workflows (release approvals, expense
+          approvals, contract sign-off). Today these are recorded in
+          a database. With Confium they become cryptographically
+          attributable — the approval chain is tamper-evident.
+        </li>
+        <li>
+          <strong>Threshold key custody.</strong> Your product
+          manages keys on behalf of users (cryptocurrency wallets,
+          document signing services, identity providers). Today
+          these are single-key in an HSM or KMS. With Confium
+          they're threshold-split across N parties.
+        </li>
+        <li>
+          <strong>Verifiable audit trail.</strong> Your product
+          must prove to customers / regulators that operations
+          happened when claimed. Today this is operational logs.
+          With Confium this is a transparency log with cryptographic
+          inclusion proofs.
+        </li>
+      </ol>
+    </Reveal>
+
+    <Reveal>
+      <h2>Scoping the integration</h2>
+      <p>
+        Three questions to scope a threshold-trust feature:
+      </p>
+
+      <h3>1. What's the trust boundary?</h3>
+      <p>
+        Identify what currently sits behind a single trusted
+        operator. Examples:
+      </p>
+      <ul>
+        <li>"Release signing is done by the release manager's GPG key."</li>
+        <li>"API keys are issued by the API team's signing service."</li>
+        <li>"Certifications are issued by the registrar's office."</li>
+        <li>"Customer funds are held by the company's single custody key."</li>
+      </ul>
+      <p>
+        Each of these is a candidate for threshold governance.
+      </p>
+
+      <h3>2. Who are the stakeholders?</h3>
+      <p>
+        Threshold requires identifying the parties who should
+        participate. Examples:
+      </p>
+      <ul>
+        <li>"Release signing: 2-of-3 release engineers + 1-of-2 security."</li>
+        <li>"API key issuance: 1-of-2 platform + 1-of-2 product."</li>
+        <li>"Certifications: 2-of-3 registrar + 1-of-1 department head."</li>
+        <li>"Custody: 3-of-5 custody operators across regions."</li>
+      </ul>
+      <p>
+        Identifying the stakeholders is the policy work; Confium's
+        predicate DSL implements it.
+      </p>
+
+      <h3>3. What's the failure mode if Confium isn't deployed?</h3>
+      <p>
+        Be honest about what happens today if a single key is
+        compromised:
+      </p>
+      <ul>
+        <li>Customer data exposure?</li>
+        <li>Financial loss?</li>
+        <li>Regulatory consequence?</li>
+        <li>Reputational damage?</li>
+      </ul>
+      <p>
+        The cost of the failure mode should justify the integration
+        cost. If the failure mode is minor, threshold governance
+        may not be worth the complexity.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Integration timeline (typical)</h2>
+      <table>
+        <thead>
+          <tr><th>Phase</th><th>Duration</th><th>Engineering cost</th><th>Outcome</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Discovery</td>
+            <td>1–2 weeks</td>
+            <td>0.5 engineers</td>
+            <td>Trust boundary identified; stakeholders mapped.</td>
+          </tr>
+          <tr>
+            <td>Architecture</td>
+            <td>1–2 weeks</td>
+            <td>1 architect + 1 security</td>
+            <td>Deployment topology + threat model.</td>
+          </tr>
+          <tr>
+            <td>Pilot</td>
+            <td>2–4 weeks</td>
+            <td>2 engineers</td>
+            <td>Working in non-prod; verified end-to-end.</td>
+          </tr>
+          <tr>
+            <td>Production cutover</td>
+            <td>2–6 weeks</td>
+            <td>2 engineers + ops</td>
+            <td>Live; monitoring in place; runbooks written.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Total: 6–14 weeks for a focused team. Mode 2 (PKI drop-in)
+        tends to be faster because the consumer code doesn't change.
+      </p>
+    </Reveal>
+
+    <Reveal>
+      <h2>Customer-facing value props</h2>
+      <p>
+        How to communicate threshold-trust features to customers:
+      </p>
+      <ul>
+        <li>
+          <strong>"No single point of compromise."</strong> Easy to
+          understand, true, and differentiating.
+        </li>
+        <li>
+          <strong>"Cryptographic audit trail."</strong> Appeals to
+          compliance-minded customers (regulated industries,
+          enterprise, government).
+        </li>
+        <li>
+          <strong>"Post-quantum ready."</strong> Future-proofing
+          angle; especially valuable for long-lived signatures.
+        </li>
+        <li>
+          <strong>"Open standards."</strong> For customers wary of
+          vendor lock-in.
+        </li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Common PM pitfalls</h2>
+      <ul>
+        <li>
+          <strong>Over-engineering the quorum.</strong> 2-of-3 is
+          often enough; 5-of-9 with cross-region constraints is
+          for high-stakes deployments only.
+        </li>
+        <li>
+          <strong>Skipping the UX for signers.</strong> Signers
+          need a way to review what they're signing. Build a signer
+          UI; don't expect people to blindly sign.
+        </li>
+        <li>
+          <strong>Underestimating operations.</strong> Threshold
+          deployments need monitoring, backup, recovery. Plan for
+          SRE involvement from the start.
+        </li>
+        <li>
+          <strong>Ignoring the long-tail UX.</strong> What happens
+          when a signer is on vacation? When a device is lost?
+          When a signer leaves the company? Build break-glass
+          before you need it.
+        </li>
+      </ul>
+    </Reveal>
+
+    <Reveal>
+      <h2>Where to go next</h2>
+      <ul>
+        <li><a href="/audiences/ctos/">CTO guide</a> — strategic context for the same decision.</li>
+        <li><a href="/audiences/developers/">Developer guide</a> — to hand off to engineering.</li>
+        <li><a href="/use-cases/">Use cases</a> — concrete scenarios to map to your product.</li>
+        <li><a href="/docs/comparison/">Comparison</a> — alternatives if Confium doesn't fit.</li>
+      </ul>
+    </Reveal>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Massive content expansion to address Confium being a heavy system with many scenarios and audiences.

**Use cases (10 new):** document-signing, email-security (S/MIME), web3-custody, iot-attestation, government-identity, healthcare-records, financial-settlement, academic-credentials, timestamping, long-term-archival.

**Audiences (3 new):** ctos (strategic), product-managers (feature scoping), contributors (open source contribution paths). Hub updated to include all three.

**SVG diagrams (4 new):** ArchitectureStackDiagram, KeyLifecycleDiagram, AdapterPatternDiagram, PQMigrationTimelineDiagram.

**Reference docs (2 new):** /docs/faq/ with 30+ common questions across 8 categories, /docs/troubleshooting/ with operational gotchas for Ruby/Rust/WASM/operations/plugin authoring/Astro 7.

**Numbers:** 73 pages indexed (was 58), 3402 Pagefind words (was 2516). Both quality gates pass.
