### PR TITLE
refactor(homepage): playground-as-thesis + design system primitives

### DIFF
--- a/TODO.complete/061-foundation-tokens-data-math.md
+++ b/TODO.complete/061-foundation-tokens-data-math.md
@@ -1,0 +1,93 @@
+# 061 — Foundation: design tokens, data model, quorum math
+
+**Category**: Architecture / Design system
+**Severity**: High (foundation for everything else)
+**Effort**: Medium
+**Status**: pending
+
+## Problem
+
+Three issues block the rest of the refactor:
+
+1. **Color tokens are inconsistent.** `QuorumPlayground.vue` and `Card.astro`
+   reference `text-brand-600`, `bg-brand-50/30`, `text-accent2`, `text-gold`
+   etc. — but the design system in `global.css` only defines `--color-brand`
+   (single shade), `--color-accent`, `--color-accent2`, and
+   `--color-gold-ink`. Tailwind 4 silently no-ops unknown color utilities,
+   so half the interactive styling is invisible.
+
+2. **Homepage content is hardcoded inline** in `index.astro` (655 lines)
+   and partially duplicated in `ModeSelector.vue` (which has its own copy
+   of the three-modes data with different fields). DRY violation.
+
+3. **Quorum math is embedded in `QuorumPlayground.vue`** as Vue refs and
+   computeds — untestable, coupled to the Vue lifecycle.
+
+## Plan
+
+### Tokens — extend `global.css`
+
+Add brand-teal-gold shade scales (50–900) as static tokens so existing
+Tailwind classes (`bg-brand-600`, `text-teal-500`, etc.) resolve. Keep
+the semantic `--accent` / `--accent2` / `--gold-ink` tokens for
+theme-flipped usage. Static shades are for fixed-identity surfaces
+(logo marks, range inputs); semantic tokens for typography that must
+adapt to light/dark.
+
+### Data model — `src/data/homepage.ts`
+
+Typed content models for the homepage. Single source of truth for
+modes, proof points, deployments, steps. Both `index.astro` and
+`ModeSelector.vue` import from here.
+
+```ts
+export type ModeId = 'peer-tc' | 'pki-drop-in' | 'sovereign-pki';
+export type BrandTone = 'blue' | 'teal' | 'gold';
+
+export interface Mode {
+  id: ModeId;
+  tone: BrandTone;
+  name: string;
+  tagline: string;
+  description: string;
+  bullets: readonly string[];
+  href: string;
+  ctaLabel: string;
+}
+
+export const MODES: readonly Mode[];
+export const PROOF_POINTS: readonly ProofPoint[];
+export const DEPLOYMENTS: readonly Deployment[];
+export const STEPS: readonly Step[];
+```
+
+### Quorum math — `src/lib/quorum.ts`
+
+Pure functions for threshold quorum. No Vue, no DOM. Trivially testable.
+
+```ts
+export type QuorumStatus = 'idle' | 'insufficient' | 'ready';
+
+export interface QuorumState {
+  total: number;
+  threshold: number;
+  participating: number;
+  status: QuorumStatus;
+  canSign: boolean;
+  parties: readonly { id: number; signed: boolean }[];
+}
+
+export function quorumState(
+  total: number,
+  threshold: number,
+  participating: number,
+): QuorumState;
+
+export function describeStatus(state: QuorumState): string;
+```
+
+## Verification
+
+- `npx astro check` passes
+- `npx vitest run` (once added in 068) covers quorum edge cases
+- Existing rendered HTML unchanged at this phase (refactor only)

--- a/TODO.complete/062-primitives.md
+++ b/TODO.complete/062-primitives.md
@@ -1,0 +1,66 @@
+# 062 — Primitives: Section, CtaLink, Timeline, ModeVenn, Card fixes
+
+**Category**: UI primitives
+**Severity**: High
+**Effort**: Medium
+**Status**: pending
+**Depends on**: 061
+
+## Problem
+
+Every section in `index.astro` duplicates the same wrapper pattern
+(`mono-label` eyebrow → bold h2 → optional lead → grid). Every CTA link
+duplicates `text-accent hover:text-accent-deep` + `→`. The "How it
+works" steps render as a 5-card grid when they're actually a sequence
+with order-encoded meaning. The three-circle logo motif (the brand's
+most distinctive asset) has no reusable form.
+
+## Plan
+
+### `Section.astro`
+
+Section wrapper that takes `eyebrow?`, `title?`, `lead?`, `tone?`
+(`'default' | 'blue' | 'teal' | 'gold'`), `class?`. Renders the standard
+section chrome. Used everywhere section chrome is needed.
+
+### `CtaLink.astro`
+
+Single arrow-link primitive. `> Read the X →` pattern, repeated ~8
+times across the homepage today. Takes `href`, `label`, optional
+`tone`.
+
+### `Timeline.astro`
+
+Horizontal step sequence with connector lines. Takes `steps: { step,
+title, body, tone }[]`. Renders the 5-stage "Generate → Distribute →
+Sign → Refresh → Anchor" flow with order encoded visually (numbered
+circles + connecting hairlines), not as a generic card grid.
+
+### `ModeVenn.astro`
+
+Reusable three-circle motif (blue + teal + gold overlapping). The
+brand identity device. Variants: `compact` (logo-sized), `feature`
+(hero-sized backdrop), `divider` (hairline section divider).
+
+### Card fixes
+
+Existing `Card.astro` has color-token bugs (`text-gold` → should be
+`text-gold-ink`; `text-brand-700` → should be `text-accent`). Also
+add a `tone: BrandTone` prop that maps to the three-mode identity
+colors. Keep the existing prop API stable to avoid breaking callers.
+
+## Architecture
+
+All primitives go in `src/components/astro/primitives/`. The directory
+name encodes their role: atomic, composable, no domain logic.
+
+OCP: a new card variant = new file, not a new branch in `Card.astro`.
+DRY: each repeated pattern extracted exactly once.
+MECE: Section = layout, Card = atomic UI, Timeline = sequence,
+ModeVenn = brand motif.
+
+## Verification
+
+- All existing pages still render identically (this phase is purely
+  additive — primitives introduced but not yet swapped into callers)
+- Type-check passes

--- a/TODO.complete/063-quorum-playground-refactor.md
+++ b/TODO.complete/063-quorum-playground-refactor.md
@@ -1,0 +1,63 @@
+# 063 — QuorumPlayground refactor: pure logic + token fixes
+
+**Category**: Code quality / interactivity
+**Severity**: Medium
+**Effort**: Small
+**Status**: pending
+**Depends on**: 061
+
+## Problem
+
+`QuorumPlayground.vue` has three concerns tangled together:
+
+1. **Quorum math** (refs + computeds) — should live in `lib/quorum.ts`
+2. **Token references that don't resolve** — `bg-brand-600`,
+   `accent-brand-600`, `bg-amber-500`, `bg-muted-foreground/40` — most
+   are silently no-op
+3. **Presentation** — actual Vue template
+
+## Plan
+
+### Extract logic
+
+Move all state computation to `lib/quorum.ts` (added in 061). The Vue
+component becomes a thin presentation layer:
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { quorumState, describeStatus } from '@lib/quorum';
+
+const total = ref(5);
+const threshold = ref(3);
+const participating = ref(0);
+
+const state = computed(() =>
+  quorumState(total.value, threshold.value, participating.value),
+);
+</script>
+```
+
+### Fix token references
+
+- `bg-brand-600` → `bg-brand` (single-shade static token, or new
+  shade scale from 061)
+- `accent-brand-600` on `<input type="range">` → use semantic
+  `accent-accent` or a CSS custom property on the input
+- `bg-amber-500` (warning state) → new `--warning` token (amber, kept
+  consistent across light/dark)
+- `bg-muted-foreground/40` → `bg-faint/40` (existing token)
+
+### Improve a11y
+
+- Status indicator: add `role="status"` and `aria-live="polite"` so
+  screen readers announce state changes
+- Range inputs: explicit `<output>` for current value
+- Status text: use `describeStatus()` from lib for consistent voice
+
+## Verification
+
+- Drag sliders → status updates correctly
+- Screen reader announces status changes
+- Visual states (idle/insufficient/ready) clearly distinct
+- `lib/quorum` is pure — no Vue imports

--- a/TODO.complete/064-hero-thesis.md
+++ b/TODO.complete/064-hero-thesis.md
@@ -1,0 +1,82 @@
+# 064 — Hero transformation: playground as thesis
+
+**Category**: Design / Homepage
+**Severity**: High
+**Effort**: Medium
+**Status**: pending
+**Depends on**: 062, 063
+
+## Problem
+
+The current hero is a list — "Threshold-native trust infrastructure
+for a post-quantum world" + a `HeroDecrypt` typewriter + a
+`ThreeModeDiagram` flowchart. None of it states the thesis. The
+thesis is the one thing only Confium can say:
+
+> **No single party can sign alone.**
+
+The interactive `QuorumPlayground` (currently buried at section 7) is
+the only element on the page that *demonstrates* the thesis. A
+visitor who drags the slider for 20 seconds understands the whole
+product. No diagram or copy will do that faster.
+
+## Plan
+
+### Replace hero right column
+
+Current right side: `ThreeModeDiagram` (decorative flowchart that
+duplicates the Three Modes section below).
+
+New right side: `QuorumPlayground`. Headline + subhead on the left,
+the interactive slider on the right. Below the slider, a single
+sentence: "Drag the slider. Watch what happens when fewer than T
+parties try to sign."
+
+### Cut the typewriter
+
+`HeroDecrypt` is a character-substitution effect — the same one on
+every dev-tools site (Vercel, Linear, Fly.io). It signals "generic
+AI-generated". Cut it. The headline renders statically.
+
+Per the global rule (never delete source files), `HeroDecrypt.vue`
+stays in the source tree, just unused on the homepage. It may find
+use elsewhere later.
+
+### Three-circle motif as hero backdrop
+
+Behind the headline + playground: a large `ModeVenn` in `feature`
+variant — three overlapping translucent circles (blue, teal, gold).
+This makes the brand identity visible at first glance and ties to
+the Three Modes section below.
+
+### Hero copy
+
+```
+[eyebrow]  THRESHOLD CRYPTOGRAPHY · POST-QUANTUM READY · OPEN SOURCE
+
+[headline] No single party
+           can sign alone.
+
+[subhead]  Confium is the threshold-native trust infrastructure
+           for settings where no party can be fully trusted alone.
+           A quorum must sign. Every operation is anchored in a
+           transparency log.
+
+[CTAs]     [Drag the playground →]   [Read the architecture]
+```
+
+## Architecture
+
+The hero is its own component: `src/components/astro/sections/Hero.astro`
+(not a primitive — used once, but factored out so `index.astro` reads
+as composition).
+
+## Verification
+
+- Lighthouse LCP still < 2.5s (playground is light DOM, no heavy
+  assets)
+- Keyboard: tab to the playground, slider works with arrow keys
+- Mobile: hero stacks (headline + playground), playground remains
+  usable at 375px
+- Screen reader: hero announces headline + subhead + playground
+  label + status

--- a/TODO.complete/065-index-restructure.md
+++ b/TODO.complete/065-index-restructure.md
@@ -1,0 +1,76 @@
+# 065 — Index.astro restructure: cuts + composition + color bands
+
+**Category**: Design / Homepage structure
+**Severity**: High
+**Effort**: Medium
+**Status**: pending
+**Depends on**: 062, 064
+
+## Problem
+
+`index.astro` is 655 lines, 12 sections in the same rhythm (eyebrow
+→ h2 → grid of cards), all in the same dark navy. The hero is the
+only bright moment. Three sections duplicate content (hero diagram
+vs. three-modes section; "What Confium is NOT" vs. architecture;
+"Find your path" vs. /audiences/).
+
+## Cuts
+
+| Section | Why cut |
+|---|---|
+| Stats band (43 crates / 725+ tests / 3 modes / 10+ protocols) | Vanity metrics. Replace with one inline proof ("0 parties can sign alone" — already implied by the hero). |
+| "What Confium is NOT" (3 cards) | Defensive positioning reads as anxiety. If "not a crypto library / not an HSM / not just OpenPGP" matters, it belongs on the architecture page. |
+| "Find your path" (6 audience cards) | Directory listing. Belongs on `/audiences/`, not the homepage. The link to `/audiences/` stays in the nav and footer. |
+| Final CTA (gradient hero repeated) | A confident product doesn't shout twice. Replaced by a quiet sign-off (TODO 067). |
+
+## Keep (restructured)
+
+1. **Hero** (interactive thesis) — TODO 064
+2. **Three Modes** — the actual product structure, color-coded
+3. **How It Works** — Timeline primitive, not grid
+4. **What Makes Confium Different** — six properties, kept
+5. **Install** — kept
+6. **Reference Deployments** — kept (gold band)
+7. **Latest from the blog** — kept but slimmed (one line + 3 cards)
+8. **Sign-off** — new (TODO 067)
+
+## Three-color mode bands
+
+Each of the three modes carries its identity color:
+- Mode 1 (Peer-to-Peer): blue tint band
+- Mode 2 (PKI Drop-in): teal tint band
+- Mode 3 (Sovereign PKI): gold tint band
+
+In the "Three Modes" section, instead of three identical cards on a
+neutral background, render three full-width subsections each with
+their tint. The mode name in the matching color. Bullets in the
+matching color. This makes the three-circle identity structural.
+
+## Composition
+
+`index.astro` becomes ~80 lines of composition:
+
+```astro
+<BaseLayout title="Confium" headerOverlay>
+  <Hero />
+  <ThreeModes />
+  <HowItWorks />
+  <Differences />
+  <Install />
+  <Deployments />
+  <BlogTeaser />
+  <SignOff />
+</BaseLayout>
+```
+
+Each section is a component in `src/components/astro/sections/`. They
+compose primitives (`Section`, `Card`, `CtaLink`, `Timeline`,
+`ModeVenn`) with data (`src/data/homepage.ts`).
+
+## Verification
+
+- Total homepage line count drops significantly (655 → ~80 in
+  `index.astro`, section components each ~30–60 lines)
+- Visual rhythm varies (hero interactive → mode bands → timeline →
+  cards → install → cards → quiet sign-off)
+- Lighthouse score maintained or improved

--- a/TODO.complete/066-typography-refresh.md
+++ b/TODO.complete/066-typography-refresh.md
@@ -1,0 +1,73 @@
+# 066 — Typography refresh: Plex Mono display + rhythm variation
+
+**Category**: Design / Typography
+**Severity**: Medium
+**Effort**: Small
+**Status**: pending
+**Depends on**: 065
+
+## Problem
+
+Every heading on the page is `font-sans text-3xl font-bold tracking-tight`.
+The eyebrow is `mono-label` on every section. The result: nothing stands
+out because everything is the same. Typography is neutral — a delivery
+vehicle, not a personality.
+
+## Plan
+
+### Display headlines in Plex Mono
+
+Headlines (`h1`, `h2`) switch to **IBM Plex Mono at display weight**.
+This gives the whole page a "technical specification" voice — exactly
+the register threshold cryptography deserves. The body stays in Plex
+Sans for readability.
+
+```css
+.display-mono {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+```
+
+Apply to `h1` and `h2` site-wide (or scoped to homepage for now —
+decide based on visual impact).
+
+### Vary section rhythm
+
+Not every section opens with `mono-label → h2 → grid`. Pick
+deliberately:
+
+- **Hero**: opens with interactive (no eyebrow)
+- **Three Modes**: opens with the three-circle motif (ModeVenn) —
+  the visual *is* the eyebrow
+- **How It Works**: opens with the Timeline — the visual *is* the
+  section, no eyebrow needed
+- **Differences**: opens with a strong pull quote (one of the six
+  properties elevated to a hero quote), then the grid below
+- **Install**: opens with a code snippet in monospace, then the
+  tabs. The code is the eyebrow.
+- **Sign-off**: no eyebrow, no heading — just a single line
+
+### Type scale
+
+Document the scale in `global.css`:
+
+```
+--text-display: clamp(2.5rem, 5vw, 4rem)   // h1
+--text-h2:      clamp(1.75rem, 3vw, 2.25rem)  // h2
+--text-h3:      1.25rem                        // card titles
+--text-body:    1.03rem                        // body
+--text-sm:      0.875rem                       // secondary
+--text-xs:      0.75rem                        // mono-label
+```
+
+Use `clamp()` for fluid type at the display level only.
+
+## Verification
+
+- Homepage reads as a technical document, not a SaaS landing page
+- Each section opens differently — no two adjacent sections share
+  the same opening pattern
+- Mobile type scale doesn't break (test at 375px)

--- a/TODO.complete/067-sign-off.md
+++ b/TODO.complete/067-sign-off.md
@@ -1,0 +1,46 @@
+# 067 — Sign-off section: quiet ending
+
+**Category**: Design / Homepage
+**Severity**: Medium
+**Effort**: Small
+**Status**: pending
+**Depends on**: 062
+
+## Problem
+
+The current homepage ends with a duplicate of the hero gradient + a
+"Start building with Confium today" CTA. This is the second shout —
+the hero already said it. Confident products end quietly.
+
+## Plan
+
+Replace the final CTA with a single-line sign-off:
+
+```
+[3-column compact sponsor row, no big cards]
+
+BSD-2-Clause · Sponsored by NLnet + Mozilla MOSS · Built in the open
+[Get started]  [Read the docs]
+```
+
+No gradient. No big heading. No "Start building today" energy. Just
+the facts and two next-step links.
+
+### Component
+
+`src/components/astro/sections/SignOff.astro`. Compact, ~30 lines.
+
+### Merge with Sponsorship
+
+Currently the page has both "Final CTA" (gradient, duplicate hero)
+and "Sponsorship" (3 sponsor cards). Merge into one quiet ending
+that combines:
+- 3 sponsor logos in a compact row (current cards resized down)
+- One-line license + funding attribution
+- Two next-step links
+
+## Verification
+
+- Page ends on a confident, quiet note
+- Sponsorship remains visible (not buried)
+- Two clear next steps for the visitor

--- a/TODO.complete/068-quorum-specs.md
+++ b/TODO.complete/068-quorum-specs.md
@@ -1,0 +1,90 @@
+# 068 — Specs: Vitest setup + quorum math tests
+
+**Category**: Quality / Testing
+**Severity**: Medium
+**Effort**: Small
+**Status**: pending
+**Depends on**: 061
+
+## Problem
+
+The project has no test infrastructure. The user's quality bar
+requires "good specs throughout". The most logic-heavy code is
+`lib/quorum.ts` (after 061) — pure functions, easy to test, high
+value to verify (the playground is the hero).
+
+## Plan
+
+### Add Vitest
+
+```json
+// package.json
+"devDependencies": {
+  "vitest": "^2.0.0"
+},
+"scripts": {
+  "test": "vitest run",
+  "test:watch": "vitest"
+}
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});
+```
+
+### Specs for `lib/quorum.ts`
+
+`src/lib/quorum.test.ts` — covers:
+
+- **Boundary cases**: T=2, N=2 (minimum valid quorum)
+- **Status transitions**: idle → insufficient → ready
+- **Invariants**: T ≤ N always; participating ≤ N always
+- **Status text**: `describeStatus()` returns correct copy for each state
+- **Parties array**: signed boolean array matches participating count
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { quorumState, describeStatus } from './quorum';
+
+describe('quorumState', () => {
+  it('marks idle when no parties participate', () => {
+    expect(quorumState(5, 3, 0).status).toBe('idle');
+  });
+
+  it('marks insufficient below threshold', () => {
+    expect(quorumState(5, 3, 2).status).toBe('insufficient');
+  });
+
+  it('marks ready at threshold', () => {
+    expect(quorumState(5, 3, 3).status).toBe('ready');
+  });
+
+  it('marks ready above threshold', () => {
+    expect(quorumState(5, 3, 5).status).toBe('ready');
+  });
+
+  it('parties array reflects participation', () => {
+    const s = quorumState(5, 3, 2);
+    expect(s.parties.filter(p => p.signed)).toHaveLength(2);
+  });
+});
+```
+
+### What NOT to test
+
+- Vue components (DOM testing adds complexity without much value here)
+- Astro components (server-rendered, verified by build + screenshot)
+- Visual styling (verified manually)
+
+## Verification
+
+- `npm test` passes all quorum specs
+- CI doesn't break (no existing tests to conflict with)
+- Coverage of `lib/quorum.ts` is 100% (it's small + pure)

--- a/TODO.complete/069-build-verify.md
+++ b/TODO.complete/069-build-verify.md
@@ -1,0 +1,71 @@
+# 069 — Build, screenshot, verify
+
+**Category**: Verification
+**Severity**: High (don't merge without this)
+**Effort**: Small
+**Status**: pending
+**Depends on**: all
+
+## Plan
+
+### Build
+
+```sh
+npm run build
+```
+
+Must succeed with no errors. Pagefind postbuild must succeed.
+
+### Type check
+
+```sh
+npx astro check
+```
+
+Must pass with no errors.
+
+### Tests
+
+```sh
+npm test
+```
+
+All quorum specs pass.
+
+### Visual verification
+
+Screenshot the homepage at 1440×900 (desktop) and 375×900 (mobile).
+
+Verify:
+- Hero shows the playground (interactive), not a flowchart
+- Three Modes section has three colored bands (blue/teal/gold)
+- How It Works renders as a horizontal timeline, not a card grid
+- No "Stats band", no "What Confium is NOT", no "Find your path",
+  no duplicate final CTA
+- Headlines render in Plex Mono
+- Page ends quietly (no second gradient)
+- Dark mode and light mode both render correctly
+- Mobile layout stacks reasonably
+
+### Lighthouse
+
+```sh
+npx lighthouse http://localhost:4321 --only-categories=performance,accessibility
+```
+
+Targets:
+- Performance ≥ 90
+- Accessibility ≥ 95
+
+### Link check
+
+```sh
+npm run check:links
+```
+
+No new broken links.
+
+## Done criteria
+
+All the above pass. Commit + open PR. Don't merge — the user does
+that.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
       "devDependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
-        "pagefind": "1.5.2"
+        "pagefind": "1.5.2",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": ">=22"
@@ -2555,6 +2556,331 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@shikijs/primitive": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
@@ -2996,6 +3322,106 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/babel-helper-vue-transform-on": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-2.0.1.tgz",
@@ -3295,6 +3721,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3624,6 +4060,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -3652,6 +4098,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3692,6 +4155,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3925,6 +4398,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/default-browser": {
@@ -4337,6 +4820,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5270,6 +5763,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6656,6 +7156,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
@@ -7102,6 +7612,51 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -7218,6 +7773,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -7296,6 +7858,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -7400,6 +7976,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
@@ -7432,6 +8015,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -7973,6 +8586,533 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-inspect": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.4.1.tgz",
@@ -8113,6 +9253,603 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.40",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
@@ -8142,6 +9879,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wsl-utils": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "postbuild": "pagefind --site dist",
     "fetch-sources": "node scripts/fetch-sources.mjs",
     "check:links": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
-    "check:links:external": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'"
+    "check:links:external": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "7.0.4",
@@ -30,7 +32,8 @@
   "devDependencies": {
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",
-    "pagefind": "1.5.2"
+    "pagefind": "1.5.2",
+    "vitest": "^2.1.9"
   },
   "engines": {
     "node": ">=22"

--- a/src/components/astro/Card.astro
+++ b/src/components/astro/Card.astro
@@ -1,28 +1,34 @@
 ---
 /**
- * Card — the homepage's most-reused visual primitive. Wraps the
- * shared `.card .card-hover` styling plus the hover-state machine.
+ * Card — atomic UI primitive for the homepage card grids.
  *
- * Use for: feature cards, blog teaser cards, audience cards, mode
- * cards, differentiator cards. Replaces ~50 lines of duplicated
- * markup across 8+ sections of the homepage and the doc index.
+ * Wraps the shared `.card .card-hover` styling. Polymorphic:
+ * `href` makes the card a link; omit for a static panel.
  *
- * Polymorphic: `href` makes the card a link; omit for a static
- * panel. The optional `accent` applies a colored left border on
- * hover to draw attention to priority cards.
+ * Tone drives the accent color (used for eyebrow + bullet dots +
+ * hover state). Maps 1:1 to BrandTone so cards in the Three Modes
+ * section can carry their mode's identity color without bespoke
+ * styling.
+ *
+ * OCP: a new card variant (e.g. "stat card", "quote card") should
+ * be a new component, not a new branch here. Card owns the
+ * common case (eyebrow + title + description + bullets + CTA).
  */
-export interface Props {
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+
+interface Props {
   title: string;
   description?: string;
   href?: string;
-  /** Optional accent color applied to the title on hover. */
-  accent?: 'accent' | 'accent2' | 'gold';
-  /** Whether the link opens in a new tab. */
+  /** Opens in a new tab (used for external links). */
   external?: boolean;
-  /** Optional mono-label eyebrow (e.g. category). */
+  /** Optional mono-label eyebrow (e.g. category or step label). */
   eyebrow?: string;
   /** Optional bullet list rendered below the description. */
-  bullets?: string[];
+  bullets?: readonly string[];
+  /** Identity tone for accent surfaces. Default 'blue'. */
+  tone?: BrandTone;
   /** Extra Tailwind classes appended to the root. */
   class?: string;
 }
@@ -31,10 +37,10 @@ const {
   title,
   description,
   href,
-  accent = 'accent',
   external = false,
   eyebrow,
   bullets,
+  tone = 'blue',
   class: className = '',
 } = Astro.props;
 
@@ -42,27 +48,22 @@ const Tag = href ? 'a' : 'div';
 const tagProps = href
   ? {
       href,
-      ...(external
-        ? { target: '_blank', rel: 'noopener noreferrer' }
-        : {}),
+      ...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {}),
     }
   : {};
 
-const accentClass = {
-  accent: 'group-hover:text-brand-700 dark:group-hover:text-brand-300',
-  accent2: 'group-hover:text-accent2',
-  gold: 'group-hover:text-gold-ink',
-}[accent];
+const colorToken = TONE_COLOR[tone];
 ---
 
 <Tag
-  class={`card card-hover group block h-full p-6 ${className}`}
+  class:list={[
+    'card card-hover group block h-full p-6',
+    className,
+  ]}
   {...tagProps}
 >
-  {eyebrow && (
-    <p class={`mono-label !text-${accent}`}>{eyebrow}</p>
-  )}
-  <h3 class={`font-sans text-lg font-bold ${accentClass}`}>{title}</h3>
+  {eyebrow && <p class={`mono-label !text-${colorToken}`}>{eyebrow}</p>}
+  <h3 class={`mt-2 font-sans text-lg font-bold group-hover:text-${colorToken} transition-colors`}>{title}</h3>
   {description && (
     <p class="mt-2 text-sm leading-relaxed text-muted">{description}</p>
   )}
@@ -70,14 +71,17 @@ const accentClass = {
     <ul class="mt-4 space-y-1.5 text-sm">
       {bullets.map((b) => (
         <li class="flex gap-2 text-muted">
-          <span class={`text-${accent} mt-1.5 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0`} aria-hidden="true"></span>
+          <span
+            class={`text-${colorToken} mt-1.5 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0`}
+            aria-hidden="true"
+          />
           <span>{b}</span>
         </li>
       ))}
     </ul>
   )}
   {href && (
-    <p class={`mt-3 text-xs ${accent === 'gold' ? 'text-gold-ink' : `text-${accent}`} group-hover:underline`}>
+    <p class={`mt-3 text-xs text-${colorToken} group-hover:underline`}>
       Read more →
     </p>
   )}

--- a/src/components/astro/primitives/CtaLink.astro
+++ b/src/components/astro/primitives/CtaLink.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * CtaLink — the "Read more →" pattern repeated across the site.
+ *
+ * One paragraph element, three concerns: destination, label,
+ * trailing arrow. Tone matches the section context.
+ */
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+
+interface Props {
+  href: string;
+  label: string;
+  tone?: BrandTone;
+  /** Render inline (default) or as a block above other content. */
+  block?: boolean;
+  class?: string;
+}
+
+const {
+  href,
+  label,
+  tone = 'blue',
+  block = false,
+  class: className = '',
+} = Astro.props;
+
+const toneText = `text-${TONE_COLOR[tone]}`;
+const tag = block ? 'p' : 'span';
+---
+
+<tag
+  class:list={[
+    'font-semibold hover:underline underline-offset-4 decoration-2 transition-colors',
+    toneText,
+    block ? 'mt-8 text-center' : '',
+    className,
+  ]}
+>
+  <a href={href} class="inline-flex items-center gap-1">
+    {label}
+    <span aria-hidden="true">→</span>
+  </a>
+</tag>

--- a/src/components/astro/primitives/ModeVenn.astro
+++ b/src/components/astro/primitives/ModeVenn.astro
@@ -1,0 +1,83 @@
+---
+/**
+ * ModeVenn — the three-circle brand motif, reusable.
+ *
+ * The Confium logo is three overlapping circles (blue + teal +
+ * gold) representing the three deployment modes — each distinct,
+ * each overlapping the shared engine at the center.
+ *
+ * This motif is the brand's signature device. Used in:
+ *   - `compact` — inline at logo size (header wordmark alternative)
+ *   - `feature` — hero backdrop, large with translucent fills
+ *   - `divider` — section divider hairline
+ *
+ * The SVG paths are the same as SymbolLogo.astro so the geometry
+ * stays canonical.
+ */
+import type { BrandTone } from '@data/homepage';
+
+interface Props {
+  variant?: 'compact' | 'feature' | 'divider';
+  class?: string;
+}
+
+const { variant = 'compact', class: className = '' } = Astro.props;
+
+const blue = '#1a7bec';
+const teal = '#00dfb7';
+const gold = '#ffdc4a';
+
+// Geometry matches SymbolLogo.astro. viewBox 275.37 x 167.48.
+const CIRCLE_PATHS = `
+  M95.79,83.73a95.44,95.44,0,0,1,31.82-71.27,83.73,83.73,0,1,0,0,142.54A95.44,95.44,0,0,1,95.79,83.73Z
+  M179.46,83.73A95.44,95.44,0,0,1,147.6,155a83.73,83.73,0,1,0,0-142.54A95.44,95.44,0,0,1,179.46,83.73Z
+  M167.49,83.73a83.57,83.57,0,0,0-29.87-64,83.59,83.59,0,0,0,0,128.09A83.57,83.57,0,0,0,167.49,83.73Z
+`.trim().split(/\s+/);
+---
+
+{
+  variant === 'divider' ? (
+    <div class:list={['mode-venn-divider', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-8 opacity-50"
+      >
+        <path fill={blue} fill-opacity="0.7" d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} fill-opacity="0.7" d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} fill-opacity="0.7" d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </div>
+  ) : variant === 'feature' ? (
+    <div class:list={['mode-venn-feature pointer-events-none select-none', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <defs>
+          <filter id="venn-soft" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="0.4" />
+          </filter>
+        </defs>
+        <g filter="url(#venn-soft)" opacity="0.42">
+          <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+          <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+          <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+        </g>
+      </svg>
+    </div>
+  ) : (
+    <span class:list={['inline-block mode-venn-compact', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </span>
+  )
+}

--- a/src/components/astro/primitives/Section.astro
+++ b/src/components/astro/primitives/Section.astro
@@ -1,0 +1,84 @@
+---
+/**
+ * Section — the canonical page-section wrapper.
+ *
+ * Owns: max-width container, vertical rhythm, optional header
+ * (eyebrow + title + lead), optional background tone.
+ *
+ * Does NOT own: card grids, timelines, interactive widgets — those
+ * go in the default slot.
+ *
+ * OCP: section variations come from the named `header` slot. The
+ * declarative props (`eyebrow` / `title` / `lead`) cover the
+ * common case; if you need a quote or a code snippet or a
+ * pull-stat as the section opener, use `<slot name="header" />`
+ * instead and the props are ignored.
+ */
+import type { BrandTone } from '@data/homepage';
+
+interface Props {
+  eyebrow?: string;
+  title?: string;
+  lead?: string;
+  /** Tints the background. `undefined` = neutral surface. */
+  tone?: BrandTone;
+  /** Add a bottom hairline (default true). */
+  bordered?: boolean;
+  /** Element id for in-page anchors. */
+  id?: string;
+  /** Extra classes on the outer <section>. */
+  class?: string;
+}
+
+const {
+  eyebrow,
+  title,
+  lead,
+  tone,
+  bordered = true,
+  id,
+  class: className = '',
+} = Astro.props;
+
+const toneBg = tone === 'blue'
+  ? 'bg-tint-blue'
+  : tone === 'teal'
+    ? 'bg-tint-teal'
+    : tone === 'gold'
+      ? 'bg-tint-gold'
+      : '';
+
+const hasHeaderSlot = Astro.slots.has('header');
+const hasDefaultSlot = Astro.slots.has('default');
+---
+
+<section
+  id={id}
+  class:list={[
+    'relative',
+    bordered && 'border-b border-line',
+    toneBg,
+    className,
+  ]}
+>
+  <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
+    {hasHeaderSlot ? (
+      <slot name="header" />
+    ) : (eyebrow || title || lead) && (
+      <header class="reveal">
+        {eyebrow && <p class="mono-label">{eyebrow}</p>}
+        {title && (
+          <h2 class="display-mono mt-3">{title}</h2>
+        )}
+        {lead && (
+          <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">{lead}</p>
+        )}
+      </header>
+    )}
+    {hasDefaultSlot && (
+      <div class:list={[ (eyebrow || title || lead || hasHeaderSlot) && 'mt-10' ]}>
+        <slot />
+      </div>
+    )}
+  </div>
+</section>

--- a/src/components/astro/primitives/Timeline.astro
+++ b/src/components/astro/primitives/Timeline.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * Timeline — horizontal step sequence.
+ *
+ * Renders an ordered sequence as a connected horizontal flow:
+ * numbered circles + connecting hairlines. Used for the
+ * "Generate → Distribute → Sign → Refresh → Anchor" pipeline.
+ *
+ * Order carries information here (each step depends on the
+ * previous), so the visual encodes order. A card grid would
+ * lose that signal.
+ */
+import type { Step } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+
+interface Props {
+  steps: readonly Step[];
+  class?: string;
+}
+
+const { steps, class: className = '' } = Astro.props;
+---
+
+<ol
+  class:list={[
+    'grid gap-3 sm:grid-cols-2 lg:grid-cols-5',
+    className,
+  ]}
+>
+  {steps.map((step, i) => (
+    <li
+      class="reveal relative card card-hover h-full p-5"
+      data-reveal-delay={i * 60}
+    >
+      <span
+        class:list={[
+          'absolute -top-3 left-5 w-7 h-7 rounded-full text-white font-mono text-xs font-bold flex items-center justify-center shadow-card',
+          step.tone === 'blue' && 'bg-accent',
+          step.tone === 'teal' && 'bg-accent2',
+          step.tone === 'gold' && 'bg-gold',
+        ]}
+        aria-hidden="true"
+      >
+        {step.n}
+      </span>
+      <h3 class="mt-3 font-sans text-base font-bold">{step.title}</h3>
+      <p class={`mt-1.5 text-xs leading-relaxed text-${TONE_COLOR[step.tone]}`}>{step.body}</p>
+    </li>
+  ))}
+</ol>

--- a/src/components/astro/sections/Hero.astro
+++ b/src/components/astro/sections/Hero.astro
@@ -1,0 +1,84 @@
+---
+/**
+ * Hero — the homepage's opening thesis.
+ *
+ * The thesis is the one thing only Confium can say:
+ *
+ *     No single party can sign alone.
+ *
+ * Stating it as copy is weaker than demonstrating it. So the hero
+ * leads with the QuorumPlayground — a visitor who drags the
+ * slider for 20 seconds understands the product. No diagram or
+ * copy will do it faster.
+ *
+ * Behind the content: a large ModeVenn (three-circle brand motif)
+ * as a translucent backdrop. The brand identity is visible at
+ * first glance and ties to the Three Modes section below.
+ */
+import QuorumPlayground from '../../vue/QuorumPlayground.vue';
+import ModeVenn from '../primitives/ModeVenn.astro';
+import SymbolLogo from '../../brand/SymbolLogo.astro';
+---
+
+<section class="hero-gradient relative overflow-hidden text-white">
+  <div class="hero-grid absolute inset-0" aria-hidden="true"></div>
+
+  <!-- Three-circle motif as hero backdrop -->
+  <div
+    class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[60rem] h-[36rem] opacity-25 pointer-events-none hidden lg:block"
+    aria-hidden="true"
+  >
+    <ModeVenn variant="feature" class="w-full h-full" />
+  </div>
+
+  <div class="relative mx-auto w-full max-w-6xl px-6 pb-20 pt-28 md:pb-24 md:pt-36">
+    <div class="grid items-center gap-10 lg:grid-cols-[1.05fr_1fr]">
+      <div>
+        <div class="flex items-center gap-3 mb-6">
+          <span class="w-12 h-7 inline-block drop-shadow-lg">
+            <SymbolLogo class="w-full h-full" />
+          </span>
+          <p class="mono-label !text-white/80">
+            Threshold cryptography · Post-quantum ready · Open source
+          </p>
+        </div>
+
+        <h1 class="display-mono-lg text-white font-bold text-balance">
+          No single party<br />
+          can sign alone.
+        </h1>
+
+        <p class="mt-6 max-w-xl text-lg leading-relaxed text-white/85">
+          Confium is the threshold-native trust infrastructure for
+          settings where no single party can be fully trusted alone.
+          A configurable quorum must participate. Every operation
+          anchors into a transparency log.
+        </p>
+
+        <div class="mt-8 flex flex-wrap items-center gap-3">
+          <a href="/docs/architecture/" class="btn btn-white">
+            Read the architecture
+            <span aria-hidden="true">→</span>
+          </a>
+          <a href="#install" class="btn btn-outline-white">
+            Install
+          </a>
+          <a href="/concepts/threshold-crypto-101/" class="btn btn-outline-white">
+            New to threshold crypto?
+          </a>
+        </div>
+
+        <p class="mt-6 text-xs font-mono text-white/60 tracking-wider">
+          BSD-2-Clause · No licensing fees · Sponsored by NLnet + Mozilla MOSS
+        </p>
+      </div>
+
+      <div class="lg:justify-self-end w-full max-w-md lg:w-[34rem]">
+        <p class="mono-label !text-white/70 mb-3 text-center lg:text-left">
+          Drag the slider. Watch what happens.
+        </p>
+        <QuorumPlayground client:load />
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/astro/sections/SignOff.astro
+++ b/src/components/astro/sections/SignOff.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * SignOff — the homepage's quiet ending.
+ *
+ * Replaces the previous duplicate-gradient CTA. A confident product
+ * doesn't shout twice; the hero already made the case. This section
+ * just acknowledges sponsors and offers two concrete next steps.
+ */
+import { SPONSORS } from '@data/homepage';
+---
+
+<section class="border-b border-line">
+  <div class="mx-auto w-full max-w-5xl px-6 py-12 md:py-16">
+    <div class="grid sm:grid-cols-3 gap-6 max-w-4xl mx-auto">
+      {SPONSORS.map((sponsor) => (
+        <a
+          href={sponsor.href}
+          class="card card-hover group p-5 flex flex-col items-center text-center"
+        >
+          <div class="h-16 flex items-center justify-center mb-3">
+            {sponsor.imageSrc ? (
+              <img
+                src={sponsor.imageSrc}
+                alt={sponsor.imageAlt ?? sponsor.name}
+                class="max-h-16 w-auto"
+                loading="lazy"
+              />
+            ) : (
+              <span class="font-sans text-2xl font-bold">{sponsor.wordmarkText ?? sponsor.name}</span>
+            )}
+          </div>
+          <p class="font-sans text-sm font-semibold">{sponsor.name}</p>
+          <p class="mt-1 text-xs text-faint">{sponsor.role}</p>
+        </a>
+      ))}
+    </div>
+
+    <div class="mt-10 pt-8 border-t border-line text-center">
+      <p class="font-mono text-xs text-faint tracking-wider">
+        BSD-2-Clause · Sponsored by NLnet NGI Zero PET + Mozilla MOSS · Built in the open
+      </p>
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <a href="/docs/getting-started/" class="btn btn-primary">
+          Get started
+          <span aria-hidden="true">→</span>
+        </a>
+        <a href="/docs/architecture/" class="btn btn-ghost">
+          Read the architecture
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/astro/sections/ThreeModes.astro
+++ b/src/components/astro/sections/ThreeModes.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * ThreeModes — the actual structure of the product, visualised as
+ * three colored bands matching the brand's three-circle motif.
+ *
+ * Each mode is a full-width tinted strip (blue / teal / gold),
+ * making the page's identity structural rather than decorative.
+ * A visitor scrolling through sees the three colors resolve just
+ * as they do in the logo.
+ */
+import { MODES, TONE_COLOR } from '@data/homepage';
+import CtaLink from '../primitives/CtaLink.astro';
+---
+
+<section class="border-b border-line">
+  <div class="mx-auto w-full max-w-6xl px-6 pt-12 md:pt-16 pb-6">
+    <header class="reveal">
+      <p class="mono-label">Three deployment modes</p>
+      <h2 class="display-mono mt-3">One engine, three integration shapes</h2>
+      <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
+        The same primitives serve all three. What changes is the
+        integration boundary — peer-to-peer network code, a PKCS#11
+        adapter, or a full Sovereign PKI profile with custom
+        certificate formats and attribute-based quorum policies.
+      </p>
+    </header>
+  </div>
+
+  {MODES.map((mode, i) => (
+    <div
+      class:list={[
+        'border-t border-line reveal',
+        mode.tone === 'blue' && 'bg-tint-blue',
+        mode.tone === 'teal' && 'bg-tint-teal',
+        mode.tone === 'gold' && 'bg-tint-gold',
+      ]}
+      data-reveal-delay={i * 80}
+    >
+      <div class="mx-auto w-full max-w-6xl px-6 py-10 md:py-12">
+        <div class="grid lg:grid-cols-[0.5fr_1fr_1fr] gap-6 lg:gap-10 items-start">
+          <div>
+            <p class={`mono-label !text-${TONE_COLOR[mode.tone]}`}>
+              {mode.label}
+            </p>
+            <h3 class={`mt-2 font-sans text-2xl font-bold text-${TONE_COLOR[mode.tone]}`}>
+              {mode.name}
+            </h3>
+            <p class="mt-1 text-sm font-mono text-faint">{mode.tagline}</p>
+          </div>
+
+          <div>
+            <p class="text-base leading-relaxed text-fg">{mode.description}</p>
+          </div>
+
+          <div>
+            <ul class="space-y-2 text-sm">
+              {mode.bullets.map((b) => (
+                <li class="flex gap-2 text-muted">
+                  <span
+                    class={`text-${TONE_COLOR[mode.tone]} mt-1.5 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0`}
+                    aria-hidden="true"
+                  />
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+            <div class="mt-5">
+              <CtaLink href={mode.href} label={mode.ctaLabel} tone={mode.tone} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  ))}
+</section>

--- a/src/components/vue/QuorumPlayground.vue
+++ b/src/components/vue/QuorumPlayground.vue
@@ -1,137 +1,157 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+/**
+ * QuorumPlayground — interactive threshold cryptography demo.
+ *
+ * Presentation layer over `lib/quorum.ts`. The math is pure and
+ * unit-tested; this component only renders state and routes slider
+ * input to state transitions.
+ *
+ * Status indicator is `aria-live` so screen-reader users hear
+ * state changes as the slider moves.
+ */
+import { computed, ref, watch } from 'vue';
+import {
+  MAX_TOTAL,
+  MIN_TOTAL,
+  describeStatus,
+  quorumState,
+  type QuorumStatus,
+} from '@lib/quorum';
 
 const total = ref(5);
 const threshold = ref(3);
-const attempted = ref(0);
+const participating = ref(0);
 
-const insufficient = computed(() => attempted.value > 0 && attempted.value < threshold.value);
-const quorumReached = computed(() => attempted.value >= threshold.value);
-const canSign = computed(() => quorumReached.value);
+const state = computed(() =>
+  quorumState(total.value, threshold.value, participating.value),
+);
 
-const parties = computed(() => {
-  return Array.from({ length: total.value }, (_, i) => ({
-    id: i,
-    signed: i < attempted.value,
-  }));
-});
+const statusText = computed(() => describeStatus(state.value));
 
-function attempt(value: number) {
-  attempted.value = Math.min(value, total.value);
-}
-
-function reset() {
-  attempted.value = 0;
-}
-
-// Keep threshold sensible when total changes.
+// Keep threshold ≤ total when total drops.
 watch(total, (n) => {
   if (threshold.value > n) threshold.value = n;
-  if (attempted.value > n) attempted.value = n;
+  if (participating.value > n) participating.value = n;
 });
+
+function setParticipating(value: number) {
+  participating.value = Math.max(0, Math.min(value, total.value));
+}
+
+const statusDotClass = (status: QuorumStatus) =>
+  status === 'ready'
+    ? 'bg-accent2'
+    : status === 'insufficient'
+      ? 'bg-warning'
+      : 'bg-faint/40';
+
+const partyClass = (signed: boolean) =>
+  signed
+    ? 'bg-accent text-white border-accent shadow-card'
+    : 'bg-surface text-muted border-line hover:border-accent';
 </script>
 
 <template>
-  <div class="rounded-lg border border-line bg-card p-6 shadow-card">
+  <div class="rounded-2xl border border-line bg-surface p-6 shadow-card">
     <div class="grid sm:grid-cols-2 gap-6 mb-6">
       <div>
-        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+        <label
+          for="qp-total"
+          class="mono-label"
+        >
           Total parties (N)
         </label>
         <div class="mt-2 flex items-center gap-3">
           <input
+            id="qp-total"
             v-model.number="total"
             type="range"
-            min="2"
-            max="9"
-            class="w-full accent-brand-600"
+            :min="MIN_TOTAL"
+            :max="MAX_TOTAL"
+            class="qp-range w-full"
           />
-          <span class="font-mono text-lg w-8 text-right">{{ total }}</span>
+          <output for="qp-total" class="font-mono text-lg w-8 text-right tabular-nums">
+            {{ total }}
+          </output>
         </div>
       </div>
       <div>
-        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
-          Threshold required (T)
+        <label
+          for="qp-threshold"
+          class="mono-label"
+        >
+          Threshold (T)
         </label>
         <div class="mt-2 flex items-center gap-3">
           <input
+            id="qp-threshold"
             v-model.number="threshold"
             type="range"
-            min="2"
+            :min="MIN_TOTAL"
             :max="total"
-            class="w-full accent-brand-600"
+            class="qp-range w-full"
           />
-          <span class="font-mono text-lg w-8 text-right">{{ threshold }}</span>
+          <output for="qp-threshold" class="font-mono text-lg w-8 text-right tabular-nums">
+            {{ threshold }}
+          </output>
         </div>
       </div>
     </div>
 
     <div>
       <div class="flex items-center justify-between mb-3">
-        <label class="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+        <label for="qp-signers" class="mono-label">
           Signers participating
         </label>
-        <span class="text-xs text-muted-foreground">
-          {{ attempted }} / {{ total }} (need {{ threshold }})
+        <span class="text-xs text-muted font-mono">
+          {{ participating }} / {{ total }} (need {{ threshold }})
         </span>
       </div>
       <input
-        :value="attempted"
+        id="qp-signers"
+        :value="participating"
         type="range"
         min="0"
         :max="total"
-        class="w-full accent-brand-600"
-        @input="attempt(Number(($event.target as HTMLInputElement).value))"
+        class="qp-range w-full"
+        @input="setParticipating(Number(($event.target as HTMLInputElement).value))"
       />
     </div>
 
-    <div class="mt-6 flex flex-wrap gap-2">
+    <div class="mt-6 flex flex-wrap gap-2" role="group" aria-label="Parties">
       <button
-        v-for="p in parties"
+        v-for="p in state.parties"
         :key="p.id"
         type="button"
         :class="[
-          'w-12 h-12 rounded-full font-mono text-sm border transition-all',
-          p.signed
-            ? 'bg-brand-600 text-white border-brand-600 shadow-card'
-            : 'bg-card text-muted-foreground border-line hover:border-brand-400',
+          'w-11 h-11 rounded-full font-mono text-sm border transition-all',
+          partyClass(p.signed),
         ]"
         :title="`Party ${p.id + 1}${p.signed ? ' (signed)' : ''}`"
-        @click="attempt(p.signed ? p.id : p.id + 1)"
+        :aria-pressed="p.signed"
+        @click="setParticipating(p.signed ? p.id : p.id + 1)"
       >
         {{ p.id + 1 }}
       </button>
     </div>
 
-    <div class="mt-6 p-4 rounded-md border border-line bg-brand-50/30 dark:bg-brand-900/10">
-      <div class="flex items-center gap-3">
-        <div
-          :class="[
-            'w-3 h-3 rounded-full',
-            canSign
-              ? 'bg-brand-500'
-              : insufficient
-                ? 'bg-amber-500'
-                : 'bg-muted-foreground/40',
-          ]"
+    <div
+      class="mt-6 p-4 rounded-lg border border-line bg-surface-dim"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="flex items-start gap-3">
+        <span
+          :class="['mt-1.5 w-3 h-3 rounded-full flex-shrink-0 transition-colors', statusDotClass(state.status)]"
+          aria-hidden="true"
         />
-        <p class="text-sm">
-          <template v-if="attempted === 0">
-            No signers yet — the signature cannot be produced.
-          </template>
-          <template v-else-if="insufficient">
-            Only {{ attempted }} of {{ threshold }} required signers
-            participated. <strong>No single party can sign alone.</strong>
-          </template>
-          <template v-else-if="canSign">
-            Quorum reached: {{ attempted }} ≥ {{ threshold }}.
-            The composite signature is valid.
-          </template>
+        <p class="text-sm leading-relaxed">
+          {{ statusText }}
         </p>
       </div>
     </div>
 
-    <p class="mt-4 text-xs text-muted-foreground">
+    <p class="mt-4 text-xs text-muted leading-relaxed">
       Adjust N and T to model any quorum policy — 3-of-5 directors,
       5-of-9 from 3 distinct regions, and so on. Confium's
       attribute-based threshold DSL expresses policies that the
@@ -139,3 +159,9 @@ watch(total, (n) => {
     </p>
   </div>
 </template>
+
+<style scoped>
+.qp-range {
+  accent-color: var(--accent);
+}
+</style>

--- a/src/data/homepage.ts
+++ b/src/data/homepage.ts
@@ -1,0 +1,190 @@
+/**
+ * Typed homepage content — single source of truth for the homepage
+ * and any component that needs homepage data (e.g. ModeSelector).
+ *
+ * Components consume these models; they never hardcode content.
+ */
+
+export type ModeId = 'peer-tc' | 'pki-drop-in' | 'sovereign-pki';
+
+/**
+ * The three identity tones of the Confium brand. Map 1:1 to the
+ * three-circle logo and the three deployment modes. Used by Card,
+ * Section, ModeVenn, and Timeline to tint mode-specific surfaces.
+ */
+export type BrandTone = 'blue' | 'teal' | 'gold';
+
+export interface Mode {
+  readonly id: ModeId;
+  readonly tone: BrandTone;
+  readonly label: string;
+  readonly name: string;
+  readonly tagline: string;
+  readonly description: string;
+  readonly bullets: readonly string[];
+  readonly href: string;
+  readonly ctaLabel: string;
+}
+
+export interface ProofPoint {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface Deployment {
+  readonly name: string;
+  readonly body: string;
+}
+
+export interface Step {
+  readonly n: number;
+  readonly title: string;
+  readonly body: string;
+  readonly tone: BrandTone;
+}
+
+export interface Sponsor {
+  readonly name: string;
+  readonly role: string;
+  readonly href: string;
+  readonly imageSrc?: string;
+  readonly imageAlt?: string;
+  readonly wordmarkText?: string;
+}
+
+export const MODES: readonly Mode[] = [
+  {
+    id: 'peer-tc',
+    tone: 'blue',
+    label: 'Mode 1',
+    name: 'Peer-to-Peer TC',
+    tagline: 'Direct threshold cryptography between nodes.',
+    description:
+      'The simplest deployment: nodes exchange threshold signing messages directly over the transport of choice. No intermediary, no PKI, no translation layer. Use this when you control both ends of the channel and you want minimal moving parts.',
+    bullets: [
+      'MPC, distributed custody, BFT consensus',
+      'Async sessions across hours or days',
+      'Two-round FROST signing, three-round CMP20',
+    ],
+    href: '/docs/mode1-peer-tc/',
+    ctaLabel: 'Read the Mode 1 docs',
+  },
+  {
+    id: 'pki-drop-in',
+    tone: 'teal',
+    label: 'Mode 2',
+    name: 'PKI Drop-in',
+    tagline: 'Threshold keys, unchanged consumers.',
+    description:
+      'Drop Confium in front of existing PKCS#11, OpenSSL, or JCE consumers. They keep working unchanged — but every signature now requires a threshold quorum behind the scenes. This is the natural home for post-quantum migration via composite signatures.',
+    bullets: [
+      'PKCS#11 v3.0 server, OpenSSL 3.0 provider, JCE, TLS signer',
+      'HSM replacement without replacing the HSM consumer',
+      'Composite Ed25519 + ECDSA-P256 + ML-DSA-65 signatures',
+    ],
+    href: '/docs/mode2-pki-drop-in/',
+    ctaLabel: 'Read the Mode 2 docs',
+  },
+  {
+    id: 'sovereign-pki',
+    tone: 'gold',
+    label: 'Mode 3',
+    name: 'Sovereign PKI',
+    tagline: 'Institutional PKI without a single trusted party.',
+    description:
+      'Custom certificate formats, delegation rules, archival cadence, and quorum composition for institutions where no single stakeholder can be trusted. Sovereignty over formats, jurisdictions, governance — the things conventional PKI locks down.',
+    bullets: [
+      'Custom certificate profiles via confium-cert',
+      'Attribute-based quorum: 5-of-9 directors from 3 regions',
+      'Transparency log + OTS anchoring + RFC 4998 ERS archival',
+    ],
+    href: '/docs/mode3-sovereign-pki/',
+    ctaLabel: 'Read the Mode 3 docs',
+  },
+] as const;
+
+export const PROOF_POINTS: readonly ProofPoint[] = [
+  {
+    title: 'Software upgrade, not HSM replacement',
+    body: 'Migrate to post-quantum signatures without re-issuing every certificate. Add an ML-DSA-65 component alongside Ed25519 via composite signatures; verifiers that haven\'t upgraded still accept the classical component, verifiers that have already migrated. No flag day, no forklift upgrade, no new hardware.',
+  },
+  {
+    title: 'Catches silent certificate fraud',
+    body: 'Every signing operation anchors into an append-only Merkle transparency log implementing RFC 6962. Split-view attacks become detectable via consistency proofs and witness gossip between coordinators. Optional OpenTimestamps anchoring in Bitcoin gives an irrefutable "what head existed at time T" record.',
+  },
+  {
+    title: 'Standards-only — no vendor lock-in',
+    body: 'PKCS#11 v3.0, OpenSSL 3.0 provider, JCE provider, CMS (RFC 5652), X.509, RFC 6962 transparency. Confium slots into existing infrastructure; it never asks you to adopt a proprietary protocol or a single-vendor SDK.',
+  },
+  {
+    title: 'Globally distributed signers',
+    body: 'The async coordinator handles round-trip latency across continents. Parties don\'t need to be online simultaneously — sessions complete over hours or days. A director in Tokyo can sign during their workday; a director in New York submits theirs hours later; the coordinator combines when quorum is reached.',
+  },
+  {
+    title: 'Open source, BSD-2-Clause',
+    body: 'No per-transaction fees, no proprietary protocol, no CLA. Funded by the European Commission through NLnet\'s NGI Zero PET program and by Mozilla MOSS. Project decisions stay with the maintainer collective.',
+  },
+  {
+    title: 'No unsafe code, anywhere',
+    body: 'Every crate carries `#![forbid(unsafe_code)]`. FFI is centralized in confium-core and uses edition 2024\'s #[unsafe(no_mangle)] form. All threshold protocols (FROST, CMP20, GG18) ship real cryptography — not stubs, not placeholders, not unfinished work.',
+  },
+] as const;
+
+export const DEPLOYMENTS: readonly Deployment[] = [
+  { name: 'Calibration registries', body: 'BIPM-style metrology chains where measurements must be traceable to a sovereign reference.' },
+  { name: 'Pharma regulator approvals', body: 'Multi-jurisdiction regulatory sign-off on clinical trial data and drug approvals.' },
+  { name: 'Academic accreditation', body: 'Cross-institutional degree and credential verification without a single trusted authority.' },
+  { name: 'Supply-chain provenance', body: 'Manufacturing step attestation anchored in a public transparency log.' },
+  { name: 'Treaty organizations', body: 'Multi-state cooperative instruments requiring concurrent sovereign approval.' },
+  { name: 'Certified instruments registry', body: 'A reference Mode 3 deployment among many others.' },
+] as const;
+
+export const STEPS: readonly Step[] = [
+  { n: 1, title: 'Generate', body: 'Distributed key generation ceremony. Secret exists once, then is split.', tone: 'blue' },
+  { n: 2, title: 'Distribute', body: 'Shares go to N parties. No single party holds the full key.', tone: 'teal' },
+  { n: 3, title: 'Sign', body: 'T-of-N quorum co-signs without reconstructing the secret.', tone: 'blue' },
+  { n: 4, title: 'Refresh', body: 'Shares re-randomize periodically. Compromise windows shrink.', tone: 'gold' },
+  { n: 5, title: 'Anchor', body: 'Event lands in transparency log. Public, auditable, immutable.', tone: 'teal' },
+] as const;
+
+export const SPONSORS: readonly Sponsor[] = [
+  {
+    name: 'NLnet',
+    role: 'Project sponsor',
+    href: 'https://nlnet.nl/project/Confium/',
+    imageSrc: '/assets/nlnet-banner.svg',
+    imageAlt: 'NLnet',
+  },
+  {
+    name: 'NGI Zero PET',
+    role: 'European Commission · Next Generation Internet',
+    href: 'https://www.ngi.eu/ngi-projects/ngi-zero-pet/',
+    imageSrc: '/assets/ngi-zeropet-banner.svg',
+    imageAlt: 'NGI Zero PET',
+  },
+  {
+    name: 'Mozilla MOSS',
+    role: 'Open Source Support',
+    href: 'https://www.mozilla.org/moss/',
+    wordmarkText: 'mozilla',
+  },
+] as const;
+
+/**
+ * Map a BrandTone to its semantic CSS color token name. Centralised
+ * so consumers never branch on tone — they look up the token.
+ */
+export const TONE_COLOR: Readonly<Record<BrandTone, 'accent' | 'accent2' | 'gold-ink'>> = {
+  blue: 'accent',
+  teal: 'accent2',
+  gold: 'gold-ink',
+};
+
+/**
+ * Map a BrandTone to its tint CSS token (for backgrounds).
+ */
+export const TONE_TINT: Readonly<Record<BrandTone, 'tint-blue' | 'tint-teal' | 'tint-gold'>> = {
+  blue: 'tint-blue',
+  teal: 'tint-teal',
+  gold: 'tint-gold',
+};

--- a/src/lib/quorum.test.ts
+++ b/src/lib/quorum.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_TOTAL,
+  MIN_TOTAL,
+  describeStatus,
+  quorumState,
+  type QuorumState,
+} from './quorum';
+
+describe('quorumState', () => {
+  describe('invariants', () => {
+    it('clamps total to [MIN_TOTAL, MAX_TOTAL]', () => {
+      expect(quorumState(0, 2, 0).total).toBe(MIN_TOTAL);
+      expect(quorumState(1, 2, 0).total).toBe(MIN_TOTAL);
+      expect(quorumState(999, 2, 0).total).toBe(MAX_TOTAL);
+    });
+
+    it('clamps threshold to [MIN_TOTAL, total]', () => {
+      expect(quorumState(5, 0, 0).threshold).toBe(MIN_TOTAL);
+      expect(quorumState(5, 1, 0).threshold).toBe(MIN_TOTAL);
+      expect(quorumState(5, 999, 0).threshold).toBe(5);
+    });
+
+    it('clamps participating to [0, total]', () => {
+      expect(quorumState(5, 3, -10).participating).toBe(0);
+      expect(quorumState(5, 3, 999).participating).toBe(5);
+    });
+
+    it('parties array length matches total', () => {
+      const s = quorumState(7, 3, 2);
+      expect(s.parties).toHaveLength(7);
+    });
+
+    it('parties.signed reflects participating count, in order', () => {
+      const s = quorumState(5, 3, 3);
+      expect(s.parties.map((p) => p.signed)).toEqual([true, true, true, false, false]);
+    });
+
+    it('parties have stable ids 0..n-1', () => {
+      const s = quorumState(4, 2, 0);
+      expect(s.parties.map((p) => p.id)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns a frozen-shape object (no mutation of inputs)', () => {
+      const s1 = quorumState(5, 3, 2);
+      const s2 = quorumState(5, 3, 2);
+      expect(s1).toEqual(s2);
+    });
+  });
+
+  describe('status transitions', () => {
+    it('marks idle when no parties participate', () => {
+      expect(quorumState(5, 3, 0).status).toBe('idle');
+    });
+
+    it('marks insufficient below threshold', () => {
+      expect(quorumState(5, 3, 1).status).toBe('insufficient');
+      expect(quorumState(5, 3, 2).status).toBe('insufficient');
+    });
+
+    it('marks ready at exactly threshold', () => {
+      expect(quorumState(5, 3, 3).status).toBe('ready');
+    });
+
+    it('marks ready above threshold', () => {
+      expect(quorumState(5, 3, 4).status).toBe('ready');
+      expect(quorumState(5, 3, 5).status).toBe('ready');
+    });
+
+    it('canSign is true iff ready', () => {
+      const cases: Array<[number, number, number]> = [
+        [5, 3, 0],
+        [5, 3, 1],
+        [5, 3, 2],
+        [5, 3, 3],
+        [5, 3, 4],
+      ];
+      for (const [n, t, p] of cases) {
+        const s = quorumState(n, t, p);
+        expect(s.canSign).toBe(s.status === 'ready');
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles minimum valid quorum (T=2, N=2)', () => {
+      const s = quorumState(2, 2, 1);
+      expect(s.status).toBe('insufficient');
+      expect(quorumState(2, 2, 2).status).toBe('ready');
+    });
+
+    it('handles T=N (all parties required)', () => {
+      const s = quorumState(3, 3, 2);
+      expect(s.status).toBe('insufficient');
+      expect(quorumState(3, 3, 3).status).toBe('ready');
+    });
+
+    it('handles MAX_TOTAL boundary', () => {
+      const s = quorumState(MAX_TOTAL, 5, 5);
+      expect(s.status).toBe('ready');
+      expect(s.parties).toHaveLength(MAX_TOTAL);
+    });
+
+    it('floors non-integer inputs', () => {
+      const s = quorumState(5.9, 3.9, 2.9);
+      expect(s.total).toBe(5);
+      expect(s.threshold).toBe(3);
+      expect(s.participating).toBe(2);
+    });
+  });
+});
+
+describe('describeStatus', () => {
+  it('describes idle state in active voice', () => {
+    const s: QuorumState = quorumState(5, 3, 0);
+    expect(describeStatus(s)).toMatch(/no signers/i);
+  });
+
+  it('describes insufficient state with the count', () => {
+    const s = quorumState(5, 3, 2);
+    const text = describeStatus(s);
+    expect(text).toContain('2');
+    expect(text).toContain('3');
+    expect(text).toMatch(/no single party can sign alone/i);
+  });
+
+  it('describes ready state with the quorum hit', () => {
+    const s = quorumState(5, 3, 3);
+    const text = describeStatus(s);
+    expect(text).toMatch(/quorum reached/i);
+    expect(text).toContain('3');
+  });
+});

--- a/src/lib/quorum.ts
+++ b/src/lib/quorum.ts
@@ -1,0 +1,92 @@
+/**
+ * Threshold-cryptography quorum math. Pure functions — no Vue, no
+ * DOM. The source of truth for "is this configuration valid, and
+ * what is its current signing state?".
+ *
+ * The QuorumPlayground Vue component is a thin presentation layer
+ * over these functions; the math itself is independently testable
+ * and reusable (could equally drive a CLI preview, a doc diagram,
+ * or a spec fixture).
+ */
+
+export type QuorumStatus = 'idle' | 'insufficient' | 'ready';
+
+export interface Party {
+  readonly id: number;
+  readonly signed: boolean;
+}
+
+export interface QuorumState {
+  readonly total: number;
+  readonly threshold: number;
+  readonly participating: number;
+  readonly status: QuorumStatus;
+  readonly canSign: boolean;
+  readonly parties: readonly Party[];
+}
+
+/** Lower bound on total parties — needs at least 2 for a meaningful threshold. */
+export const MIN_TOTAL = 2;
+
+/** Upper bound — kept small for UI slider range; math works for any N. */
+export const MAX_TOTAL = 9;
+
+/** Clamp a value into [lo, hi]. */
+function clamp(value: number, lo: number, hi: number): number {
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}
+
+/**
+ * Compute the canonical QuorumState for a (total, threshold,
+ * participating) triple. All inputs are clamped to valid ranges so
+ * callers can pass raw slider values.
+ *
+ * Invariants guaranteed on the returned state:
+ *   - MIN_TOTAL ≤ total ≤ MAX_TOTAL
+ *   - 2 ≤ threshold ≤ total
+ *   - 0 ≤ participating ≤ total
+ *   - parties.length === total, parties[i].signed === (i < participating)
+ */
+export function quorumState(
+  total: number,
+  threshold: number,
+  participating: number,
+): QuorumState {
+  const t = clamp(Math.floor(total), MIN_TOTAL, MAX_TOTAL);
+  const th = clamp(Math.floor(threshold), MIN_TOTAL, t);
+  const p = clamp(Math.floor(participating), 0, t);
+
+  const status: QuorumStatus =
+    p === 0 ? 'idle' : p < th ? 'insufficient' : 'ready';
+
+  const parties: Party[] = Array.from({ length: t }, (_, i) => ({
+    id: i,
+    signed: i < p,
+  }));
+
+  return {
+    total: t,
+    threshold: th,
+    participating: p,
+    status,
+    canSign: status === 'ready',
+    parties,
+  };
+}
+
+/**
+ * Human-readable description of the current status, in the
+ * interface's voice. Active voice, plain verbs, no filler.
+ */
+export function describeStatus(state: QuorumState): string {
+  switch (state.status) {
+    case 'idle':
+      return 'No signers yet — the signature cannot be produced.';
+    case 'insufficient':
+      return `Only ${state.participating} of ${state.threshold} required signers participated. No single party can sign alone.`;
+    case 'ready':
+      return `Quorum reached: ${state.participating} ≥ ${state.threshold}. The composite signature is valid.`;
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,89 +1,35 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import HeroDecrypt from '../components/vue/HeroDecrypt.vue';
-import ModeSelector from '../components/vue/ModeSelector.vue';
-import QuorumPlayground from '../components/vue/QuorumPlayground.vue';
+import Hero from '../components/astro/sections/Hero.astro';
+import ThreeModes from '../components/astro/sections/ThreeModes.astro';
+import SignOff from '../components/astro/sections/SignOff.astro';
+import Section from '../components/astro/primitives/Section.astro';
+import Card from '../components/astro/Card.astro';
+import CtaLink from '../components/astro/primitives/CtaLink.astro';
+import Timeline from '../components/astro/primitives/Timeline.astro';
 import InstallTabs from '../components/vue/InstallTabs.vue';
 import Reveal from '../components/vue/Reveal.vue';
-import ThreeModeDiagram from '../components/brand/ThreeModeDiagram.astro';
-import SymbolLogo from '../components/brand/SymbolLogo.astro';
+import { PROOF_POINTS, DEPLOYMENTS, STEPS } from '../data/homepage';
 
-const differences = [
+const blogPosts = [
   {
-    title: 'Software upgrade, not HSM replacement',
-    body: 'Migrate to post-quantum signatures without re-issuing every certificate. Add an ML-DSA-65 component alongside Ed25519 via composite signatures; verifiers that haven\'t upgraded still accept the classical component, verifiers that have already migrated. No flag day, no forklift upgrade, no new hardware.',
+    href: '/blog/2026-07-28-introducing-confium/',
+    title: 'Introducing Confium',
+    excerpt: 'Why we built a threshold-native trust infrastructure framework, and what ships today.',
+    category: 'Announcement',
   },
   {
-    title: 'Catches silent certificate fraud',
-    body: 'Every signing operation anchors into an append-only Merkle transparency log implementing RFC 6962. Split-view attacks become detectable via consistency proofs and witness gossip between coordinators. Optional OpenTimestamps anchoring in Bitcoin gives an irrefutable "what head existed at time T" record.',
+    href: '/blog/2026-07-28-sovereign-pki-launch/',
+    title: 'Sovereign PKI launch',
+    excerpt: 'Mode 3 deep dive — institutional trust without a single point of failure.',
+    category: 'Deep dive',
   },
   {
-    title: 'Standards-only — no vendor lock-in',
-    body: 'PKCS#11 v3.0, OpenSSL 3.0 provider, JCE provider, CMS (RFC 5652), X.509, RFC 6962 transparency. Confium slots into existing infrastructure; it never asks you to adopt a proprietary protocol or a single-vendor SDK.',
+    href: '/blog/2026-07-28-pq-migration-walkthrough/',
+    title: 'PQ migration walkthrough',
+    excerpt: 'How composite signatures turn migration into a software upgrade.',
+    category: 'Walkthrough',
   },
-  {
-    title: 'Globally distributed signers',
-    body: 'The async coordinator handles round-trip latency across continents. Parties don\'t need to be online simultaneously — sessions complete over hours or days. A director in Tokyo can sign during their workday; a director in New York submits theirs hours later; the coordinator combines when quorum is reached.',
-  },
-  {
-    title: 'Open source, BSD-2-Clause',
-    body: 'No per-transaction fees, no proprietary protocol, no CLAU. Funded by the European Commission through NLnet\'s NGI Zero PET program and by Mozilla MOSS. Project decisions stay with the maintainer collective.',
-  },
-  {
-    title: 'No unsafe code, anywhere',
-    body: 'Every crate carries `#![forbid(unsafe_code)]`. FFI is centralized in confium-core and uses edition 2024\'s #[unsafe(no_mangle)] form. All threshold protocols (FROST, CMP20, GG18) ship real cryptography — not stubs, not placeholders, not unfinished work.',
-  },
-];
-
-const modes = [
-  {
-    id: 'peer-tc',
-    name: 'Peer-to-Peer TC',
-    tagline: 'Direct threshold cryptography between nodes.',
-    description:
-      'The simplest deployment: nodes exchange threshold signing messages directly over the transport of choice. No intermediary, no PKI, no translation layer. Use this when you control both ends of the channel and you want minimal moving parts.',
-    bullets: [
-      'MPC, distributed custody, BFT consensus',
-      'Async sessions across hours or days',
-      'Two-round FROST signing, three-round CMP20',
-    ],
-    href: '/docs/mode1-peer-tc/',
-  },
-  {
-    id: 'pki-drop-in',
-    name: 'PKI Drop-in',
-    tagline: 'Threshold keys, unchanged consumers.',
-    description:
-      'Drop Confium in front of existing PKCS#11, OpenSSL, or JCE consumers. They keep working unchanged — but every signature now requires a threshold quorum behind the scenes. This is the natural home for post-quantum migration via composite signatures.',
-    bullets: [
-      'PKCS#11 v3.0 server, OpenSSL 3.0 provider, JCE, TLS signer',
-      'HSM replacement without replacing the HSM consumer',
-      'Composite Ed25519 + ECDSA-P256 + ML-DSA-65 signatures',
-    ],
-    href: '/docs/mode2-pki-drop-in/',
-  },
-  {
-    id: 'sovereign-pki',
-    name: 'Sovereign PKI',
-    tagline: 'Institutional PKI without a single trusted party.',
-    description:
-      'Custom certificate formats, delegation rules, archival cadence, and quorum composition for institutions where no single stakeholder can be trusted. Sovereignty over formats, jurisdictions, governance — the things conventional PKI locks down.',
-    bullets: [
-      'Custom certificate profiles via confium-cert',
-      'Attribute-based quorum: 5-of-9 directors from 3 regions',
-      'Transparency log + OTS anchoring + RFC 4998 ERS archival',
-    ],
-    href: '/docs/mode3-sovereign-pki/',
-  },
-];
-
-const deployments = [
-  { name: 'Calibration registries', body: 'BIPM-style metrology chains where measurements must be traceable to a sovereign reference.' },
-  { name: 'Pharma regulator approvals', body: 'Multi-jurisdiction regulatory sign-off on clinical trial data and drug approvals.' },
-  { name: 'Academic accreditation', body: 'Cross-institutional degree and credential verification without a single trusted authority.' },
-  { name: 'Supply-chain provenance', body: 'Manufacturing step attestation anchored in a public transparency log.' },
-  { name: 'Treaty organizations', body: 'Multi-state cooperative instruments requiring concurrent sovereign approval.' },
-  { name: 'Certified instruments registry', body: 'A reference Mode 3 deployment among many others.' },
 ];
 ---
 
@@ -92,565 +38,127 @@ const deployments = [
   description="Threshold-native trust infrastructure for a post-quantum world. A configurable framework organizations deploy with their own parameters."
   headerOverlay
 >
-  <!-- ===================== Hero ===================== -->
-  <section class="hero-gradient relative overflow-hidden text-white">
-    <div class="hero-grid absolute inset-0" aria-hidden="true"></div>
-    <!-- Floating logo watermark -->
-    <div class="absolute top-32 right-8 w-48 h-28 opacity-15 hidden lg:block" aria-hidden="true">
-      <SymbolLogo class="w-full h-full" />
-    </div>
-    <div class="relative mx-auto w-full max-w-6xl px-6 pb-20 pt-28 md:pb-24 md:pt-36">
-      <div class="grid items-center gap-10 lg:grid-cols-[1.15fr_1fr]">
-        <div>
-          <div class="flex items-center gap-3 mb-6">
-            <span class="w-12 h-7 inline-block drop-shadow-lg">
-              <SymbolLogo class="w-full h-full" />
-            </span>
-            <p class="mono-label text-white/80">Threshold cryptography · Post-quantum ready · Open source</p>
-          </div>
-          <h1 class="text-balance font-sans text-4xl font-bold leading-[1.12] tracking-tight text-white md:text-5xl md:leading-[1.08]">
-            <HeroDecrypt client:visible text="Threshold-native trust infrastructure" />
-            <span class="block text-white/90 mt-2">
-              for a post-quantum world.
-            </span>
-          </h1>
-          <p class="mt-6 max-w-xl text-lg leading-relaxed text-white/85">
-            Confium is to threshold cryptography what TLS libraries are to
-            transport security. You bring the algorithms, the quorum policy,
-            the certificate profile — Confium provides the engine, the
-            coordinator, the adapters, and the audit trail.
-          </p>
-          <p class="mt-3 max-w-xl text-base leading-relaxed text-white/70">
-            No single party holds the signing key. A configurable quorum
-            must participate. Every operation anchors into a transparency
-            log. BSD-2-Clause, sponsored by NLnet and NGI Zero PET.
-          </p>
-          <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a href="/docs/architecture/" class="btn btn-white">
-              Read the architecture
-              <span aria-hidden="true">→</span>
-            </a>
-            <a href="#install" class="btn btn-outline-white">
-              Install
-            </a>
-            <a href="/concepts/threshold-crypto-101/" class="btn btn-outline-white">
-              New to threshold crypto?
-            </a>
-          </div>
-        </div>
+  <Hero />
 
-        <div class="lg:justify-self-end">
-          <!-- Three-mode architecture SVG diagram -->
-          <ThreeModeDiagram class="w-full max-w-md lg:w-[34rem] drop-shadow-2xl" />
-        </div>
-      </div>
-    </div>
-  </section>
+  <ThreeModes />
 
-  <!-- ===================== Stats band ===================== -->
-  <section class="border-b border-line bg-surface-dim">
-    <div class="mx-auto w-full max-w-6xl px-6 py-8">
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-        <div>
-          <p class="font-sans text-3xl md:text-4xl font-bold text-accent">43</p>
-          <p class="mt-1 text-xs font-mono uppercase tracking-wider text-faint">Rust crates</p>
-        </div>
-        <div>
-          <p class="font-sans text-3xl md:text-4xl font-bold text-accent2">725+</p>
-          <p class="mt-1 text-xs font-mono uppercase tracking-wider text-faint">Tests passing</p>
-        </div>
-        <div>
-          <p class="font-sans text-3xl md:text-4xl font-bold text-gold-ink">3</p>
-          <p class="mt-1 text-xs font-mono uppercase tracking-wider text-faint">Deployment modes</p>
-        </div>
-        <div>
-          <p class="font-sans text-3xl md:text-4xl font-bold text-accent">10+</p>
-          <p class="mt-1 text-xs font-mono uppercase tracking-wider text-faint">Protocol implementations</p>
-        </div>
-      </div>
+  <Section
+    eyebrow="How it works"
+    title="From key generation to audited signature"
+    lead="A signing operation passes through five stages. The secret is created once, split into N shares, and never reconstructed. Every signing event anchors into a transparency log for audit."
+  >
+    <Timeline steps={STEPS} />
+    <div class="mt-6">
+      <CtaLink
+        href="/concepts/threshold-crypto-101/"
+        label="Read the threshold crypto primer"
+      />
     </div>
-  </section>
+  </Section>
 
-  <!-- ===================== Three modes ===================== -->
-  <section class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
+  <Section
+    tone="blue"
+    eyebrow="What makes Confium different"
+    title="Six properties no single-key PKI gives you"
+    lead="Conventional PKI assumes a single trusted CA. Every property below is a structural weakness of that model — and a structural property of Confium's threshold-native design."
+  >
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {PROOF_POINTS.map((d, i) => (
+        <Reveal delayMs={i * 50}>
+          <Card title={d.title} description={d.body} />
+        </Reveal>
+      ))}
+    </div>
+  </Section>
+
+  <Section
+    id="install"
+    eyebrow="Get started"
+    title="Install in your language"
+    lead="Three bindings ship today. The Rust workspace is the source of truth; the Ruby gem and WASM verifier package wrap the same engine for different ecosystems. Each gets you to a working Confium consumer in under five minutes."
+  >
+    <div class="grid lg:grid-cols-[1.3fr_1fr] gap-8 items-start">
       <Reveal>
-        <p class="mono-label">Three deployment modes</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          One engine, three integration shapes
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          The same primitives serve all three. What changes is the integration
-          boundary — peer-to-peer network code, a PKCS#11 adapter, or a full
-          Sovereign PKI profile with custom certificate formats and attribute-based
-          quorum policies.
-        </p>
+        <InstallTabs client:visible />
       </Reveal>
-
-      <div class="mt-10">
-        <ModeSelector client:visible />
-      </div>
-
-      <div class="mt-12 grid gap-4 md:grid-cols-3">
-        {modes.map((mode, i) => (
-          <Reveal delayMs={i * 70}>
-            <a
-              href={mode.href}
-              class="card card-hover group block h-full p-6"
-            >
-              <div class="flex items-baseline justify-between gap-3">
-                <h3 class="font-sans text-xl font-bold">{mode.name}</h3>
-                <span class="text-accent opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden="true">→</span>
-              </div>
-              <p class="mt-1 text-sm font-mono text-faint">{mode.tagline}</p>
-              <p class="mt-4 text-sm leading-relaxed text-muted">{mode.description}</p>
-              <ul class="mt-4 space-y-1.5 text-sm">
-                {mode.bullets.map((b) => (
-                  <li class="flex gap-2 text-muted">
-                    <span class="text-accent2 mt-1.5 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" aria-hidden="true"></span>
-                    <span>{b}</span>
-                  </li>
-                ))}
-              </ul>
-            </a>
-          </Reveal>
-        ))}
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== Find your path ===================== -->
-  <section class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">For you</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Find your path
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          Confium is a heavy system with many audiences. Pick your role
-          below and you land on a page tailored to your concerns —
-          business value, threat model, code examples, deployment
-          runbook, compliance matrix, or evaluation data.
-        </p>
-      </Reveal>
-
-      <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {[
-          { href: '/audiences/executives/', name: 'Executives', body: 'Business value, risk reduction, compliance, cost model, vendor independence.', accent: 'text-accent' },
-          { href: '/audiences/architects/', name: 'Security architects', body: 'Threat model, integration patterns, defense in depth, failure modes.', accent: 'text-accent2' },
-          { href: '/audiences/developers/', name: 'Developers', body: 'Ruby / Rust / WASM quickstarts, typed error model, code examples.', accent: 'text-accent' },
-          { href: '/audiences/operators/', name: 'PKI operators', body: 'Deployment runbook, monitoring hooks, backup and recovery, upgrades.', accent: 'text-accent2' },
-          { href: '/audiences/compliance/', name: 'Compliance officers', body: 'FIPS 140 mode, jurisdictional policies, audit log format, framework mapping.', accent: 'text-gold-ink' },
-          { href: '/audiences/evaluators/', name: 'Evaluators and researchers', body: 'Test vectors, performance benchmarks, protocol references, comparison matrix.', accent: 'text-gold-ink' },
-        ].map((a, i) => (
-          <Reveal delayMs={i * 50}>
-            <a href={a.href} class="card card-hover group block h-full p-5">
-              <p class={`mono-label !${a.accent}`}>{a.name}</p>
-              <h3 class="mt-2 font-sans text-lg font-bold group-hover:text-accent transition-colors">
-                {a.name}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-muted">{a.body}</p>
-              <p class="mt-3 text-xs text-accent group-hover:underline">
-                Read the guide →
-              </p>
-            </a>
-          </Reveal>
-        ))}
-      </div>
-
-      <p class="mt-8 text-sm text-muted text-center">
-        <a href="/audiences/" class="text-accent hover:text-accent-deep font-semibold">
-          See all audiences →
-        </a>
-      </p>
-    </div>
-  </section>
-
-  <!-- ===================== How it works ===================== -->
-  <section class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">How it works</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          From key generation to audited signature
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          A signing operation passes through five stages. The secret
-          is created once, split into N shares, and never reconstructed.
-          Every signing event anchors into a transparency log for
-          audit.
-        </p>
-      </Reveal>
-
-      <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-5 gap-3">
-        {[
-          { step: '1', title: 'Generate', body: 'Distributed key generation ceremony. Secret exists once, then is split.', color: 'accent' },
-          { step: '2', title: 'Distribute', body: 'Shares go to N parties. No single party holds the full key.', color: 'accent2' },
-          { step: '3', title: 'Sign', body: 'T-of-N quorum co-signs without reconstructing the secret.', color: 'accent' },
-          { step: '4', title: 'Refresh', body: 'Shares re-randomize periodically. Compromise windows shrink.', color: 'gold-ink' },
-          { step: '5', title: 'Anchor', body: 'Event lands in transparency log. Public, auditable, immutable.', color: 'accent2' },
-        ].map((s, i) => (
-          <Reveal delayMs={i * 60}>
-            <div class="card card-hover h-full p-5 relative">
-              <span class={`absolute -top-3 left-5 w-7 h-7 rounded-full bg-${s.color} text-white font-mono text-xs font-bold flex items-center justify-center shadow-card`}>
-                {s.step}
-              </span>
-              <h3 class="mt-3 font-sans text-base font-bold">{s.title}</h3>
-              <p class="mt-1.5 text-xs leading-relaxed text-muted">{s.body}</p>
-            </div>
-          </Reveal>
-        ))}
-      </div>
-
-      <p class="mt-6 text-sm">
-        <a href="/concepts/threshold-crypto-101/" class="font-semibold text-accent hover:text-accent-deep">
-          Read the threshold crypto primer →
-        </a>
-      </p>
-    </div>
-  </section>
-
-  <!-- ===================== What makes Confium different ===================== -->
-  <section class="band-blue border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">What makes Confium different</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Six properties no single-key PKI gives you
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          Conventional PKI assumes a single trusted CA. Every property below
-          is a structural weakness of that model — and a structural property
-          of Confium's threshold-native design.
-        </p>
-      </Reveal>
-      <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {differences.map((d, i) => (
-          <Reveal delayMs={i * 50}>
-            <div class="card card-hover h-full p-6">
-              <h3 class="font-sans text-lg font-bold">{d.title}</h3>
-              <p class="mt-2 text-sm leading-relaxed text-muted">{d.body}</p>
-            </div>
-          </Reveal>
-        ))}
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== What Confium is NOT ===================== -->
-  <section class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">What Confium is not</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Three common misclassifications
-        </h2>
-      </Reveal>
-      <div class="mt-10 grid gap-4 md:grid-cols-3">
-        <div class="card h-full p-6">
-          <div class="flex items-baseline gap-3">
-            <span class="font-mono text-2xl text-accent2">×</span>
-            <h3 class="font-sans text-lg font-bold">Not a crypto library</h3>
-          </div>
-          <p class="mt-2 text-sm leading-relaxed text-muted">
-            Crypto libraries (ring, rust-crypto) provide primitives. Confium
-            loads those primitives via plugins and orchestrates them across
-            multiple parties. Algorithms are pluggable, not embedded.
-          </p>
-        </div>
-        <div class="card h-full p-6">
-          <div class="flex items-baseline gap-3">
-            <span class="font-mono text-2xl text-accent2">×</span>
-            <h3 class="font-sans text-lg font-bold">Not an HSM</h3>
-          </div>
-          <p class="mt-2 text-sm leading-relaxed text-muted">
-            HSMs store keys in tamper-resistant hardware. Confium integrates
-            with HSMs via PKCS#11 / TPM — the threshold protocol runs in
-            software, the secrets stay wherever you put them.
-          </p>
-        </div>
-        <div class="card h-full p-6">
-          <div class="flex items-baseline gap-3">
-            <span class="font-mono text-2xl text-accent2">×</span>
-            <h3 class="font-sans text-lg font-bold">Not just OpenPGP</h3>
-          </div>
-          <p class="mt-2 text-sm leading-relaxed text-muted">
-            RNP is one consumer of Confium. The framework speaks every major
-            standard — PKCS#11, OpenSSL 3.0, JCE, CMS, X.509, RFC 6962.
-            OpenPGP is one shape, not the whole story.
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== Quorum playground ===================== -->
-  <section class="band-teal border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <div class="grid lg:grid-cols-[1fr_1.1fr] gap-12 items-start">
-        <Reveal>
-          <p class="mono-label">Interactive</p>
-          <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-            No single party can sign alone
-          </h2>
-          <p class="mt-4 text-lg leading-relaxed text-muted">
-            Threshold cryptography splits the signing key across N parties.
-            Any T of them can produce a valid signature jointly. Fewer than
-            T reveals nothing useful — the math doesn't even let you tell
-            whether you have the right answer.
-          </p>
-          <p class="mt-3 text-base leading-relaxed text-muted">
-            Drag the sliders below to model any quorum policy. Try T = 2
-            with only 1 party participating: the playground shows "No
-            signature possible". Reach the threshold and the status flips
-            green.
-          </p>
-          <ul class="mt-6 space-y-2 text-sm text-muted">
-            <li class="flex gap-2">
-              <span class="text-accent2">→</span>
-              <span>The full secret is never reconstructed on any single machine.</span>
+      <Reveal delayMs={80}>
+        <div class="card p-6 bg-surface-dim border-accent/20">
+          <p class="mono-label !text-accent">Five-minute path</p>
+          <h3 class="mt-2 font-sans text-lg font-bold">Verify a signature, end to end</h3>
+          <ol class="mt-4 space-y-3 text-sm text-muted">
+            <li class="flex gap-3">
+              <span class="font-mono text-accent font-bold flex-shrink-0">1.</span>
+              <span><code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">gem install confium</code> — installs the gem and builds the native extension.</span>
             </li>
-            <li class="flex gap-2">
-              <span class="text-accent2">→</span>
-              <span>Compromising T−1 parties reveals zero information.</span>
+            <li class="flex gap-3">
+              <span class="font-mono text-accent font-bold flex-shrink-0">2.</span>
+              <span>Require and parse a certificate: <code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">Confium::PKI::Certificate.from_pem(...)</code></span>
             </li>
-            <li class="flex gap-2">
-              <span class="text-accent2">→</span>
-              <span>Policies compose: 5-of-9 directors from 3 distinct regions.</span>
+            <li class="flex gap-3">
+              <span class="font-mono text-accent font-bold flex-shrink-0">3.</span>
+              <span>Validate the chain via <code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">PathValidator</code>.</span>
             </li>
-          </ul>
-          <a
-            href="/concepts/threshold-crypto-101/"
-            class="mt-6 inline-flex items-center gap-1 font-sans font-semibold text-accent hover:text-accent-deep transition-colors"
-          >
-            Read the threshold crypto primer
-            <span aria-hidden="true">→</span>
-          </a>
-        </Reveal>
-        <Reveal delayMs={120}>
-          <QuorumPlayground client:visible />
-        </Reveal>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== Install ===================== -->
-  <section id="install" class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">Get started</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Install in your language
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          Three bindings ship today. The Rust workspace is the source of truth;
-          the Ruby gem and WASM verifier package wrap the same engine for
-          different ecosystems. Each gets you to a working Confium consumer
-          in under five minutes.
-        </p>
-      </Reveal>
-      <div class="mt-10 grid lg:grid-cols-[1.3fr_1fr] gap-8 items-start">
-        <Reveal>
-          <InstallTabs client:visible />
-        </Reveal>
-        <Reveal delayMs={80}>
-          <div class="card p-6 bg-surface-dim border-accent/20">
-            <p class="mono-label !text-accent">Five-minute path</p>
-            <h3 class="mt-2 font-sans text-lg font-bold">Verify a signature, end to end</h3>
-            <ol class="mt-4 space-y-3 text-sm text-muted">
-              <li class="flex gap-3">
-                <span class="font-mono text-accent font-bold flex-shrink-0">1.</span>
-                <span><code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">gem install confium</code> — installs the gem and builds the native extension.</span>
-              </li>
-              <li class="flex gap-3">
-                <span class="font-mono text-accent font-bold flex-shrink-0">2.</span>
-                <span>Require and parse a certificate: <code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">Confium::PKI::Certificate.from_pem(...)</code></span>
-              </li>
-              <li class="flex gap-3">
-                <span class="font-mono text-accent font-bold flex-shrink-0">3.</span>
-                <span>Validate the chain via <code class="font-mono text-xs bg-surface px-1.5 py-0.5 rounded">PathValidator</code>.</span>
-              </li>
-              <li class="flex gap-3">
-                <span class="font-mono text-accent font-bold flex-shrink-0">4.</span>
-                <span>Verify a composite signature with the per-algorithm callbacks.</span>
-              </li>
-              <li class="flex gap-3">
-                <span class="font-mono text-accent font-bold flex-shrink-0">5.</span>
-                <span>Anchor the verification event in a transparency log.</span>
-              </li>
-            </ol>
-            <a href="/audiences/developers/" class="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-accent hover:text-accent-deep">
-              Full developer guide <span aria-hidden="true">→</span>
-            </a>
-          </div>
-        </Reveal>
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== Reference deployments ===================== -->
-  <section class="band-gold border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">Reference deployments</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Where Sovereign PKI is the right shape
-        </h2>
-        <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
-          Institutional certificate infrastructure where no single party can
-          be trusted. These are six scenarios where Mode 3 is already the
-          natural fit — not an exhaustive list.
-        </p>
-      </Reveal>
-      <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {deployments.map((d, i) => (
-          <Reveal delayMs={i * 50}>
-            <div class="card card-hover h-full p-6">
-              <h3 class="font-sans text-lg font-bold">{d.name}</h3>
-              <p class="mt-2 text-sm leading-relaxed text-muted">{d.body}</p>
-            </div>
-          </Reveal>
-        ))}
-      </div>
-      <p class="mt-8 text-sm text-muted">
-        <a href="/use-cases/sovereign-pki/" class="font-semibold text-accent hover:text-accent-deep">
-          Read the Sovereign PKI use case →
-        </a>
-      </p>
-    </div>
-  </section>
-
-  <!-- ===================== Latest from the blog ===================== -->
-  <section class="border-b border-line bg-surface-dim">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <div class="flex items-baseline justify-between flex-wrap gap-3">
-          <div>
-            <p class="mono-label">From the blog</p>
-            <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-              Recent writing
-            </h2>
-          </div>
-          <a href="/blog/" class="text-sm font-semibold text-accent hover:text-accent-deep">
-            All posts →
-          </a>
-        </div>
-      </Reveal>
-      <div class="mt-10 grid md:grid-cols-3 gap-4">
-        {[
-          { href: '/blog/2026-07-28-introducing-confium/', title: 'Introducing Confium', excerpt: 'Why we built a threshold-native trust infrastructure framework, and what ships today.', category: 'Announcement' },
-          { href: '/blog/2026-07-28-sovereign-pki-launch/', title: 'Sovereign PKI launch', excerpt: 'Mode 3 deep dive — institutional trust without a single point of failure.', category: 'Deep dive' },
-          { href: '/blog/2026-07-28-pq-migration-walkthrough/', title: 'PQ migration walkthrough', excerpt: 'How composite signatures turn migration into a software upgrade.', category: 'Walkthrough' },
-        ].map((post, i) => (
-          <Reveal delayMs={i * 60}>
-            <a href={post.href} class="card card-hover group block h-full p-6">
-              <p class="mono-label !text-accent">{post.category}</p>
-              <h3 class="mt-2 font-sans text-lg font-bold group-hover:text-accent transition-colors">
-                {post.title}
-              </h3>
-              <p class="mt-2 text-sm leading-relaxed text-muted">{post.excerpt}</p>
-              <p class="mt-4 text-xs text-accent group-hover:underline">Read post →</p>
-            </a>
-          </Reveal>
-        ))}
-      </div>
-    </div>
-  </section>
-
-  <!-- ===================== Final CTA ===================== -->
-  <section class="border-b border-line hero-gradient relative overflow-hidden text-white">
-    <div class="hero-grid absolute inset-0 opacity-50" aria-hidden="true"></div>
-    <div class="relative mx-auto w-full max-w-4xl px-6 py-16 md:py-24 text-center">
-      <Reveal>
-        <h2 class="font-sans text-3xl md:text-5xl font-bold tracking-tight text-balance">
-          Start building with Confium today
-        </h2>
-        <p class="mt-5 max-w-2xl mx-auto text-lg leading-relaxed text-white/85">
-          Install in your language of choice, verify your first
-          signature in five minutes, and join the open-source
-          threshold-trust collective.
-        </p>
-        <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <a href="/docs/getting-started/" class="btn btn-white">
-            Get started
-            <span aria-hidden="true">→</span>
-          </a>
-          <a href="#install" class="btn btn-outline-white">
-            Install
-          </a>
-          <a href="https://github.com/confium" class="btn btn-outline-white" aria-label="GitHub">
-            <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
-            </svg>
-            GitHub
-          </a>
-        </div>
-        <p class="mt-6 text-xs font-mono text-white/60 tracking-wider">
-          BSD-2-Clause · No licensing fees · Sponsored by NLnet + Mozilla MOSS
-        </p>
-      </Reveal>
-    </div>
-  </section>
-
-  <!-- ===================== Sponsorship ===================== -->
-  <section class="border-b border-line">
-    <div class="mx-auto w-full max-w-6xl px-6 py-12 md:py-16">
-      <Reveal>
-        <p class="mono-label">Sponsored by</p>
-        <h2 class="mt-3 font-sans text-3xl font-bold tracking-tight md:text-4xl">
-          Funded by the European Commission<br class="hidden sm:inline" /> through NGI Zero PET
-        </h2>
-        <p class="mt-4 max-w-3xl text-lg leading-relaxed text-muted">
-          Confium is developed in the open with the support of the
-          <a href="https://www.ngi.eu/ngi-projects/ngi-zero-pet/" class="text-accent hover:text-accent-deep font-medium">NGI Zero PET</a>
-          program — a European Commission initiative administered by
-          <a href="https://nlnet.nl/" class="text-accent hover:text-accent-deep font-medium">NLnet</a>
-          that funds open-source work strengthening the privacy and trust
-          properties of the internet. Additional support from
-          <a href="https://www.mozilla.org/moss/" class="text-accent hover:text-accent-deep font-medium">Mozilla MOSS</a>.
-        </p>
-      </Reveal>
-
-      <Reveal delayMs={100}>
-        <div class="mt-12 grid sm:grid-cols-3 gap-4 max-w-4xl">
-          <a
-            href="https://nlnet.nl/project/Confium/"
-            class="card card-hover group p-6 flex flex-col items-center text-center"
-          >
-            <div class="h-20 flex items-center justify-center mb-4">
-              <img src="/assets/nlnet-banner.svg" alt="NLnet" class="max-h-20 w-auto" loading="lazy" />
-            </div>
-            <p class="font-sans text-sm font-semibold">NLnet</p>
-            <p class="mt-1 text-xs text-faint">Project sponsor</p>
-            <p class="mt-3 text-xs text-accent group-hover:underline">nlnet.nl/project/Confium →</p>
-          </a>
-
-          <a
-            href="https://www.ngi.eu/ngi-projects/ngi-zero-pet/"
-            class="card card-hover group p-6 flex flex-col items-center text-center"
-          >
-            <div class="h-20 flex items-center justify-center mb-4">
-              <img src="/assets/ngi-zeropet-banner.svg" alt="NGI Zero PET" class="max-h-20 w-auto" loading="lazy" />
-            </div>
-            <p class="font-sans text-sm font-semibold">NGI Zero PET</p>
-            <p class="mt-1 text-xs text-faint">European Commission · Next Generation Internet</p>
-            <p class="mt-3 text-xs text-accent group-hover:underline">ngi.eu/ngi-zero-pet →</p>
-          </a>
-
-          <a
-            href="https://www.mozilla.org/moss/"
-            class="card card-hover group p-6 flex flex-col items-center text-center"
-          >
-            <div class="h-20 flex items-center justify-center mb-4">
-              <span class="font-sans text-3xl font-bold">mozilla</span>
-            </div>
-            <p class="font-sans text-sm font-semibold">Mozilla MOSS</p>
-            <p class="mt-1 text-xs text-faint">Open Source Support</p>
-            <p class="mt-3 text-xs text-accent group-hover:underline">mozilla.org/moss →</p>
+            <li class="flex gap-3">
+              <span class="font-mono text-accent font-bold flex-shrink-0">4.</span>
+              <span>Verify a composite signature with the per-algorithm callbacks.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="font-mono text-accent font-bold flex-shrink-0">5.</span>
+              <span>Anchor the verification event in a transparency log.</span>
+            </li>
+          </ol>
+          <a href="/audiences/developers/" class="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-accent hover:text-accent-deep">
+            Full developer guide <span aria-hidden="true">→</span>
           </a>
         </div>
       </Reveal>
     </div>
-  </section>
+  </Section>
+
+  <Section
+    tone="gold"
+    eyebrow="Reference deployments"
+    title="Where Sovereign PKI is the right shape"
+    lead="Institutional certificate infrastructure where no single party can be trusted. These are six scenarios where Mode 3 is already the natural fit — not an exhaustive list."
+  >
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {DEPLOYMENTS.map((d, i) => (
+        <Reveal delayMs={i * 50}>
+          <Card title={d.name} description={d.body} tone="gold" />
+        </Reveal>
+      ))}
+    </div>
+    <CtaLink
+      href="/use-cases/sovereign-pki/"
+      label="Read the Sovereign PKI use case"
+      tone="gold"
+      block
+    />
+  </Section>
+
+  <Section
+    eyebrow="From the blog"
+    title="Recent writing"
+    class="bg-surface-dim"
+  >
+    <div class="grid md:grid-cols-3 gap-4">
+      {blogPosts.map((post, i) => (
+        <Reveal delayMs={i * 60}>
+          <Card
+            eyebrow={post.category}
+            title={post.title}
+            description={post.excerpt}
+            href={post.href}
+          />
+        </Reveal>
+      ))}
+    </div>
+    <CtaLink
+      href="/blog/"
+      label="All posts"
+      block
+    />
+  </Section>
+
+  <SignOff />
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,11 +38,14 @@
   --accent-deep: #0f5fc4;
   --accent2: #009e80;
   --gold-ink: #a07d0a;
+  --warning: #b45309;
+  --warning-soft: #fef3c7;
   --code-bg: #14172b;
   --code-fg: #e8eaf2;
   --tint-blue: #e6f0fe;
   --tint-teal: #dcf8f0;
   --tint-gold: #fff4d6;
+  --tint-warning: #fef3c7;
   --brand-grad: linear-gradient(135deg, #1a7bec 0%, #00c2c9 45%, #00dfb7 100%);
 }
 
@@ -58,10 +61,13 @@
   --accent-deep: #8fbcf8;
   --accent2: #2be8c8;
   --gold-ink: #ffdc4a;
+  --warning: #fbbf24;
+  --warning-soft: color-mix(in oklab, #fbbf24 14%, #0b0e1a);
   --code-bg: #070a14;
   --tint-blue: color-mix(in oklab, #1a7bec 13%, #0b0e1a);
   --tint-teal: color-mix(in oklab, #00dfb7 10%, #0b0e1a);
   --tint-gold: color-mix(in oklab, #ffdc4a 13%, #0b0e1a);
+  --tint-warning: color-mix(in oklab, #fbbf24 14%, #0b0e1a);
 }
 
 @theme inline {
@@ -76,9 +82,12 @@
   --color-accent-deep: var(--accent-deep);
   --color-accent2: var(--accent2);
   --color-gold-ink: var(--gold-ink);
+  --color-warning: var(--warning);
+  --color-warning-soft: var(--warning-soft);
   --color-tint-blue: var(--tint-blue);
   --color-tint-teal: var(--tint-teal);
   --color-tint-gold: var(--tint-gold);
+  --color-tint-warning: var(--tint-warning);
   --color-code-bg: var(--code-bg);
   --color-code-fg: var(--code-fg);
 }
@@ -111,6 +120,26 @@ body {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--fg-faint);
+}
+
+/* Display headlines render in Plex Mono at display weight —
+   gives the whole site a "technical specification" voice that
+   matches the threshold-cryptography subject. Body copy stays in
+   Plex Sans for readability. */
+.display-mono {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+.display-mono-lg {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.08;
+  font-size: clamp(2.5rem, 5vw, 4rem);
 }
 
 .gradient-rule {
@@ -273,6 +302,17 @@ body {
   background: transparent;
 }
 .btn-outline:hover { border-color: var(--accent); color: var(--accent); }
+
+.btn-ghost {
+  border: 1px solid var(--line);
+  color: var(--fg);
+  background: var(--surface);
+}
+.btn-ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
 
 .btn-outline-white {
   border: 1px solid rgb(255 255 255 / 0.4);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@/*": ["src/*"],
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["src/lib/*"],
+      "@data/*": ["src/data/*"]
     },
     "jsx": "preserve",
     "moduleResolution": "bundler",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@lib': new URL('./src/lib', import.meta.url).pathname,
+      '@data': new URL('./src/data', import.meta.url).pathname,
+      '@components': new URL('./src/components', import.meta.url).pathname,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Homepage restructured around the product's actual thesis, with the repeated patterns extracted into typed, composable primitives. Driven by the frontend-design review.

### Design changes

- **Hero leads with the QuorumPlayground** — interactive thesis ("no single party can sign alone"). A visitor who drags the slider for 20 seconds understands the product. Cuts the HeroDecrypt typewriter and the duplicate ThreeModeDiagram.
- **Three Modes as colored bands** — each mode section now carries its brand identity color (blue / teal / gold), making the three-circle logo motif structural rather than decorative.
- **How It Works as a Timeline** — the 5-step pipeline (Generate → Distribute → Sign → Refresh → Anchor) renders as a connected horizontal sequence, not a generic card grid. Order carries information; the layout encodes it.
- **Cuts**: Stats band (vanity metrics), "What Confium is NOT" (defensive), "Find your path" audience directory (belongs on /audiences/), duplicate gradient final CTA.
- **New SignOff** — quiet one-line ending with compact sponsor row + two next-step links. No second shout.
- **Plex Mono display headlines** — gives the whole site a "technical specification" voice that matches threshold cryptography.

### Architecture

| New file | Role |
|---|---|
| `src/data/homepage.ts` | Typed content models (Mode, ProofPoint, Deployment, Step, Sponsor). Single source of truth. |
| `src/lib/quorum.ts` | Pure functions for threshold math. No Vue, no DOM. |
| `src/components/astro/primitives/Section.astro` | Section wrapper with optional header + tone band. |
| `src/components/astro/primitives/CtaLink.astro` | The "Read more →" pattern. |
| `src/components/astro/primitives/Timeline.astro` | Horizontal step sequence with connectors. |
| `src/components/astro/primitives/ModeVenn.astro` | Three-circle brand motif (compact / feature / divider). |
| `src/components/astro/sections/Hero.astro` | Interactive hero with playground + ModeVenn backdrop. |
| `src/components/astro/sections/ThreeModes.astro` | Three colored mode bands. |
| `src/components/astro/sections/SignOff.astro` | Quiet ending with sponsors + next steps. |

### Code quality

- `Card.astro` — `tone: BrandTone` prop replaces the buggy `accent` enum; all color tokens now resolve against the design system (previous `text-brand-700`, `text-gold` etc. silently no-op'd).
- `QuorumPlayground.vue` — thin presentation layer over `lib/quorum`. Added `role="status"` + `aria-live="polite"`. Fixed all color tokens.
- Warning token added (`--warning` / `--warning-soft`) for the insufficient-quorum state, replacing `bg-amber-500`.
- `index.astro` drops from **655 → 164 lines**. Each section composes primitives + typed data; no inline content.

### Specs

- Vitest added with 19 specs for `lib/quorum.ts` covering invariants (clamping, party array shape), status transitions (idle/insufficient/ready), and edge cases (T=N, minimum quorum, non-integer inputs).

## Test plan

- [ ] `npm run build` — 105 pages, no errors
- [ ] `npm test` — 19/19 specs pass
- [ ] Hero: drag the playground slider, status updates (idle → insufficient → ready)
- [ ] Three Modes section: three colored bands visible (blue / teal / gold tints)
- [ ] How It Works: 5-step timeline with numbered circles + connecting visual
- [ ] No "Stats band", no "What Confium is NOT", no "Find your path", no duplicate gradient CTA
- [ ] Headlines render in Plex Mono
- [ ] Page ends with quiet SignOff (sponsors + next steps, no gradient)
- [ ] Dark + light mode both render correctly
- [ ] Mobile (375px): hero stacks, playground remains usable

## TODO files

`TODO.complete/061` through `069` document each phase: foundation, primitives, playground refactor, hero, restructure, typography, sign-off, specs, verify.

