### PR TITLE
feat(diagrams): PKCS#11 + OpenSSL provider diagrams

### DIFF
--- a/src/components/brand/OpenSSLProviderDiagram.astro
+++ b/src/components/brand/OpenSSLProviderDiagram.astro
@@ -1,0 +1,62 @@
+---
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="openssl-title" set:html={`
+  <title id="openssl-title">OpenSSL 3.0 provider dispatches EVP_PKEY_sign calls to Confium.</title>
+
+  <!-- Application -->
+  <rect x="180" y="20" width="120" height="48" rx="8" fill="#1a7bec"/>
+  <text x="240" y="40" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white" letter-spacing="2">APPLICATION</text>
+  <text x="240" y="55" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">nginx · curl · custom</text>
+
+  <!-- EVP_PKEY_sign call -->
+  <rect x="140" y="85" width="200" height="28" rx="4" fill="#e6f0fe"/>
+  <text x="240" y="103" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" fill="#1a7bec" font-weight="700">EVP_PKEY_sign(ctx, sig, msg)</text>
+
+  <line x1="240" y1="68" x2="240" y2="85" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- OpenSSL core -->
+  <rect x="120" y="130" width="240" height="56" rx="10" fill="#0f1326"/>
+  <text x="240" y="153" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">OPENSSL CORE</text>
+  <text x="240" y="170" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#a8aec9">dispatches by algorithm name</text>
+
+  <line x1="240" y1="113" x2="240" y2="130" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- Algorithm table inside OpenSSL -->
+  <g font-family="IBM Plex Mono, monospace" font-size="9">
+    <text x="135" y="195" fill="#a8aec9">Ed25519 →</text>
+    <text x="135" y="208" fill="#00dfb7">  confium provider</text>
+    <text x="240" y="195" fill="#a8aec9">ECDSA →</text>
+    <text x="240" y="208" fill="#00dfb7">  confium provider</text>
+    <text x="345" y="195" fill="#a8aec9">AES →</text>
+    <text x="345" y="208" fill="#ffdc4a">  default provider</text>
+  </g>
+
+  <!-- Provider arrows -->
+  <line x1="180" y1="208" x2="100" y2="240" stroke="#1a7bec" stroke-width="2"/>
+  <line x1="270" y1="208" x2="100" y2="240" stroke="#1a7bec" stroke-width="2"/>
+  <line x1="365" y1="208" x2="380" y2="240" stroke="#ffdc4a" stroke-width="1.5" stroke-dasharray="3 3"/>
+
+  <!-- Confium provider (left) -->
+  <rect x="30" y="240" width="140" height="56" rx="10" fill="url(#op-grad)"/>
+  <defs>
+    <linearGradient id="op-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+  </defs>
+  <text x="100" y="263" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">CONFIUM</text>
+  <text x="100" y="278" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.9">in-process lib</text>
+  <text x="100" y="289" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.9">→ coordinator</text>
+
+  <!-- Default provider (right) -->
+  <rect x="310" y="240" width="140" height="56" rx="10" fill="white" stroke="#ffdc4a" stroke-width="1.5"/>
+  <text x="380" y="263" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="#a07d0a" letter-spacing="2">DEFAULT</text>
+  <text x="380" y="278" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">OpenSSL native</text>
+  <text x="380" y="289" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#5f6680">(hashes, AES, etc.)</text>
+
+  <!-- Bottom annotation -->
+  <text x="240" y="325" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" font-style="italic" fill="#5f6680">in-process provider — no IPC overhead</text>
+  <text x="240" y="343" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" font-weight="700" fill="#1a7bec" letter-spacing="2">SELECTIVE ALGORITHM ROUTING</text>
+`}/>

--- a/src/components/brand/PKCS11AdapterDiagram.astro
+++ b/src/components/brand/PKCS11AdapterDiagram.astro
@@ -1,0 +1,80 @@
+---
+interface Props { class?: string }
+const { class: className = '' } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360" class={className} role="img" aria-labelledby="pkcs11-title" set:html={`
+  <title id="pkcs11-title">PKCS#11 adapter maps slot/token objects to Confium threshold signing sessions.</title>
+
+  <!-- Consumer -->
+  <rect x="180" y="20" width="120" height="48" rx="8" fill="#1a7bec"/>
+  <text x="240" y="40" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white" letter-spacing="2">CONSUMER</text>
+  <text x="240" y="55" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="white">OpenSSL · Java · nginx</text>
+
+  <!-- API call -->
+  <rect x="160" y="80" width="160" height="28" rx="4" fill="#e6f0fe"/>
+  <text x="240" y="98" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" fill="#1a7bec" font-weight="700">C_Sign(handle, data)</text>
+
+  <line x1="240" y1="68" x2="240" y2="80" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- PKCS#11 Adapter (center) -->
+  <rect x="140" y="125" width="200" height="60" rx="10" fill="url(#pk-grad)"/>
+  <defs>
+    <linearGradient id="pk-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1a7bec"/><stop offset="100%" stop-color="#00c2c9"/>
+    </linearGradient>
+  </defs>
+  <text x="240" y="148" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" font-weight="700" fill="white" letter-spacing="2">PKCS#11 ADAPTER</text>
+  <text x="240" y="163" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.9">slot → signer</text>
+  <text x="240" y="175" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white" opacity="0.9">token → keypair</text>
+
+  <line x1="240" y1="108" x2="240" y2="125" stroke="#1a7bec" stroke-width="2"/>
+
+  <!-- Slots (left) -->
+  <g font-family="IBM Plex Mono, monospace" font-size="9">
+    <rect x="20" y="135" width="100" height="40" rx="6" fill="white" stroke="#00c2c9"/>
+    <text x="70" y="152" text-anchor="middle" fill="#009e80" font-weight="700">SLOT 0</text>
+    <text x="70" y="166" text-anchor="middle" fill="#5f6680">tls-signing</text>
+
+    <rect x="20" y="180" width="100" height="40" rx="6" fill="white" stroke="#00c2c9"/>
+    <text x="70" y="197" text-anchor="middle" fill="#009e80" font-weight="700">SLOT 1</text>
+    <text x="70" y="211" text-anchor="middle" fill="#5f6680">code-signing</text>
+  </g>
+
+  <line x1="120" y1="155" x2="140" y2="155" stroke="#00c2c9" stroke-width="1.5"/>
+  <line x1="120" y1="200" x2="140" y2="180" stroke="#00c2c9" stroke-width="1.5"/>
+
+  <!-- Coordinator (right) -->
+  <rect x="360" y="135" width="100" height="40" rx="6" fill="#009e80"/>
+  <text x="410" y="152" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">COORDINATOR</text>
+  <text x="410" y="166" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="white">threshold session</text>
+
+  <line x1="340" y1="155" x2="360" y2="155" stroke="#009e80" stroke-width="2"/>
+
+  <!-- Dispatch arrow to coordinator -->
+  <text x="350" y="148" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#009e80">dispatch</text>
+
+  <!-- Threshold output below -->
+  <line x1="240" y1="185" x2="240" y2="240" stroke="#009e80" stroke-width="2"/>
+
+  <!-- Signers (bottom) -->
+  <g font-family="IBM Plex Mono, monospace" font-size="9">
+    <circle cx="90" cy="290" r="22" fill="#1a7bec"/>
+    <text x="90" y="293" text-anchor="middle" fill="white" font-weight="700">S1</text>
+    <circle cx="180" cy="290" r="22" fill="#1a7bec"/>
+    <text x="180" y="293" text-anchor="middle" fill="white" font-weight="700">S2</text>
+    <circle cx="300" cy="290" r="22" fill="#1a7bec"/>
+    <text x="300" y="293" text-anchor="middle" fill="white" font-weight="700">S3</text>
+    <circle cx="390" cy="290" r="22" fill="#eef4fa" stroke="#dfe8f2"/>
+    <text x="390" y="293" text-anchor="middle" fill="#5f6680" font-weight="700">SN</text>
+  </g>
+
+  <line x1="410" y1="175" x2="90" y2="268" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="410" y1="175" x2="180" y2="268" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="410" y1="175" x2="300" y2="268" stroke="#1a7bec" stroke-width="1.5"/>
+  <line x1="410" y1="175" x2="390" y2="268" stroke="#5f6680" stroke-width="1" stroke-dasharray="2 2"/>
+
+  <!-- Output -->
+  <rect x="170" y="325" width="140" height="28" rx="6" fill="#0f1326"/>
+  <text x="240" y="343" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="10" font-weight="700" fill="white">standard signature</text>
+`}/>


### PR DESCRIPTION
TODO.completion #049. Two new SVG diagrams for the adapter deep-dive pages.