### PR TITLE
docs(cli): 12-page CLI reference + 2 SVG diagrams

### DIFF
--- a/src/components/brand/CLIArchitectureDiagram.astro
+++ b/src/components/brand/CLIArchitectureDiagram.astro
@@ -1,0 +1,50 @@
+---
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="cli-arch-title" set:html={`
+  <title id="cli-arch-title">CLI dispatches to local plugin store, config store, trust list, and the remote registry.</title>
+
+  <!-- CLI box (center top) -->
+  <rect x="180" y="40" width="120" height="56" rx="10" fill="url(#cli-grad)"/>
+  <defs>
+    <linearGradient id="cli-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+  </defs>
+  <text x="240" y="62" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">CLI</text>
+  <text x="240" y="80" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white" opacity="0.9">confium</text>
+
+  <!-- Four targets -->
+  <g font-family="IBM Plex Sans, sans-serif">
+    <rect x="40" y="170" width="120" height="64" rx="8" fill="white" stroke="#1a7bec" stroke-width="1.5"/>
+    <text x="100" y="194" text-anchor="middle" font-size="11" font-weight="700" fill="#1a7bec">Plugin store</text>
+    <text x="100" y="210" text-anchor="middle" font-size="9" fill="#5f6680">~/.confium/</text>
+    <text x="100" y="222" text-anchor="middle" font-size="9" fill="#5f6680">plugins/</text>
+
+    <rect x="180" y="170" width="120" height="64" rx="8" fill="white" stroke="#00c2c9" stroke-width="1.5"/>
+    <text x="240" y="194" text-anchor="middle" font-size="11" font-weight="700" fill="#009e80">Config store</text>
+    <text x="240" y="210" text-anchor="middle" font-size="9" fill="#5f6680">~/.confium/</text>
+    <text x="240" y="222" text-anchor="middle" font-size="9" fill="#5f6680">config.toml</text>
+
+    <rect x="320" y="170" width="120" height="64" rx="8" fill="white" stroke="#ffdc4a" stroke-width="1.5"/>
+    <text x="380" y="194" text-anchor="middle" font-size="11" font-weight="700" fill="#a07d0a">Trust list</text>
+    <text x="380" y="210" text-anchor="middle" font-size="9" fill="#5f6680">~/.confium/</text>
+    <text x="380" y="222" text-anchor="middle" font-size="9" fill="#5f6680">trust.toml</text>
+  </g>
+
+  <!-- Lines from CLI to local targets -->
+  <line x1="220" y1="96" x2="100" y2="170" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="240" y1="96" x2="240" y2="170" stroke="#00c2c9" stroke-width="1.5"/>
+  <line x1="260" y1="96" x2="380" y2="170" stroke="#ffdc4a" stroke-width="1.5"/>
+
+  <!-- Registry (cloud) -->
+  <ellipse cx="240" cy="300" rx="100" ry="32" fill="#e6f0fe" stroke="#1a7bec" stroke-width="1.5"/>
+  <text x="240" y="298" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="#1a7bec">REGISTRY</text>
+  <text x="240" y="313" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">registry.confium.org</text>
+
+  <line x1="240" y1="96" x2="240" y2="268" stroke="#5f6680" stroke-width="1" stroke-dasharray="4 4"/>
+
+  <text x="240" y="345" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#5f6680">local state + remote registry · no daemon required</text>
+`}/>

--- a/src/components/brand/DaemonArchitectureDiagram.astro
+++ b/src/components/brand/DaemonArchitectureDiagram.astro
@@ -1,0 +1,78 @@
+---
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="daemon-arch-title" set:html={`
+  <title id="daemon-arch-title">confiumd serves JSON-RPC over Unix socket or TCP, dispatching to subsystems.</title>
+
+  <!-- Daemon (center) -->
+  <rect x="170" y="40" width="140" height="60" rx="10" fill="url(#d-grad)"/>
+  <defs>
+    <linearGradient id="d-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+  </defs>
+  <text x="240" y="62" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">DAEMON</text>
+  <text x="240" y="80" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white" opacity="0.9">confiumd · JSON-RPC 2.0</text>
+
+  <!-- Listeners -->
+  <g font-family="IBM Plex Mono, monospace" font-size="10">
+    <rect x="40" y="50" width="100" height="40" rx="6" fill="white" stroke="#1a7bec"/>
+    <text x="90" y="68" text-anchor="middle" fill="#1a7bec" font-weight="700">Unix socket</text>
+    <text x="90" y="82" text-anchor="middle" font-size="8" fill="#5f6680">/var/run/</text>
+    <text x="90" y="92" text-anchor="middle" font-size="8" fill="#5f6680">confium.sock</text>
+
+    <rect x="340" y="50" width="100" height="40" rx="6" fill="white" stroke="#00c2c9"/>
+    <text x="390" y="68" text-anchor="middle" fill="#009e80" font-weight="700">TCP</text>
+    <text x="390" y="82" text-anchor="middle" font-size="8" fill="#5f6680">127.0.0.1:7878</text>
+  </g>
+
+  <line x1="140" y1="70" x2="170" y2="70" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="310" y1="70" x2="340" y2="70" stroke="#00c2c9" stroke-width="1.5"/>
+
+  <!-- Dispatch arrow -->
+  <line x1="240" y1="100" x2="240" y2="140" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- Subsystem boxes -->
+  <g font-family="IBM Plex Sans, sans-serif" font-size="10">
+    <rect x="40" y="160" width="100" height="50" rx="6" fill="white" stroke="#dfe8f2"/>
+    <text x="90" y="180" text-anchor="middle" font-weight="700" fill="#1a7bec">Coordinator</text>
+    <text x="90" y="195" text-anchor="middle" font-size="9" fill="#5f6680">threshold</text>
+    <text x="90" y="205" text-anchor="middle" font-size="9" fill="#5f6680">sessions</text>
+
+    <rect x="155" y="160" width="100" height="50" rx="6" fill="white" stroke="#dfe8f2"/>
+    <text x="205" y="180" text-anchor="middle" font-weight="700" fill="#009e80">Transparency</text>
+    <text x="205" y="195" text-anchor="middle" font-size="9" fill="#5f6680">Merkle log</text>
+    <text x="205" y="205" text-anchor="middle" font-size="9" fill="#5f6680">inclusion proofs</text>
+
+    <rect x="270" y="160" width="100" height="50" rx="6" fill="white" stroke="#dfe8f2"/>
+    <text x="320" y="180" text-anchor="middle" font-weight="700" fill="#a07d0a">PKI</text>
+    <text x="320" y="195" text-anchor="middle" font-size="9" fill="#5f6680">cert verify</text>
+    <text x="320" y="205" text-anchor="middle" font-size="9" fill="#5f6680">path validate</text>
+
+    <rect x="385" y="160" width="60" height="50" rx="6" fill="white" stroke="#dfe8f2"/>
+    <text x="415" y="180" text-anchor="middle" font-weight="700" fill="#5f6680">...</text>
+    <text x="415" y="195" text-anchor="middle" font-size="9" fill="#5f6680">other</text>
+    <text x="415" y="205" text-anchor="middle" font-size="9" fill="#5f6680">subsystems</text>
+  </g>
+
+  <!-- Lines from dispatch to subsystems -->
+  <line x1="240" y1="140" x2="90" y2="160" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="240" y1="140" x2="205" y2="160" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="240" y1="140" x2="320" y2="160" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="240" y1="140" x2="415" y2="160" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+
+  <!-- Plugin layer -->
+  <rect x="40" y="240" width="400" height="40" rx="8" fill="#0f1326"/>
+  <text x="240" y="258" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="#a8aec9" letter-spacing="2">PLUGIN STORE</text>
+  <text x="240" y="272" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#a8aec9">botan · openssl · ring · frost-p256 · cmp20 · ...</text>
+
+  <line x1="90" y1="210" x2="90" y2="240" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="205" y1="210" x2="205" y2="240" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="320" y1="210" x2="320" y2="240" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+  <line x1="415" y1="210" x2="415" y2="240" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+
+  <text x="240" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">long-running service · systemd unit · JSON-RPC clients in any language</text>
+  <text x="240" y="340" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec" letter-spacing="2">STATELESS COORDINATOR · STATE IN TRANSPARENCY LOG</text>
+`}/>

--- a/src/content/docs/cli/config.mdx
+++ b/src/content/docs/cli/config.mdx
@@ -1,0 +1,93 @@
+---
+title: "confium config"
+description: "Read and write local Confium configuration."
+audience: developer
+order: 22
+---
+
+# `confium config`
+
+## Synopsis
+
+```sh
+confium config get <key>
+confium config set <key> <value>
+confium config unset <key>
+confium config list [--json]
+```
+
+## Description
+
+Reads and writes the local configuration file
+(`~/.confium/config.toml`). The configuration controls registry
+URL, plugin directory, log level, and other CLI defaults.
+
+## Subcommands
+
+### `config get`
+
+Reads a single configuration value.
+
+```sh
+$ confium config get registry.url
+https://registry.confium.org
+```
+
+### `config set`
+
+Writes a configuration value.
+
+```sh
+confium config set log.level debug
+```
+
+### `config unset`
+
+Removes a configuration key.
+
+```sh
+confium config unset plugins.dir
+```
+
+### `config list`
+
+Prints the entire configuration as TOML (or JSON with `--json`).
+
+## Configuration keys
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `registry.url` | `https://registry.confium.org` | Plugin registry URL. |
+| `registry.cache_dir` | `~/.confium/cache` | Local cache for downloaded artifacts. |
+| `plugins.dir` | `~/.confium/plugins` | Installed plugin directory. |
+| `log.level` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error`. |
+| `log.file` | `~/.confium/confium.log` | Log file path. |
+
+## Examples
+
+```sh
+# Use a custom registry
+confium config set registry.url https://registry.internal
+
+# Increase verbosity
+confium config set log.level debug
+
+# Move plugin directory
+confium config set plugins.dir /opt/confium/plugins
+
+# Dump configuration as JSON
+confium config list --json
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Key not found (for `get` / `unset`). |
+| 2 | Usage error. |
+
+## See also
+
+- [CLI overview](./)
+- [`confium trust`](./trust/)

--- a/src/content/docs/cli/daemon.mdx
+++ b/src/content/docs/cli/daemon.mdx
@@ -1,0 +1,163 @@
+---
+title: "confiumd"
+description: "The confiumd daemon — long-running JSON-RPC service for signing sessions, transparency log interaction, and PKI operations."
+audience: developer
+order: 23
+---
+
+import DaemonArchitectureDiagram from '../../../components/brand/DaemonArchitectureDiagram.astro';
+
+# `confiumd`
+
+`confiumd` is the long-running service binary. It exposes a JSON-RPC
+API over Unix socket or TCP for signing sessions, transparency log
+interaction, PKI operations, and threshold session orchestration.
+
+## Install
+
+```sh
+cargo install confium-daemon --locked
+```
+
+Or from the workspace:
+
+```sh
+cargo install --path crates/confium-daemon --locked
+```
+
+Verify:
+
+```sh
+$ confiumd --version
+confiumd 0.3.0
+```
+
+## Architecture
+
+<DaemonArchitectureDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The daemon binds to a Unix socket or TCP port and serves JSON-RPC
+requests. Each request is dispatched to the appropriate subsystem
+(coordinator, transparency log, PKI validator, etc.).
+
+## Synopsis
+
+```sh
+confiumd --listen <scheme>://<addr> [--config <path>] [--log-level <level>]
+```
+
+## Examples
+
+```sh
+# Bind to a Unix socket
+confiumd --listen unix:///var/run/confium.sock
+
+# Bind to a TCP port
+confiumd --listen tcp://127.0.0.1:7878
+
+# Bind to all interfaces (use behind a reverse proxy)
+confiumd --listen tcp://0.0.0.0:7878
+
+# Custom config + debug logging
+confiumd --listen unix:///var/run/confium.sock --config /etc/confium/daemon.toml --log-level debug
+```
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--listen <scheme>://<addr>` | Listen address. `unix://` or `tcp://`. |
+| `--config <path>` | Configuration file path. Default: `/etc/confium/daemon.toml`. |
+| `--log-level <level>` | Log level. Default: `info`. |
+| `--plugins-dir <path>` | Override the plugin directory. |
+| `--version` | Print version and exit. |
+
+## Configuration file
+
+`/etc/confium/daemon.toml`:
+
+```toml
+[server]
+listen = "unix:///var/run/confium.sock"
+log_level = "info"
+
+[plugins]
+dir = "/var/lib/confium/plugins"
+
+[coordinator]
+transparency_log = "log:tcp://log.internal:7444"
+default_quorum = { threshold = 3, total = 5 }
+
+[policy]
+fips_mode = false
+allowed_signature_algorithms = ["ECDSA-P256", "Ed25519"]
+```
+
+## JSON-RPC API
+
+The daemon speaks standard JSON-RPC 2.0. Example session:
+
+```sh
+$ echo '{"jsonrpc":"2.0","method":"version","id":1}' | nc -U /var/run/confium.sock
+{"jsonrpc":"2.0","result":{"engine":"0.3.0","daemon":"0.3.0"},"id":1}
+```
+
+Common methods:
+
+| Method | Description |
+| --- | --- |
+| `version` | Engine + daemon versions. |
+| `list_plugins` | Installed plugins (same as `confium list`). |
+| `load_plugin` | Load a plugin by name. |
+| `sign` | Start a signing session. |
+| `verify` | Verify a signature. |
+| `transparency_append` | Append an entry to the log. |
+| `transparency_inclusion_proof` | Get an inclusion proof. |
+
+The full API is documented in the
+[Rust workspace](https://github.com/confium/confium/tree/main/crates/confium-daemon).
+
+## Running as a service
+
+### systemd
+
+`/etc/systemd/system/confiumd.service`:
+
+```ini
+[Unit]
+Description=Confium daemon
+After=network.target
+
+[Service]
+Type=simple
+User=confium
+Group=confium
+ExecStart=/usr/local/bin/confiumd --listen unix:///var/run/confium.sock
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl enable --now confiumd
+```
+
+### Docker
+
+```dockerfile
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY confiumd /usr/local/bin/
+RUN useradd -m confium
+USER confium
+EXPOSE 7878
+ENTRYPOINT ["confiumd", "--listen", "tcp://0.0.0.0:7878"]
+```
+
+## See also
+
+- [CLI overview](./)
+- [`confium-publish`](./publish/)
+- [Operator guide](/audiences/operators/) — production deployment.
+- [Architecture](/docs/architecture/)

--- a/src/content/docs/cli/index.mdx
+++ b/src/content/docs/cli/index.mdx
@@ -1,0 +1,115 @@
+---
+title: "Confium CLI"
+description: "The confium command-line tool — install, manage, and operate Confium plugins, signers, and the local configuration store."
+audience: developer
+order: 13
+---
+
+import CLIArchitectureDiagram from '../../../components/brand/CLIArchitectureDiagram.astro';
+
+# Confium CLI
+
+The `confium` command-line tool is the primary user-facing interface
+to the engine. It manages the local plugin store, the configuration,
+the trusted-publisher list, and the registry client.
+
+## Install
+
+```sh
+cargo install confium-cli --locked
+```
+
+Or, if you have the workspace checked out:
+
+```sh
+cargo install --path crates/confium-cli --locked
+```
+
+Verify:
+
+```sh
+$ confium version
+confium 0.3.0
+```
+
+## Commands
+
+| Command | Status | Description |
+| --- | --- | --- |
+| [`confium version`](./version/) | ✅ functional | Print version information. |
+| [`confium install`](./install/) | ⚠️ stub (awaits `confium-net`) | Install a plugin from the registry. |
+| [`confium remove`](./remove/) | ✅ functional | Remove an installed plugin. |
+| [`confium update`](./update/) | ⚠️ stub (awaits `confium-net`) | Update a plugin to the latest version. |
+| [`confium list`](./list/) | ✅ functional | List installed plugins. |
+| [`confium info`](./info/) | ✅ functional | Show details for one plugin. |
+| [`confium search`](./search/) | ✅ functional | Search the registry for plugins. |
+| [`confium trust`](./trust/) | ✅ functional | Manage the trusted-publisher list. |
+| [`confium config`](./config/) | ✅ functional | Read and write local configuration. |
+
+Two commands (`install`, `update`) are stubs that await the
+`confium-net` HTTP-fetching crate. They parse arguments and emit
+the right shape; the actual download path uses a `NoopDownloader`
+that returns immediately. When `confium-net` lands, the swap is a
+single trait change.
+
+## Architecture
+
+<CLIArchitectureDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+The CLI talks to:
+
+- The **local plugin store** (filesystem under `~/.confium/plugins/`).
+- The **configuration store** (`~/.confium/config.toml`).
+- The **trusted-publisher list** (`~/.confium/trust.toml`).
+- The **plugin registry** (HTTPS to `registry.confium.org`).
+
+For daemon-mode operations (signing sessions, transparency log
+interaction), use the separate [`confiumd`](./daemon/) binary.
+
+## Conventions
+
+All commands:
+
+- Exit `0` on success.
+- Exit `2` on usage error (bad arguments).
+- Exit `1` on operational failure (plugin not found, network error).
+- Print human-readable output to stdout by default.
+- Print machine-readable output to stdout with `--json` where supported.
+
+## Shell completion
+
+Generate completion scripts:
+
+```sh
+confium completion bash > /etc/bash_completion.d/confium
+confium completion zsh > /usr/local/share/zsh/site-functions/_confium
+confium completion fish > ~/.config/fish/completions/confium.fish
+```
+
+## Configuration file
+
+The CLI reads `~/.confium/config.toml`:
+
+```toml
+[registry]
+url = "https://registry.confium.org"
+cache_dir = "~/.confium/cache"
+
+[plugins]
+dir = "~/.confium/plugins"
+
+[log]
+level = "info"   # trace, debug, info, warn, error
+```
+
+Override the location with `--config <path>` or `CONFium_CONFIG`
+environment variable.
+
+## See also
+
+- [`confiumd`](./daemon/) — the daemon binary.
+- [`confium-publish`](./publish/) — the plugin-author tool.
+- [Plugin author guide](https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx)
+  (Rust workspace docs).
+- [Developer guide](/audiences/developers/) — using the CLI in development.
+- [Operator guide](/audiences/operators/) — running the CLI in production.

--- a/src/content/docs/cli/info.mdx
+++ b/src/content/docs/cli/info.mdx
@@ -1,0 +1,77 @@
+---
+title: "confium info"
+description: "Show detailed information about an installed Confium plugin."
+audience: developer
+order: 19
+---
+
+# `confium info`
+
+## Synopsis
+
+```sh
+confium info <plugin>[@version] [--json]
+```
+
+## Description
+
+Prints detailed information about a specific installed plugin:
+metadata (name, version, vendor, license), implemented interfaces
+and their versions, declared dependencies, signing key fingerprint,
+and installation timestamp.
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<plugin>` | Yes | Plugin name with optional `@version`. |
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+confium info botan
+
+# JSON for scripting
+confium info botan --json | jq '.metadata'
+```
+
+## Sample output
+
+```
+Plugin:    botan
+Version:   3.0.0
+Vendor:    Ribose Open
+License:   BSD-2-Clause
+Fingerprint: sha256:9b1d96e3...
+
+Interfaces:
+  hash v0      (SHA-256, SHA-384, SHA-512, SM3)
+  cipher v1    (AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305)
+  signature v0 (Ed25519, ECDSA-P256, ECDSA-P384)
+
+Dependencies:
+  (none)
+
+Installed: 2026-07-28T11:42:13Z
+Source:    registry.confium.org/botan@3.0.0
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Plugin not installed. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium list`](./list/)
+- [`confium trust`](./trust/)
+- [CLI overview](./)

--- a/src/content/docs/cli/install.mdx
+++ b/src/content/docs/cli/install.mdx
@@ -1,0 +1,82 @@
+---
+title: "confium install"
+description: "Install a Confium plugin from the registry. Currently a stub awaiting the confium-net HTTP-fetching crate."
+audience: developer
+order: 15
+---
+
+# `confium install`
+
+## Status: stub
+
+The `install` command parses arguments and dispatches to the
+registry client, but the actual download uses a `NoopDownloader`
+that returns immediately without fetching bytes. Real network
+fetching awaits the `confium-net` HTTP crate. Until then, you can
+install plugins manually:
+
+```sh
+# Manual install:
+cp my-plugin.so ~/.confium/plugins/
+confium trust add --publisher my-publisher-key
+```
+
+## Synopsis
+
+```sh
+confium install <plugin>[@version] [--force] [--no-trust]
+```
+
+## Description
+
+Installs a plugin from the Confium registry to the local plugin
+store (`~/.confium/plugins/`). Resolves the plugin against the
+registry, downloads the artifact, verifies the SHA-256 against
+the manifest's signature, and stages it under the local plugin
+directory.
+
+If the plugin declares dependencies on other providers, those are
+checked at load time and the install fails with a clear error if
+any are unmet.
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<plugin>` | Yes | Plugin name with optional `@version` suffix. Examples: `botan`, `botan@3.0`, `openssl@3.0.8`. |
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--force` | Overwrite if the plugin is already installed. |
+| `--no-trust` | Skip the trusted-publisher check (use with caution). |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+# Install the latest version of the botan plugin
+confium install botan
+
+# Install a specific version
+confium install botan@3.0
+
+# Force reinstall
+confium install botan --force
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Network or verification failure. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium remove`](./remove/)
+- [`confium update`](./update/)
+- [`confium trust`](./trust/)
+- [CLI overview](./)

--- a/src/content/docs/cli/list.mdx
+++ b/src/content/docs/cli/list.mdx
@@ -1,0 +1,64 @@
+---
+title: "confium list"
+description: "List installed Confium plugins, optionally filtered by interface or algorithm."
+audience: developer
+order: 18
+---
+
+# `confium list`
+
+## Synopsis
+
+```sh
+confium list [--interface <name>] [--algorithm <name>] [--json]
+```
+
+## Description
+
+Lists all installed plugins in the local store. Output includes
+the plugin name, version, publisher, and the interfaces it
+implements.
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--interface <name>` | Filter by interface (e.g. `hash`, `signature`, `kem`). |
+| `--algorithm <name>` | Filter by algorithm (e.g. `Ed25519`, `ML-DSA-65`). |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+# List everything
+confium list
+
+# Filter by interface
+confium list --interface signature
+
+# JSON output for scripting
+confium list --json | jq '.[] | .name'
+```
+
+## Sample output
+
+```
+NAME        VERSION  PUBLISHER        INTERFACES
+botan       3.0.0    Ribose Open      hash cipher aead signature kem
+openssl     3.0.8    OpenSSL Project  hash cipher aead signature
+ring        0.17.8   BoringSSL        hash aead signature
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Plugin store unreadable. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium info`](./info/)
+- [`confium install`](./install/)
+- [CLI overview](./)

--- a/src/content/docs/cli/publish.mdx
+++ b/src/content/docs/cli/publish.mdx
@@ -1,0 +1,130 @@
+---
+title: "confium-publish"
+description: "The plugin author's publishing tool — wraps a plugin artifact, signs the manifest, and prepares it for submission to the Confium registry."
+audience: developer
+order: 24
+---
+
+# `confium-publish`
+
+`confium-publish` is the plugin author's companion to `confium install`.
+It loads your built plugin, computes its SHA-256, generates a
+`manifest.toml`, signs the manifest with your publisher PGP key, and
+writes a directory tree ready to drop into the registry repository.
+
+## Install
+
+```sh
+cargo install confium-publish --locked
+```
+
+## Synopsis
+
+```sh
+confium-publish <plugin-path> --publisher <key-id> [--out <dir>] [--version <ver>]
+```
+
+## Examples
+
+```sh
+# Build your plugin
+cargo build --release
+
+# Publish (creates ./dist/my-plugin@0.1.0/ with manifest.toml + signature)
+confium-publish ./target/release/libmy_plugin.so \
+  --publisher A1B2C3D4 \
+  --version 0.1.0 \
+  --out ./dist
+
+# Submit as a PR against the registry repo
+cd ../confium-registry
+cp -r ../my-plugin/dist/my-plugin@0.1.0 ./plugins/
+git checkout -b add-my-plugin-0.1.0
+git add .
+git commit -m "Add my-plugin@0.1.0"
+git push
+# Open PR...
+```
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--publisher <key-id>` | PGP key ID for signing. Required. |
+| `--version <ver>` | Plugin version (defaults to `CARGO_PKG_VERSION`). |
+| `--out <dir>` | Output directory. Default: `./dist`. |
+| `--name <name>` | Override the plugin name (defaults to library name). |
+| `--vendor <name>` | Vendor name for the manifest metadata. |
+| `--license <spdx>` | License SPDX identifier (e.g. `BSD-2-Clause`). |
+| `--interface <name>` | Declare an implemented interface (repeatable). |
+
+## Manifest output
+
+The tool writes:
+
+```
+dist/
+└── my-plugin@0.1.0/
+    ├── manifest.toml         # plugin metadata + SHA-256
+    ├── manifest.sig          # detached PGP signature
+    ├── artifact.sha256       # SHA-256 of the .so/.dylib/.dll
+    └── README.md             # generated from manifest
+```
+
+`manifest.toml` example:
+
+```toml
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+vendor = "Example Corp"
+license = "BSD-2-Clause"
+
+[artifact]
+path = "libmy_plugin.so"
+sha256 = "9b1d96e3..."
+
+[[interfaces]]
+name = "hash"
+version = 0
+algorithms = ["SHA-256", "SHA-512"]
+
+[signing]
+publisher = "A1B2C3D4"
+signature = "manifest.sig"
+```
+
+## Trusted publisher setup
+
+Before publishing, you need a PGP key pair that the registry
+recognizes as a trusted publisher:
+
+1. Generate a key (or use an existing one).
+2. Submit the public key to the registry's trusted-publishers list
+   via PR.
+3. Once merged, your signed manifests will be accepted by
+   `confium install` for users who trust the registry.
+
+## Verification
+
+The publish tool verifies your plugin loads correctly before
+generating the manifest:
+
+```sh
+$ confium-publish ./target/release/libmy_plugin.so --publisher A1B2C3D4
+[INFO] Loading plugin...
+[INFO] Querying interfaces...
+[INFO]   hash v0
+[INFO] Computing SHA-256...
+[INFO] Generating manifest...
+[INFO] Signing manifest with A1B2C3D4...
+[INFO] Wrote dist/my-plugin@0.1.0/
+```
+
+## See also
+
+- [CLI overview](./)
+- [`confiumd`](./daemon/)
+- [Plugin author guide](https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx)
+  (Rust workspace docs).
+- [Contributor guide](/audiences/contributors/) — for new plugin authors.

--- a/src/content/docs/cli/remove.mdx
+++ b/src/content/docs/cli/remove.mdx
@@ -1,0 +1,61 @@
+---
+title: "confium remove"
+description: "Remove an installed Confium plugin from the local store."
+audience: developer
+order: 16
+---
+
+# `confium remove`
+
+## Synopsis
+
+```sh
+confium remove <plugin>[@version] [--purge]
+```
+
+## Description
+
+Removes a plugin from the local plugin store. If the plugin has
+multiple versions installed, only the specified version is removed
+unless `--purge` is given.
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<plugin>` | Yes | Plugin name with optional `@version` suffix. |
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--purge` | Remove all installed versions. |
+| `--yes` | Skip the interactive confirmation prompt. |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+# Remove a specific version
+confium remove botan@3.0
+
+# Remove all versions
+confium remove botan --purge
+
+# Non-interactive
+confium remove botan --purge --yes
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Plugin not installed. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium install`](./install/)
+- [`confium list`](./list/)
+- [CLI overview](./)

--- a/src/content/docs/cli/search.mdx
+++ b/src/content/docs/cli/search.mdx
@@ -1,0 +1,76 @@
+---
+title: "confium search"
+description: "Search the Confium plugin registry for available plugins."
+audience: developer
+order: 20
+---
+
+# `confium search`
+
+## Synopsis
+
+```sh
+confium search [<query>] [--interface <name>] [--algorithm <name>] [--json]
+```
+
+## Description
+
+Searches the Confium plugin registry for plugins matching the
+query. Results are ranked by relevance and include name, version,
+publisher, and a short description.
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<query>` | No | Free-text query (plugin name, vendor, description). If omitted, returns all plugins. |
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--interface <name>` | Filter by interface (e.g. `hash`, `signature`). |
+| `--algorithm <name>` | Filter by algorithm. |
+| `--limit <n>` | Limit results (default 25). |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+# Search by name
+confium search botan
+
+# Filter by interface
+confium search --interface signature
+
+# Find all PQ-signature plugins
+confium search --algorithm ML-DSA-65
+
+# JSON output
+confium search botan --json
+```
+
+## Sample output
+
+```
+NAME          VERSION  PUBLISHER         DESCRIPTION
+botan         3.0.0    Ribose Open       Botan crypto plugin (FIPS-capable)
+botan-fips    3.0.0    Ribose Open       Botan built in FIPS 140 mode
+ring          0.17.8   BoringSSL         Ring crypto plugin (performance)
+
+3 results (limit 25)
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Registry unreachable. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium install`](./install/)
+- [`confium info`](./info/)
+- [CLI overview](./)

--- a/src/content/docs/cli/trust.mdx
+++ b/src/content/docs/cli/trust.mdx
@@ -1,0 +1,98 @@
+---
+title: "confium trust"
+description: "Manage the trusted-publisher list — which publishers' plugins the local install will accept."
+audience: developer
+order: 21
+---
+
+# `confium trust`
+
+## Synopsis
+
+```sh
+confium trust add    <publisher-key> [--alias <name>]
+confium trust remove <publisher-key-or-alias>
+confium trust list   [--json]
+confium trust verify <publisher-key>
+```
+
+## Description
+
+Manages the trusted-publisher list stored in
+`~/.confium/trust.toml`. Plugins signed by untrusted publishers
+are rejected by `install` and `update` unless `--no-trust` is
+passed.
+
+## Subcommands
+
+### `trust add`
+
+Adds a publisher's signing key to the trusted list. The key can
+be specified as a fingerprint or a path to a public key file.
+
+```sh
+confium trust add --alias ribose 9B1D96E3...
+```
+
+### `trust remove`
+
+Removes a publisher from the trusted list. Accepts either the
+fingerprint or the alias.
+
+```sh
+confium trust remove ribose
+```
+
+### `trust list`
+
+Lists all trusted publishers.
+
+```sh
+confium trust list
+```
+
+### `trust verify`
+
+Verifies that a publisher's key matches the trusted list. Useful
+for CI scripts.
+
+```sh
+confium trust verify 9B1D96E3...
+```
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--alias <name>` | Set a friendly alias (for `add`). |
+| `--json` | Emit machine-readable JSON (for `list`). |
+
+## Examples
+
+```sh
+# Add the official Ribose publisher
+confium trust add 9B1D96E3... --alias ribose
+
+# List all trusted publishers
+confium trust list
+
+# Remove by alias
+confium trust remove ribose
+
+# Script-friendly verify (exits 0 if trusted)
+confium trust verify 9B1D96E3... && echo "trusted"
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | Publisher not found (for `remove` / `verify`). |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium install`](./install/)
+- [`confium info`](./info/)
+- [CLI overview](./)

--- a/src/content/docs/cli/update.mdx
+++ b/src/content/docs/cli/update.mdx
@@ -1,0 +1,74 @@
+---
+title: "confium update"
+description: "Update an installed plugin to the latest version. Currently a stub awaiting the confium-net HTTP-fetching crate."
+audience: developer
+order: 17
+---
+
+# `confium update`
+
+## Status: stub
+
+Like [`confium install`](./install/), `update` parses arguments and
+emits the right shape, but the actual download path uses a
+`NoopDownloader`. Real network fetching awaits the `confium-net`
+crate.
+
+## Synopsis
+
+```sh
+confium update [<plugin>] [--all] [--check]
+```
+
+## Description
+
+Updates one or more installed plugins to the latest version from
+the registry. Without arguments, updates all installed plugins
+where a newer version is available.
+
+The SHA-256 of the new artifact is verified against the manifest's
+signature. The trusted-publisher list is consulted; updates from
+untrusted publishers are rejected unless `--no-trust` is given.
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<plugin>` | No | Plugin name to update. If omitted, all installed plugins are checked. |
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--all` | Update all installed plugins. |
+| `--check` | Only check for available updates; do not apply. |
+| `--no-trust` | Skip the trusted-publisher check. |
+| `--yes` | Skip confirmation prompts. |
+| `--json` | Emit machine-readable JSON. |
+
+## Examples
+
+```sh
+# Check what updates are available
+confium update --check
+
+# Update a specific plugin
+confium update botan
+
+# Update everything
+confium update --all --yes
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+| 1 | No updates available, or update failed. |
+| 2 | Usage error. |
+
+## See also
+
+- [`confium install`](./install/)
+- [`confium list`](./list/)
+- [CLI overview](./)

--- a/src/content/docs/cli/version.mdx
+++ b/src/content/docs/cli/version.mdx
@@ -1,0 +1,46 @@
+---
+title: "confium version"
+description: "Print the version of the confium CLI and the underlying engine."
+audience: developer
+order: 14
+---
+
+# `confium version`
+
+## Synopsis
+
+```sh
+confium version
+```
+
+## Description
+
+Prints the version of the `confium` CLI binary. The version is
+sourced from `CARGO_PKG_VERSION` at compile time, so it matches the
+crate version on crates.io.
+
+A future release will also report the version of the underlying
+`confium-core` engine when the engine exposes a public version
+accessor.
+
+## Options
+
+`confium version` takes no options.
+
+## Examples
+
+```sh
+$ confium version
+confium 0.3.0
+```
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success. |
+
+## See also
+
+- [CLI overview](./)
+- [`confium config`](./config/)


### PR DESCRIPTION
TODO.completion #045. Resolves the 'where is the CLI' complaint: 12 new /docs/cli/ pages covering all 9 commands + daemon + publish. Two stubs (install, update) clearly marked. Two new diagrams.