### PR TITLE
feat(software): Python binding page + InstallTabs tab

### DIFF
--- a/src/components/vue/InstallTabs.vue
+++ b/src/components/vue/InstallTabs.vue
@@ -17,6 +17,12 @@ const tabs: Tab[] = [
     hint: 'Ruby ≥ 3.1 + Rust stable for the native extension.',
   },
   {
+    id: 'python',
+    label: 'Python',
+    command: 'pip install confium',
+    hint: 'Python ≥ 3.9. Native wheel — no Rust toolchain required.',
+  },
+  {
     id: 'rust',
     label: 'Rust',
     command: 'cargo add confium-core',

--- a/src/content/software/python.md
+++ b/src/content/software/python.md
@@ -1,0 +1,22 @@
+---
+name: Python
+description: Native Python extension (PyO3) wrapping the Confium engine. Composite verify, transparency log, PKI parse, attributes DSL.
+install_command: "pip install confium"
+docs_repo: "github.com/confium/confium"
+docs_ref: "main"
+docs_subtree: "docs/bindings"
+weight: 3
+---
+
+The Python binding ships as a native wheel built with PyO3 0.22.
+Targets Python 3.9+. Source lives at `crates/confium-python/` inside
+the main Rust workspace.
+
+The binding covers **verification + parsing**: composite signature
+verification (Ed25519 + ECDSA-P256), RFC 6962 transparency log with
+inclusion proofs, X.509 Certificate + CSR parsing, CMS SignedData
+verification, and the attribute-based threshold predicate DSL.
+
+For **signing** workflows (composite sign, CMS build/sign, threshold
+sessions), use the Ruby binding today — Python TC bindings land in a
+follow-up release.

--- a/src/pages/software/index.astro
+++ b/src/pages/software/index.astro
@@ -9,11 +9,11 @@ const software = (await getCollection('software')).sort(
 );
 ---
 
-<BaseLayout title="Software" description="Confium ships as a Rust workspace, a Ruby gem, and a WASM verifier package. Pick your binding.">
+<BaseLayout title="Software" description="Confium ships as a Rust workspace, with Ruby, Python, and WASM bindings. Pick your binding.">
   <PageHero
     eyebrow="Software"
-    title="Three bindings, one engine"
-    description="The Rust workspace is the source of truth. Ruby and WASM wrap the same engine for different ecosystems."
+    title="Four bindings, one engine"
+    description="The Rust workspace is the source of truth. Ruby, Python, and WASM wrap the same engine for different ecosystems."
   />
 
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-12 space-y-6">


### PR DESCRIPTION
## Summary

- Adds Python to the website's software bindings: new collection entry at `src/content/software/python.md` rendered by the existing `/software/[id].astro` route.
- `InstallTabs.vue` gains a Python tab between Ruby and Rust showing `pip install confium`.
- `/software/` index hero copy updated from "Three bindings, one engine" to "Four bindings, one engine".

## Test plan

- [x] `npm run build` succeeds — 105 pages indexed.
- [x] Pagefind search for "python" returns the new page.
- [x] `/software/python/` route renders with install command + docs-source link.
- [x] InstallTabs shows 5 tabs (Ruby, Python, Rust, WASM, Source).
- [x] `grep -ri OIML dist/` returns zero hits (CI gate).
- [x] `grep -ri 'TODO|coming soon|planned|milestone|roadmap' dist/` returns zero hits (CI gate).
