### PR TITLE
Phase 3: section design refresh

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,15 @@ export default defineConfig({
   integrations: [vue(), sitemap(), mdx()],
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        '@': new URL('./src', import.meta.url).pathname,
+        '@components': new URL('./src/components', import.meta.url).pathname,
+        '@layouts': new URL('./src/layouts', import.meta.url).pathname,
+        '@lib': new URL('./src/lib', import.meta.url).pathname,
+        '@data': new URL('./src/data', import.meta.url).pathname,
+      },
+    },
   },
   markdown: {
     shikiConfig: {

--- a/src/components/astro/PageHero.astro
+++ b/src/components/astro/PageHero.astro
@@ -1,23 +1,62 @@
 ---
 /**
- * PageHero — matches RNP's PageHero component exactly.
- * Pastel tint wash over a graph-paper grid, mono-label eyebrow, big title,
- * description, gradient rule underneath.
+ * PageHero — the unified hero for section landing pages.
+ *
+ * One-sentence orientation: eyebrow → Plex Mono display title →
+ * description → optional slot for content below.
+ *
+ * `tone` drives the eyebrow color. `backdrop` toggles the
+ * three-circle motif behind the hero (used on section landings to
+ * tie back to the brand identity established by the homepage).
+ *
+ * For content pages within a section, use `PageIntro` instead —
+ * it has breadcrumbs and a who-for callout. PageHero is for
+ * landing pages without a specific page context.
  */
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+import ModeVenn from './primitives/ModeVenn.astro';
+
 interface Props {
   eyebrow?: string;
   title: string;
   description?: string;
+  /** Identity tone for the eyebrow accent. Default 'blue'. */
+  tone?: BrandTone;
+  /** Show the three-circle brand motif behind the hero. Default true. */
+  backdrop?: boolean;
+  class?: string;
 }
-const { eyebrow, title, description } = Astro.props;
+
+const {
+  eyebrow,
+  title,
+  description,
+  tone = 'blue',
+  backdrop = true,
+  class: className = '',
+} = Astro.props;
+
+const colorToken = TONE_COLOR[tone];
 ---
 
-<header class="page-hero-bg relative overflow-hidden border-b border-line">
-  <div class="mx-auto w-full max-w-6xl px-6 pb-12 pt-28 md:pb-16 md:pt-32">
-    {eyebrow && <p class="mono-label">{eyebrow}</p>}
-    <h1 class="mt-3 font-sans text-4xl font-bold tracking-tight md:text-5xl">
-      {title}
-    </h1>
+<header
+  class:list={[
+    'page-hero-bg relative overflow-hidden border-b border-line',
+    className,
+  ]}
+>
+  {backdrop && (
+    <div
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[60rem] h-[36rem] opacity-15 pointer-events-none hidden lg:block"
+      aria-hidden="true"
+    >
+      <ModeVenn variant="feature" class="w-full h-full" />
+    </div>
+  )}
+  <div class="relative mx-auto w-full max-w-6xl px-6 pb-12 pt-28 md:pb-16 md:pt-32">
+    {eyebrow && <p class={`mono-label !text-${colorToken}`}>{eyebrow}</p>}
+    <h1 class="display-mono-lg mt-3">{title}</h1>
     {description && (
       <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
         {description}

--- a/src/components/astro/primitives/Breadcrumb.astro
+++ b/src/components/astro/primitives/Breadcrumb.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * Breadcrumb — the trail above the page title.
+ *
+ * Renders `Home > Docs > Architecture` with proper `aria-label` and
+ * a structured `<nav>` element. The last item is plain text (the
+ * current page). Items are visually separated by a chevron slug.
+ */
+interface Props {
+  trail: readonly { label: string; href?: string }[];
+  class?: string;
+}
+
+const { trail, class: className = '' } = Astro.props;
+---
+
+<nav
+  aria-label="Breadcrumb"
+  class:list={['text-sm text-muted', className]}
+>
+  <ol class="flex flex-wrap items-center gap-1.5">
+    {trail.map((item, i) => (
+      <li class="flex items-center gap-1.5">
+        {item.href && i < trail.length - 1 ? (
+          <a href={item.href} class="hover:text-foreground transition-colors">
+            {item.label}
+          </a>
+        ) : (
+          <span class="text-foreground" aria-current="page">{item.label}</span>
+        )}
+        {i < trail.length - 1 && (
+          <span aria-hidden="true" class="text-faint">/</span>
+        )}
+      </li>
+    ))}
+  </ol>
+</nav>

--- a/src/components/astro/primitives/ModeVenn.astro
+++ b/src/components/astro/primitives/ModeVenn.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * ModeVenn — the three-circle brand motif, reusable.
+ *
+ * The Confium logo is three overlapping circles (blue + teal +
+ * gold) representing the three deployment modes — each distinct,
+ * each overlapping the shared engine at the center.
+ *
+ * This motif is the brand's signature device. Used in:
+ *   - `compact` — inline at logo size (header wordmark alternative)
+ *   - `feature` — section-hero backdrop, large with translucent fills
+ *   - `divider` — section divider hairline
+ *
+ * The SVG paths are the same as SymbolLogo.astro so the geometry
+ * stays canonical.
+ */
+
+interface Props {
+  variant?: 'compact' | 'feature' | 'divider';
+  class?: string;
+}
+
+const { variant = 'compact', class: className = '' } = Astro.props;
+
+const blue = '#1a7bec';
+const teal = '#00dfb7';
+const gold = '#ffdc4a';
+
+// Geometry matches SymbolLogo.astro. viewBox 275.37 x 167.48.
+const CIRCLE_PATHS = [
+  'M95.79,83.73a95.44,95.44,0,0,1,31.82-71.27,83.73,83.73,0,1,0,0,142.54A95.44,95.44,0,0,1,95.79,83.73Z',
+  'M179.46,83.73A95.44,95.44,0,0,1,147.6,155a83.73,83.73,0,1,0,0-142.54A95.44,95.44,0,0,1,179.46,83.73Z',
+  'M167.49,83.73a83.57,83.57,0,0,0-29.87-64,83.59,83.59,0,0,0,0,128.09A83.57,83.57,0,0,0,167.49,83.73Z',
+];
+---
+
+{
+  variant === 'divider' ? (
+    <div class:list={['mode-venn-divider', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-8 opacity-50"
+      >
+        <path fill={blue} fill-opacity="0.7" d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} fill-opacity="0.7" d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} fill-opacity="0.7" d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </div>
+  ) : variant === 'feature' ? (
+    <div class:list={['mode-venn-feature pointer-events-none select-none', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <g opacity="0.5">
+          <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+          <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+          <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+        </g>
+      </svg>
+    </div>
+  ) : (
+    <span class:list={['inline-block mode-venn-compact', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </span>
+  )
+}

--- a/src/components/astro/primitives/PageIntro.astro
+++ b/src/components/astro/primitives/PageIntro.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * PageIntro — the unified hero for content pages.
+ *
+ * Owns the eyebrow + Plex Mono title + one-sentence orientation
+ * that sits above every content page. Wraps the breadcrumbs and
+ * the "Who this is for" callout, so pages get a consistent
+ * orientation without each having to compose the bits themselves.
+ *
+ * The `intro` field is the page's answer to "what is this page
+ * about, in one sentence". Reading just the intro + title tells
+ * you if the page is for you.
+ */
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+
+export interface Props {
+  eyebrow: string;
+  title: string;
+  /** One-sentence orientation. Names what the page covers. */
+  intro: string;
+  /** Identity tone for the eyebrow accent. Default 'blue'. */
+  tone?: BrandTone;
+  class?: string;
+}
+
+const { eyebrow, title, intro, tone = 'blue', class: className = '' } = Astro.props;
+const colorToken = TONE_COLOR[tone];
+---
+
+<header
+  class:list={[
+    'border-b border-line bg-surface-dim/40',
+    className,
+  ]}
+>
+  <div class="mx-auto w-full max-w-6xl px-6 py-10 md:py-14">
+    <div class="max-w-3xl">
+      <nav class="mb-4">
+        <slot name="breadcrumb" />
+      </nav>
+      <p class={`mono-label !text-${colorToken}`}>{eyebrow}</p>
+      <h1 class="display-mono-lg mt-3">{title}</h1>
+      <p class="mt-4 text-lg leading-relaxed text-muted">
+        {intro}
+      </p>
+      <div class="mt-6">
+        <slot name="who-for" />
+      </div>
+    </div>
+  </div>
+</header>

--- a/src/components/astro/primitives/WhoFor.astro
+++ b/src/components/astro/primitives/WhoFor.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * WhoFor — the "👤 For: architects, evaluators" callout.
+ *
+ * Surfaces who the page is written for, so a visitor can
+ * self-select into or out of the page within seconds. Each name
+ * is a link to its audience page.
+ *
+ * Accepts either audience slugs (`developers`) or short aliases
+ * (`developer`) — the call resolves to the canonical slug via
+ * `resolveAudience()`.
+ */
+import { AUDIENCES, resolveAudience } from '@data/audiences';
+
+export interface Props {
+  /** Names — slugs or aliases. Unknown names are filtered out. */
+  for: readonly string[];
+  label?: string;
+  class?: string;
+}
+
+const { for: audienceNames, label = 'For', class: className = '' } = Astro.props;
+
+const items = audienceNames
+  .map(resolveAudience)
+  .filter((slug) => AUDIENCES.some((a) => a.slug === slug))
+  .map((slug) => ({
+    slug,
+    href: `/audiences/${slug}/`,
+    audience: AUDIENCES.find((a) => a.slug === slug),
+  }));
+---
+
+{items.length > 0 && (
+  <aside
+    class:list={[
+      'card p-4 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm',
+      className,
+    ]}
+    aria-label={label}
+  >
+    <span class="mono-label text-faint whitespace-nowrap">{label}</span>
+    {items.map((item, i) => (
+      <>
+        <a
+          href={item.href}
+          class="text-accent hover:text-accent-deep font-semibold transition-colors"
+        >
+          {item.audience?.name ?? slug}
+        </a>
+        {i < items.length - 1 && (
+          <span class="text-faint" aria-hidden="true">·</span>
+        )}
+      </>
+    ))}
+  </aside>
+)}

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -9,6 +9,7 @@ const nav = [
   { label: 'Docs', href: '/docs/' },
   { label: 'Concepts', href: '/concepts/' },
   { label: 'Use Cases', href: '/use-cases/' },
+  { label: 'For You', href: '/audiences/' },
   { label: 'Plugins', href: '/plugins/' },
   { label: 'Specs', href: '/specs/' },
   { label: 'Software', href: '/software/' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,13 @@ import { glob } from 'astro/loaders';
 const adocFrontmatter = z.object({
   title: z.string(),
   description: z.string().optional(),
+  /**
+   * One-sentence orientation shown in the page intro. Either
+   * define this explicitly or fall back to `description`. Pages
+   * should set this so visitors get a clear answer to "what is
+   * this page?" within the first scroll.
+   */
+  intro: z.string().optional(),
   date: z.coerce.date().optional(),
   author: z.string().optional(),
   tags: z.array(z.string()).default([]),
@@ -25,6 +32,7 @@ const adocFrontmatter = z.object({
 const mdFrontmatter = z.object({
   title: z.string(),
   description: z.string().optional(),
+  intro: z.string().optional(),
   mode: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal('cross')]).optional(),
   order: z.number().optional(),
 });
@@ -68,7 +76,9 @@ export const collections = {
 
   use_cases: defineCollection({
     loader: glob({ base: './src/content/use_cases', pattern: '**/*.mdx' }),
-    schema: mdFrontmatter,
+    schema: mdFrontmatter.extend({
+      audience: z.array(z.string()).default([]),
+    }),
   }),
 
   glossary: defineCollection({

--- a/src/data/audiences.ts
+++ b/src/data/audiences.ts
@@ -1,0 +1,44 @@
+/**
+ * Audiences — the canonical list of audience pages.
+ *
+ * Single source of truth for the 12 audience pages. Consumed by
+ * `/audiences/index.astro`, the WhoFor primitive, and any other
+ * code that needs to enumerate or link to audience pages.
+ *
+ * The `aliases` field on each entry handles alternate names —
+ * the docs schema uses singular forms (`developer`, `executive`)
+ * while the page slugs are plural (`developers`, `executives`).
+ * Components should look up via `resolveAudience(name)`.
+ */
+
+export const AUDIENCES = [
+  { slug: 'executives', name: 'Executives', tagline: 'Business value, risk, and compliance', aliases: ['executive'] },
+  { slug: 'architects', name: 'Security architects', tagline: 'Threat model and integration patterns', aliases: ['architect'] },
+  { slug: 'developers', name: 'Developers', tagline: 'API, examples, and SDK choice', aliases: ['developer'] },
+  { slug: 'operators', name: 'PKI operators', tagline: 'Deployment, monitoring, and runbooks', aliases: ['operator'] },
+  { slug: 'compliance', name: 'Compliance officers', tagline: 'FIPS, jurisdictions, and audit', aliases: [] },
+  { slug: 'evaluators', name: 'Evaluators and researchers', tagline: 'Test vectors, benchmarks, and protocol references', aliases: ['evaluator', 'researcher'] },
+  { slug: 'ctos', name: 'CTOs and engineering directors', tagline: 'Strategic adoption and risk posture', aliases: ['cto'] },
+  { slug: 'product-managers', name: 'Product managers', tagline: 'Scoping threshold-trust features', aliases: ['product-manager'] },
+  { slug: 'contributors', name: 'Open source contributors', tagline: 'Code, docs, plugins, security research', aliases: ['contributor'] },
+  { slug: 'students', name: 'Students and educators', tagline: 'Teaching materials, labs, and reading lists', aliases: ['student'] },
+  { slug: 'auditors', name: 'Security auditors', tagline: 'Audit checklist, evidence, and common findings', aliases: ['auditor'] },
+  { slug: 'web3', name: 'Web3 and blockchain developers', tagline: 'Threshold custody, MPC wallets, and on-chain signing', aliases: [] },
+] as const;
+
+export type AudienceSlug = (typeof AUDIENCES)[number]['slug'];
+
+/**
+ * Resolve any audience reference (slug or alias) to its slug.
+ * Returns the input unchanged if no match — caller decides how to
+ * handle unknown names.
+ */
+export function resolveAudience(name: string): string {
+  for (const a of AUDIENCES) {
+    if (a.slug === name || (a as { aliases?: readonly string[] }).aliases?.includes(name)) {
+      return a.slug;
+    }
+  }
+  return name;
+}
+

--- a/src/data/homepage.ts
+++ b/src/data/homepage.ts
@@ -1,0 +1,32 @@
+/**
+ * Homepage design tokens — typed continuations of the design system.
+ *
+ * Used by section components and primitives throughout the site
+ * to map the three brand identity tones to semantic CSS tokens.
+ */
+
+export type BrandTone = 'blue' | 'teal' | 'gold';
+
+/**
+ * Map a BrandTone to its semantic CSS color token name. Centralised
+ * so consumers never branch on tone — they look up the token.
+ */
+export const TONE_COLOR: Readonly<Record<BrandTone, 'accent' | 'accent2' | 'gold-ink'>> = {
+  blue: 'accent',
+  teal: 'accent2',
+  gold: 'gold-ink',
+};
+
+/**
+ * Map a BrandTone to its tint CSS token (for section bands).
+ */
+export const TONE_TINT: Readonly<Record<BrandTone, 'tint-blue' | 'tint-teal' | 'tint-gold'>> = {
+  blue: 'tint-blue',
+  teal: 'tint-teal',
+  gold: 'tint-gold',
+};
+
+/**
+ * Inverted tonal order to alternate panels: blue, teal, gold, blue, ...
+ */
+export const TONE_CYCLE: readonly BrandTone[] = ['blue', 'teal', 'gold'];

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,28 +1,94 @@
 ---
+/**
+ * DocsLayout — the chrome for /docs/, /concepts/, /use-cases/ pages.
+ *
+ * Owns the page intro (eyebrow + title + one-sentence orientation
+ * + breadcrumbs + who-for callout) and the 3-column prose grid
+ * (sidebar | prose | TOC). The intro answers "what is this page
+ * and is it for me?" within 30 seconds — without it, visitors
+ * landed on technical content with no context.
+ *
+ * The intro is built from `entry.data` fields:
+ *   - eyebrow: from `data.eyebrow` (or derived from collection name)
+ *   - title: from `data.title`
+ *   - intro: from `data.intro` (or `data.description` as fallback)
+ *   - audience: from `data.audience` (passed to WhoFor)
+ *
+ * PageIntro is the new hero; the old bare 3-column grid is gone.
+ */
 import BaseLayout from './BaseLayout.astro';
 import TocNav from '@components/astro/TocNav.astro';
 import Prose from '@components/astro/Prose.astro';
+import PageIntro from '@components/astro/primitives/PageIntro.astro';
+import Breadcrumb from '@components/astro/primitives/Breadcrumb.astro';
+import WhoFor from '@components/astro/primitives/WhoFor.astro';
+import type { BrandTone } from '@data/homepage';
 
-interface Props {
+export interface Props {
   title: string;
   description?: string;
+  /**
+   * One-sentence orientation. Optional — falls back to `description`
+   * when not provided. Pages should always set this explicitly.
+   */
+  intro?: string;
+  /** Eyebrow shown above the title. Defaults to the collection label. */
+  eyebrow?: string;
+  /** Audience names from the content schema (e.g. ['developers']). */
+  audience?: string[];
+  /** Identity tone for the eyebrow. Inherits from the page's section. */
+  tone?: BrandTone;
   sidebar?: { label: string; href: string; current?: boolean }[];
+  /** Source path for the "Edit on GitHub" link. */
   sourcePath?: string;
   headings?: { depth: number; slug: string; text: string }[];
+  /** Breadcrumb trail. Auto-derived if not provided. */
+  trail?: { label: string; href?: string }[];
+  /** Visible section label for the breadcrumb home. Defaults to the eyebrow. */
+  sectionLabel?: string;
+  /** Visible section href for the breadcrumb. Defaults to the eyebrow's URL. */
+  sectionHref?: string;
 }
 
 const {
   title,
   description,
+  intro,
+  eyebrow,
+  audience,
+  tone,
   sidebar = [],
   sourcePath,
   headings = [],
+  trail,
+  sectionLabel,
+  sectionHref,
 } = Astro.props;
 
 const filteredHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
+// Use explicit intro, fall back to description, fall back to empty.
+const introText = intro ?? description ?? '';
+// Breadcrumb: Home > Section > Page title. Caller can override.
+const crumbTrail = trail ?? [
+  { label: 'Home', href: '/' },
+  ...(sectionLabel
+    ? [{ label: sectionLabel, href: sectionHref }]
+    : []),
+  { label: title },
+];
 ---
 
 <BaseLayout title={title} description={description}>
+  <PageIntro
+    eyebrow={eyebrow ?? 'Documentation'}
+    title={title}
+    intro={introText}
+    tone={tone}
+  >
+    <Breadcrumb slot="breadcrumb" trail={crumbTrail} />
+    <WhoFor slot="who-for" for={audience ?? []} />
+  </PageIntro>
+
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
     <div class="lg:grid lg:grid-cols-[16rem_minmax(0,1fr)_14rem] lg:gap-8">
       {sidebar.length > 0 && (

--- a/src/pages/concepts/[...id].astro
+++ b/src/pages/concepts/[...id].astro
@@ -25,8 +25,13 @@ const sidebar = allConcepts
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Concept"
+  tone="teal"
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Concepts"
+  sectionHref="/concepts/"
 >
   <Content />
 </DocsLayout>

--- a/src/pages/docs/[...id].astro
+++ b/src/pages/docs/[...id].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import type { BrandTone } from '@data/homepage';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
@@ -20,13 +21,21 @@ const sidebar = allDocs
     href: `/docs/${d.id}/`,
     current: d.id === doc.id,
   }));
+
+const audience = doc.data.audience ? [doc.data.audience] : undefined;
 ---
 
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Documentation"
+  tone="blue"
+  audience={audience}
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Docs"
+  sectionHref="/docs/"
 >
   <Content />
 </DocsLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,6 +137,12 @@ const deployments = [
               New to threshold crypto?
             </a>
           </div>
+          <p class="mt-5 text-sm text-white/70">
+            Not sure where to start?
+            <a href="/audiences/" class="text-white underline decoration-white/40 hover:decoration-white transition-colors font-medium">
+              Find your path →
+            </a>
+          </p>
         </div>
 
         <div class="lg:justify-self-end">

--- a/src/pages/use-cases/[id].astro
+++ b/src/pages/use-cases/[id].astro
@@ -25,8 +25,14 @@ const sidebar = allItems
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Use case"
+  tone="gold"
+  audience={doc.data.audience}
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Use cases"
+  sectionHref="/use-cases/"
 >
   <Content />
 </DocsLayout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@/*": ["src/*"],
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["src/lib/*"],
+      "@data/*": ["src/data/*"]
     },
     "jsx": "preserve",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Phase 3: section design refresh

Part of the whole-site refactor plan at `/Users/mulgogi/.claude/plans/plan-whole-site-refactor-for-distributed-pnueli.md`.

Builds on top of the preceding phases. Should be merged in order: Phase 0 → 1 → 2 → 3 → 5 → 6.

## Test plan

- [x] `npx astro build` succeeds (106 pages)
- [x] `lychee` 0 errors
- [x] Visual chrome renders correctly
