### PR TITLE
ci(tests): add link_check job — lychee runs on every PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,3 +24,24 @@ jobs:
       run: npm test
       env:
         CI: true
+
+  type_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install astro check
+      run: npm install --no-save @astrojs/check typescript
+
+    - name: Type check
+      run: npx astro check
+      env:
+        CI: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,38 @@ jobs:
       run: npx astro check
       env:
         CI: true
+
+  link_check:
+    # Builds the site then runs lychee against the built HTML.
+    # Verifies every internal link resolves and external links
+    # aren't 404. lychee.toml holds the exclude list (self URLs,
+    # bot-blocked sites) and accept codes.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Fetch software documentation sources
+      run: npm run fetch-sources
+
+    - name: Build with Astro
+      # prebuild clones the software docs sources into vendor/;
+      # postbuild runs Pagefind indexing. Output: './dist'.
+      run: npm run build
+      env:
+        CI: true
+
+    - name: Link Checker
+      uses: lycheeverse/lychee-action@v2
+      with:
+        # --root-dir resolves root-relative links against the local build.
+        # lychee.toml holds accept codes and exclusions.
+        args: --root-dir ${{ github.workspace }}/dist --config lychee.toml --no-progress 'dist/**/*.html'
+        fail: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run Vitest
+      run: npm test
+      env:
+        CI: true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,15 @@ export default defineConfig({
   integrations: [vue(), sitemap(), mdx()],
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        '@': new URL('./src', import.meta.url).pathname,
+        '@components': new URL('./src/components', import.meta.url).pathname,
+        '@layouts': new URL('./src/layouts', import.meta.url).pathname,
+        '@lib': new URL('./src/lib', import.meta.url).pathname,
+        '@data': new URL('./src/data', import.meta.url).pathname,
+      },
+    },
   },
   markdown: {
     shikiConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,26 @@
       "devDependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
-        "pagefind": "1.5.2"
+        "@vitest/coverage-v8": "^2.1.9",
+        "pagefind": "1.5.2",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -917,6 +933,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.5",
@@ -2048,6 +2071,34 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2272,6 +2323,17 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -2554,6 +2616,331 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@shikijs/primitive": {
       "version": "4.3.1",
@@ -2996,6 +3383,151 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/babel-helper-vue-transform-on": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-2.0.1.tgz",
@@ -3220,6 +3752,32 @@
         "am-i-vibing": "dist/cli.mjs"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ansis": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
@@ -3295,6 +3853,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3549,6 +4117,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
@@ -3575,6 +4153,19 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
@@ -3624,6 +4215,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -3652,6 +4253,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3692,6 +4310,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3742,6 +4370,26 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3795,6 +4443,21 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/crossws": {
       "version": "0.3.5",
@@ -3925,6 +4588,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/default-browser": {
@@ -4101,11 +4774,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.396",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
       "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -4338,6 +5025,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4454,6 +5151,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4498,6 +5212,61 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4519,6 +5288,16 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -4845,6 +5624,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -4937,6 +5726,90 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -5271,6 +6144,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5298,6 +6178,35 @@
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-extensions": {
@@ -6347,6 +7256,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6543,6 +7478,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
@@ -6650,11 +7592,55 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
@@ -7102,6 +8088,51 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -7218,6 +8249,49 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -7297,11 +8371,89 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -7315,6 +8467,46 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strnum": {
@@ -7348,6 +8540,19 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -7394,10 +8599,32 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -7432,6 +8659,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -7973,6 +9230,533 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-inspect": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.4.1.tgz",
@@ -8113,6 +9897,603 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.40",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
@@ -8142,6 +10523,137 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wsl-utils": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "postbuild": "pagefind --site dist",
     "fetch-sources": "node scripts/fetch-sources.mjs",
     "check:links": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
-    "check:links:external": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'"
+    "check:links:external": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@astrojs/mdx": "7.0.4",
@@ -30,7 +33,9 @@
   "devDependencies": {
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",
-    "pagefind": "1.5.2"
+    "@vitest/coverage-v8": "^2.1.9",
+    "pagefind": "1.5.2",
+    "vitest": "^2.1.9"
   },
   "engines": {
     "node": ">=22"

--- a/src/components/astro/PageHero.astro
+++ b/src/components/astro/PageHero.astro
@@ -1,23 +1,62 @@
 ---
 /**
- * PageHero — matches RNP's PageHero component exactly.
- * Pastel tint wash over a graph-paper grid, mono-label eyebrow, big title,
- * description, gradient rule underneath.
+ * PageHero — the unified hero for section landing pages.
+ *
+ * One-sentence orientation: eyebrow → Plex Mono display title →
+ * description → optional slot for content below.
+ *
+ * `tone` drives the eyebrow color. `backdrop` toggles the
+ * three-circle motif behind the hero (used on section landings to
+ * tie back to the brand identity established by the homepage).
+ *
+ * For content pages within a section, use `PageIntro` instead —
+ * it has breadcrumbs and a who-for callout. PageHero is for
+ * landing pages without a specific page context.
  */
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+import ModeVenn from './primitives/ModeVenn.astro';
+
 interface Props {
   eyebrow?: string;
   title: string;
   description?: string;
+  /** Identity tone for the eyebrow accent. Default 'blue'. */
+  tone?: BrandTone;
+  /** Show the three-circle brand motif behind the hero. Default true. */
+  backdrop?: boolean;
+  class?: string;
 }
-const { eyebrow, title, description } = Astro.props;
+
+const {
+  eyebrow,
+  title,
+  description,
+  tone = 'blue',
+  backdrop = true,
+  class: className = '',
+} = Astro.props;
+
+const colorToken = TONE_COLOR[tone];
 ---
 
-<header class="page-hero-bg relative overflow-hidden border-b border-line">
-  <div class="mx-auto w-full max-w-6xl px-6 pb-12 pt-28 md:pb-16 md:pt-32">
-    {eyebrow && <p class="mono-label">{eyebrow}</p>}
-    <h1 class="mt-3 font-sans text-4xl font-bold tracking-tight md:text-5xl">
-      {title}
-    </h1>
+<header
+  class:list={[
+    'page-hero-bg relative overflow-hidden border-b border-line',
+    className,
+  ]}
+>
+  {backdrop && (
+    <div
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[60rem] h-[36rem] opacity-15 pointer-events-none hidden lg:block"
+      aria-hidden="true"
+    >
+      <ModeVenn variant="feature" class="w-full h-full" />
+    </div>
+  )}
+  <div class="relative mx-auto w-full max-w-6xl px-6 pb-12 pt-28 md:pb-16 md:pt-32">
+    {eyebrow && <p class={`mono-label !text-${colorToken}`}>{eyebrow}</p>}
+    <h1 class="display-mono-lg mt-3">{title}</h1>
     {description && (
       <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted">
         {description}

--- a/src/components/astro/SiteFooter.astro
+++ b/src/components/astro/SiteFooter.astro
@@ -3,29 +3,36 @@ const year = new Date().getFullYear();
 
 const columns = [
   {
-    title: 'Software',
+    title: 'Build',
     links: [
-      { label: 'Rust workspace', href: '/software/rust/' },
-      { label: 'Ruby gem', href: '/software/ruby/' },
-      { label: 'WASM verifier', href: '/software/wasm/' },
-      { label: 'All software', href: '/software/' },
+      { label: 'Docs', href: '/docs/' },
+      { label: 'Software', href: '/software/' },
+      { label: 'Plugins', href: '/plugins/' },
+      { label: 'Contribute', href: '/contribute/' },
+    ],
+  },
+  {
+    title: 'Learn',
+    links: [
+      { label: 'Concepts', href: '/concepts/' },
+      { label: 'Specs', href: '/specs/' },
+      { label: 'Glossary', href: '/glossary/' },
+      { label: 'Blog', href: '/blog/' },
+    ],
+  },
+  {
+    title: 'Use',
+    links: [
+      { label: 'Use cases', href: '/use-cases/' },
+      { label: 'For You', href: '/audiences/' },
+      { label: 'Security', href: '/security/' },
+      { label: 'Funding', href: '/funding/' },
     ],
   },
   {
     title: 'Project',
     links: [
       { label: 'About', href: '/about/' },
-      { label: 'Blog', href: '/blog/' },
-      { label: 'Specs', href: '/specs/' },
-      { label: 'Contribute', href: '/contribute/' },
-    ],
-  },
-  {
-    title: 'Resources',
-    links: [
-      { label: 'Security', href: '/security/' },
-      { label: 'Funding', href: '/funding/' },
-      { label: 'Glossary', href: '/glossary/' },
       { label: 'RSS feed', href: '/rss.xml' },
     ],
   },

--- a/src/components/astro/primitives/Breadcrumb.astro
+++ b/src/components/astro/primitives/Breadcrumb.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * Breadcrumb — the trail above the page title.
+ *
+ * Renders `Home > Docs > Architecture` with proper `aria-label` and
+ * a structured `<nav>` element. The last item is plain text (the
+ * current page). Items are visually separated by a chevron slug.
+ */
+interface Props {
+  trail: readonly { label: string; href?: string }[];
+  class?: string;
+}
+
+const { trail, class: className = '' } = Astro.props;
+---
+
+<nav
+  aria-label="Breadcrumb"
+  class:list={['text-sm text-muted', className]}
+>
+  <ol class="flex flex-wrap items-center gap-1.5">
+    {trail.map((item, i) => (
+      <li class="flex items-center gap-1.5">
+        {item.href && i < trail.length - 1 ? (
+          <a href={item.href} class="hover:text-foreground transition-colors">
+            {item.label}
+          </a>
+        ) : (
+          <span class="text-foreground" aria-current="page">{item.label}</span>
+        )}
+        {i < trail.length - 1 && (
+          <span aria-hidden="true" class="text-faint">/</span>
+        )}
+      </li>
+    ))}
+  </ol>
+</nav>

--- a/src/components/astro/primitives/ModeVenn.astro
+++ b/src/components/astro/primitives/ModeVenn.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * ModeVenn — the three-circle brand motif, reusable.
+ *
+ * The Confium logo is three overlapping circles (blue + teal +
+ * gold) representing the three deployment modes — each distinct,
+ * each overlapping the shared engine at the center.
+ *
+ * This motif is the brand's signature device. Used in:
+ *   - `compact` — inline at logo size (header wordmark alternative)
+ *   - `feature` — section-hero backdrop, large with translucent fills
+ *   - `divider` — section divider hairline
+ *
+ * The SVG paths are the same as SymbolLogo.astro so the geometry
+ * stays canonical.
+ */
+
+interface Props {
+  variant?: 'compact' | 'feature' | 'divider';
+  class?: string;
+}
+
+const { variant = 'compact', class: className = '' } = Astro.props;
+
+const blue = '#1a7bec';
+const teal = '#00dfb7';
+const gold = '#ffdc4a';
+
+// Geometry matches SymbolLogo.astro. viewBox 275.37 x 167.48.
+const CIRCLE_PATHS = [
+  'M95.79,83.73a95.44,95.44,0,0,1,31.82-71.27,83.73,83.73,0,1,0,0,142.54A95.44,95.44,0,0,1,95.79,83.73Z',
+  'M179.46,83.73A95.44,95.44,0,0,1,147.6,155a83.73,83.73,0,1,0,0-142.54A95.44,95.44,0,0,1,179.46,83.73Z',
+  'M167.49,83.73a83.57,83.57,0,0,0-29.87-64,83.59,83.59,0,0,0,0,128.09A83.57,83.57,0,0,0,167.49,83.73Z',
+];
+---
+
+{
+  variant === 'divider' ? (
+    <div class:list={['mode-venn-divider', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-8 opacity-50"
+      >
+        <path fill={blue} fill-opacity="0.7" d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} fill-opacity="0.7" d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} fill-opacity="0.7" d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </div>
+  ) : variant === 'feature' ? (
+    <div class:list={['mode-venn-feature pointer-events-none select-none', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <g opacity="0.5">
+          <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+          <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+          <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+        </g>
+      </svg>
+    </div>
+  ) : (
+    <span class:list={['inline-block mode-venn-compact', className]} aria-hidden="true">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 275.37 167.48"
+        class="w-full h-full"
+      >
+        <path fill={blue} d={CIRCLE_PATHS[0]} transform="translate(0.08 0.01)" />
+        <path fill={teal} d={CIRCLE_PATHS[1]} transform="translate(0.08 0.01)" />
+        <path fill={gold} d={CIRCLE_PATHS[2]} transform="translate(0.08 0.01)" />
+      </svg>
+    </span>
+  )
+}

--- a/src/components/astro/primitives/PageIntro.astro
+++ b/src/components/astro/primitives/PageIntro.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * PageIntro — the unified hero for content pages.
+ *
+ * Owns the eyebrow + Plex Mono title + one-sentence orientation
+ * that sits above every content page. Wraps the breadcrumbs and
+ * the "Who this is for" callout, so pages get a consistent
+ * orientation without each having to compose the bits themselves.
+ *
+ * The `intro` field is the page's answer to "what is this page
+ * about, in one sentence". Reading just the intro + title tells
+ * you if the page is for you.
+ */
+import type { BrandTone } from '@data/homepage';
+import { TONE_COLOR } from '@data/homepage';
+
+export interface Props {
+  eyebrow: string;
+  title: string;
+  /** One-sentence orientation. Names what the page covers. */
+  intro: string;
+  /** Identity tone for the eyebrow accent. Default 'blue'. */
+  tone?: BrandTone;
+  class?: string;
+}
+
+const { eyebrow, title, intro, tone = 'blue', class: className = '' } = Astro.props;
+const colorToken = TONE_COLOR[tone];
+---
+
+<header
+  class:list={[
+    'border-b border-line bg-surface-dim/40',
+    className,
+  ]}
+>
+  <div class="mx-auto w-full max-w-6xl px-6 py-10 md:py-14">
+    <div class="max-w-3xl">
+      <nav class="mb-4">
+        <slot name="breadcrumb" />
+      </nav>
+      <p class={`mono-label !text-${colorToken}`}>{eyebrow}</p>
+      <h1 class="display-mono-lg mt-3">{title}</h1>
+      <p class="mt-4 text-lg leading-relaxed text-muted">
+        {intro}
+      </p>
+      <div class="mt-6">
+        <slot name="who-for" />
+      </div>
+    </div>
+  </div>
+</header>

--- a/src/components/astro/primitives/WhoFor.astro
+++ b/src/components/astro/primitives/WhoFor.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * WhoFor — the "👤 For: architects, evaluators" callout.
+ *
+ * Surfaces who the page is written for, so a visitor can
+ * self-select into or out of the page within seconds. Each name
+ * is a link to its audience page.
+ *
+ * Accepts either audience slugs (`developers`) or short aliases
+ * (`developer`) — the call resolves to the canonical slug via
+ * `resolveAudience()`.
+ */
+import { AUDIENCES, resolveAudience } from '@data/audiences';
+
+export interface Props {
+  /** Names — slugs or aliases. Unknown names are filtered out. */
+  for: readonly string[];
+  label?: string;
+  class?: string;
+}
+
+const { for: audienceNames, label = 'For', class: className = '' } = Astro.props;
+
+const items = audienceNames
+  .map(resolveAudience)
+  .filter((slug) => AUDIENCES.some((a) => a.slug === slug))
+  .map((slug) => ({
+    slug,
+    href: `/audiences/${slug}/`,
+    audience: AUDIENCES.find((a) => a.slug === slug),
+  }));
+---
+
+{items.length > 0 && (
+  <aside
+    class:list={[
+      'card p-4 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm',
+      className,
+    ]}
+    aria-label={label}
+  >
+    <span class="mono-label text-faint whitespace-nowrap">{label}</span>
+    {items.map((item, i) => (
+      <>
+        <a
+          href={item.href}
+          class="text-accent hover:text-accent-deep font-semibold transition-colors"
+        >
+          {item.audience?.name ?? slug}
+        </a>
+        {i < items.length - 1 && (
+          <span class="text-faint" aria-hidden="true">·</span>
+        )}
+      </>
+    ))}
+  </aside>
+)}

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -9,6 +9,7 @@ const nav = [
   { label: 'Docs', href: '/docs/' },
   { label: 'Concepts', href: '/concepts/' },
   { label: 'Use Cases', href: '/use-cases/' },
+  { label: 'For You', href: '/audiences/' },
   { label: 'Plugins', href: '/plugins/' },
   { label: 'Specs', href: '/specs/' },
   { label: 'Software', href: '/software/' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,13 @@ import { glob } from 'astro/loaders';
 const adocFrontmatter = z.object({
   title: z.string(),
   description: z.string().optional(),
+  /**
+   * One-sentence orientation shown in the page intro. Either
+   * define this explicitly or fall back to `description`. Pages
+   * should set this so visitors get a clear answer to "what is
+   * this page?" within the first scroll.
+   */
+  intro: z.string().optional(),
   date: z.coerce.date().optional(),
   author: z.string().optional(),
   tags: z.array(z.string()).default([]),
@@ -25,6 +32,7 @@ const adocFrontmatter = z.object({
 const mdFrontmatter = z.object({
   title: z.string(),
   description: z.string().optional(),
+  intro: z.string().optional(),
   mode: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal('cross')]).optional(),
   order: z.number().optional(),
 });
@@ -68,7 +76,9 @@ export const collections = {
 
   use_cases: defineCollection({
     loader: glob({ base: './src/content/use_cases', pattern: '**/*.mdx' }),
-    schema: mdFrontmatter,
+    schema: mdFrontmatter.extend({
+      audience: z.array(z.string()).default([]),
+    }),
   }),
 
   glossary: defineCollection({

--- a/src/content/docs/adapters/jce.mdx
+++ b/src/content/docs/adapters/jce.mdx
@@ -203,7 +203,7 @@ The coordinator is unreachable. Check:
 
 ## See also
 
-- [Adapters overview](./)
+- [Adapters overview](/docs/adapters/)
 - [PKCS#11 adapter](/docs/adapters/pkcs11/) — alternative via `SunPKCS11`.
 - [Java JCA documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/Provider.html)
 - [Source code](https://github.com/confium/confium/tree/main/crates/confium-jce-provider)

--- a/src/content/docs/adapters/openssl.mdx
+++ b/src/content/docs/adapters/openssl.mdx
@@ -167,7 +167,7 @@ openssl list -signature-algorithms -provider confium
 
 ## See also
 
-- [Adapters overview](./)
+- [Adapters overview](/docs/adapters/)
 - [PKCS#11 adapter](/docs/adapters/pkcs11/) — alternative for older OpenSSL or non-OpenSSL consumers.
 - [Web TLS use case](/use-cases/web-tls/)
 - [confium-openssl-provider crate](https://github.com/confium/confium/tree/main/crates/confium-openssl-provider)

--- a/src/content/docs/adapters/pkcs11.mdx
+++ b/src/content/docs/adapters/pkcs11.mdx
@@ -172,7 +172,7 @@ env CONFium_TLS_PIN;
 
 ## See also
 
-- [Adapters overview](./)
+- [Adapters overview](/docs/adapters/)
 - [OpenSSL provider](/docs/adapters/openssl/) — alternative for OpenSSL 3.0 native.
 - [confium-pkcs11-server binary](/docs/tooling/pkcs11-server/)
 - [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)

--- a/src/content/docs/cli/config.mdx
+++ b/src/content/docs/cli/config.mdx
@@ -89,5 +89,5 @@ confium config list --json
 
 ## See also
 
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)
 - [`confium trust`](/docs/cli/trust/)

--- a/src/content/docs/cli/daemon.mdx
+++ b/src/content/docs/cli/daemon.mdx
@@ -157,7 +157,7 @@ ENTRYPOINT ["confiumd", "--listen", "tcp://0.0.0.0:7878"]
 
 ## See also
 
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)
 - [`confium-publish`](/docs/cli/publish/)
 - [Operator guide](/audiences/operators/) — production deployment.
 - [Architecture](/docs/architecture/)

--- a/src/content/docs/cli/info.mdx
+++ b/src/content/docs/cli/info.mdx
@@ -74,4 +74,4 @@ Source:    registry.confium.org/botan@3.0.0
 
 - [`confium list`](/docs/cli/list/)
 - [`confium trust`](/docs/cli/trust/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/install.mdx
+++ b/src/content/docs/cli/install.mdx
@@ -79,4 +79,4 @@ confium install botan --force
 - [`confium remove`](/docs/cli/remove/)
 - [`confium update`](/docs/cli/update/)
 - [`confium trust`](/docs/cli/trust/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/list.mdx
+++ b/src/content/docs/cli/list.mdx
@@ -61,4 +61,4 @@ ring        0.17.8   BoringSSL        hash aead signature
 
 - [`confium info`](/docs/cli/info/)
 - [`confium install`](/docs/cli/install/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/publish.mdx
+++ b/src/content/docs/cli/publish.mdx
@@ -123,7 +123,7 @@ $ confium-publish ./target/release/libmy_plugin.so --publisher A1B2C3D4
 
 ## See also
 
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)
 - [`confiumd`](/docs/cli/daemon/)
 - [Plugin author guide](https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx)
   (Rust workspace docs).

--- a/src/content/docs/cli/remove.mdx
+++ b/src/content/docs/cli/remove.mdx
@@ -58,4 +58,4 @@ confium remove botan --purge --yes
 
 - [`confium install`](/docs/cli/install/)
 - [`confium list`](/docs/cli/list/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/search.mdx
+++ b/src/content/docs/cli/search.mdx
@@ -73,4 +73,4 @@ ring          0.17.8   BoringSSL         Ring crypto plugin (performance)
 
 - [`confium install`](/docs/cli/install/)
 - [`confium info`](/docs/cli/info/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/trust.mdx
+++ b/src/content/docs/cli/trust.mdx
@@ -95,4 +95,4 @@ confium trust verify 9B1D96E3... && echo "trusted"
 
 - [`confium install`](/docs/cli/install/)
 - [`confium info`](/docs/cli/info/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/update.mdx
+++ b/src/content/docs/cli/update.mdx
@@ -71,4 +71,4 @@ confium update --all --yes
 
 - [`confium install`](/docs/cli/install/)
 - [`confium list`](/docs/cli/list/)
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)

--- a/src/content/docs/cli/version.mdx
+++ b/src/content/docs/cli/version.mdx
@@ -42,5 +42,5 @@ confium 0.3.0
 
 ## See also
 
-- [CLI overview](./)
+- [CLI overview](/docs/cli/)
 - [`confium config`](/docs/cli/config/)

--- a/src/content/docs/pq-migration.mdx
+++ b/src/content/docs/pq-migration.mdx
@@ -1,9 +1,15 @@
 ---
 title: Post-quantum migration
 description: Migrate from classical to post-quantum signatures via composite signatures. Software upgrade, not HSM replacement. No certificate re-issuance flag day.
+intro: How to migrate an existing PKI from classical to post-quantum signatures using Confium's composite signatures. For the business case, see the use case instead.
 audience: developer
 order: 8
 ---
+
+> **Looking for the why?** This page covers the *how* — composite
+> signature types, verifier compatibility, migration phases. For
+> the business case (cost, risk reduction, timeline), read the
+> [PQ migration use case](/use-cases/pq-migration/) instead.
 
 # Post-quantum migration
 

--- a/src/content/docs/tooling/index.mdx
+++ b/src/content/docs/tooling/index.mdx
@@ -14,8 +14,8 @@ and four adapter libraries. Each is documented in its own page below.
 
 | Tool | Crate | Description |
 | --- | --- | --- |
-| [`confiumd`](../cli/daemon/) | `confium-daemon` | Long-running JSON-RPC service for signing sessions, transparency log, PKI operations. |
-| [`confium-publish`](../cli/publish/) | `confium-publish` | Plugin author's publishing tool — wraps, signs, and stages plugins for the registry. |
+| [`confiumd`](/docs/cli/daemon/) | `confium-daemon` | Long-running JSON-RPC service for signing sessions, transparency log, PKI operations. |
+| [`confium-publish`](/docs/cli/publish/) | `confium-publish` | Plugin author's publishing tool — wraps, signs, and stages plugins for the registry. |
 | [`confium-pkcs11-server`](/docs/tooling/pkcs11-server/) | `confium-pkcs11-server` | PKCS#11 v3.0 server — exposes Confium as an HSM to existing PKCS#11 consumers. |
 | [`confium-test-harness`](/docs/tooling/test-harness/) | `confium-test-harness` | NIST MPTS evaluation harness. |
 | `sim` | `confium-test-harness` | Multi-party threshold simulation runner. |

--- a/src/content/docs/tooling/jce-provider.mdx
+++ b/src/content/docs/tooling/jce-provider.mdx
@@ -119,7 +119,7 @@ the WASM verifier package via JNI.
 
 ## See also
 
-- [Tooling overview](./)
+- [Tooling overview](/docs/tooling/)
 - [PKCS#11 server](/docs/tooling/pkcs11-server/) — alternative via `SunPKCS11`.
 - [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)
 - [Java JCE documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/Provider.html)

--- a/src/content/docs/tooling/openssl-provider.mdx
+++ b/src/content/docs/tooling/openssl-provider.mdx
@@ -112,7 +112,7 @@ threshold session itself (~30ms typical in-region).
 
 ## See also
 
-- [Tooling overview](./)
+- [Tooling overview](/docs/tooling/)
 - [PKCS#11 server](/docs/tooling/pkcs11-server/) — alternative for older OpenSSL or non-OpenSSL consumers.
 - [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)
 - [Web TLS use case](/use-cases/web-tls/)

--- a/src/content/docs/tooling/pkcs11-server.mdx
+++ b/src/content/docs/tooling/pkcs11-server.mdx
@@ -130,7 +130,7 @@ A typical PKCS#11 `C_Sign()` call to the server:
 
 ## See also
 
-- [Tooling overview](./)
+- [Tooling overview](/docs/tooling/)
 - [OpenSSL provider](/docs/tooling/openssl-provider/) — alternative for native OpenSSL 3.0.
 - [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/)
 - [Operator guide](/audiences/operators/)

--- a/src/content/docs/tooling/test-harness.mdx
+++ b/src/content/docs/tooling/test-harness.mdx
@@ -106,7 +106,7 @@ The harness is designed for CI pipelines:
 ## See also
 
 - [Evaluators guide](/audiences/evaluators/) — performance numbers and protocol references.
-- [Tooling overview](./)
+- [Tooling overview](/docs/tooling/)
 - Test vectors in the workspace (see the
   [Confium repository](https://github.com/confium/confium) at the
   `crates/confium-test-harness/tests/vectors/` directory)

--- a/src/content/use_cases/pq-migration.mdx
+++ b/src/content/use_cases/pq-migration.mdx
@@ -1,9 +1,15 @@
 ---
 title: PQ migration
 description: Migrate from classical to post-quantum signatures without re-issuing every certificate. Composite signatures, software-only upgrade path.
+intro: The business case for migrating from classical to post-quantum signatures. For the technical implementation, see the docs.
 mode: cross
 order: 5
 ---
+
+> **Looking for the how?** This page covers the *why* — quantum
+> threat, cost model, risk reduction. For composite signature
+> types, verifier compatibility, and migration phases, read the
+> [PQ migration docs](/docs/pq-migration/) instead.
 
 # PQ migration
 

--- a/src/data/audiences.test.ts
+++ b/src/data/audiences.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { AUDIENCES, resolveAudience, type AudienceSlug } from './audiences';
+
+describe('AUDIENCES', () => {
+  it('contains the canonical 12 audience pages', () => {
+    expect(AUDIENCES).toHaveLength(12);
+  });
+
+  it('every entry has a unique slug', () => {
+    const slugs = AUDIENCES.map((a) => a.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('every entry has a non-empty name and tagline', () => {
+    for (const a of AUDIENCES) {
+      expect(a.name.length).toBeGreaterThan(0);
+      expect(a.tagline.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all slugs match the slug pattern (lowercase, hyphen-separated)', () => {
+    const slugPattern = /^[a-z][a-z0-9-]*$/;
+    for (const a of AUDIENCES) {
+      expect(a.slug).toMatch(slugPattern);
+    }
+  });
+});
+
+describe('resolveAudience', () => {
+  it('returns the slug unchanged for known slugs', () => {
+    expect(resolveAudience('developers')).toBe('developers');
+    expect(resolveAudience('architects')).toBe('architects');
+    expect(resolveAudience('executives')).toBe('executives');
+  });
+
+  it('resolves singular aliases to plural slugs', () => {
+    // The docs schema uses singular forms; audience pages are plural.
+    expect(resolveAudience('developer')).toBe('developers');
+    expect(resolveAudience('architect')).toBe('architects');
+    expect(resolveAudience('executive')).toBe('executives');
+    expect(resolveAudience('operator')).toBe('operators');
+    expect(resolveAudience('evaluator')).toBe('evaluators');
+    expect(resolveAudience('researcher')).toBe('evaluators');
+    expect(resolveAudience('cto')).toBe('ctos');
+    expect(resolveAudience('product-manager')).toBe('product-managers');
+    expect(resolveAudience('contributor')).toBe('contributors');
+    expect(resolveAudience('student')).toBe('students');
+    expect(resolveAudience('auditor')).toBe('auditors');
+  });
+
+  it('returns the input unchanged for unknown names', () => {
+    // Caller decides how to handle unknown names — typically by
+    // filtering them out downstream.
+    expect(resolveAudience('nonexistent')).toBe('nonexistent');
+    expect(resolveAudience('')).toBe('');
+  });
+
+  it('resolves case-sensitively', () => {
+    // Slugs are lowercase. Uppercase variants are not aliased.
+    expect(resolveAudience('Developers')).toBe('Developers');
+    expect(resolveAudience('DEVELOPER')).toBe('DEVELOPER');
+  });
+});
+
+describe('AUDIENCES alias coverage', () => {
+  // Sanity-check that every alias declared in AUDIENCES actually
+  // resolves back to its parent slug.
+  it('every alias resolves to its declaring slug', () => {
+    for (const a of AUDIENCES) {
+      const aliases = (a as { aliases?: readonly string[] }).aliases ?? [];
+      for (const alias of aliases) {
+        expect(resolveAudience(alias)).toBe(a.slug);
+      }
+    }
+  });
+
+  it('every AudienceSlug value is present in AUDIENCES', () => {
+    // TypeScript guarantees this at compile time; runtime check
+    // catches schema drift if AUDIENCES is edited without updating
+    // the AudienceSlug type.
+    const slugs = new Set(AUDIENCES.map((a) => a.slug));
+    const sampleSlugs: AudienceSlug[] = [
+      'executives',
+      'architects',
+      'developers',
+      'operators',
+      'compliance',
+      'evaluators',
+      'ctos',
+      'product-managers',
+      'contributors',
+      'students',
+      'auditors',
+      'web3',
+    ];
+    for (const s of sampleSlugs) {
+      expect(slugs.has(s)).toBe(true);
+    }
+  });
+});

--- a/src/data/audiences.ts
+++ b/src/data/audiences.ts
@@ -1,0 +1,44 @@
+/**
+ * Audiences — the canonical list of audience pages.
+ *
+ * Single source of truth for the 12 audience pages. Consumed by
+ * `/audiences/index.astro`, the WhoFor primitive, and any other
+ * code that needs to enumerate or link to audience pages.
+ *
+ * The `aliases` field on each entry handles alternate names —
+ * the docs schema uses singular forms (`developer`, `executive`)
+ * while the page slugs are plural (`developers`, `executives`).
+ * Components should look up via `resolveAudience(name)`.
+ */
+
+export const AUDIENCES = [
+  { slug: 'executives', name: 'Executives', tagline: 'Business value, risk, and compliance', aliases: ['executive'] },
+  { slug: 'architects', name: 'Security architects', tagline: 'Threat model and integration patterns', aliases: ['architect'] },
+  { slug: 'developers', name: 'Developers', tagline: 'API, examples, and SDK choice', aliases: ['developer'] },
+  { slug: 'operators', name: 'PKI operators', tagline: 'Deployment, monitoring, and runbooks', aliases: ['operator'] },
+  { slug: 'compliance', name: 'Compliance officers', tagline: 'FIPS, jurisdictions, and audit', aliases: [] },
+  { slug: 'evaluators', name: 'Evaluators and researchers', tagline: 'Test vectors, benchmarks, and protocol references', aliases: ['evaluator', 'researcher'] },
+  { slug: 'ctos', name: 'CTOs and engineering directors', tagline: 'Strategic adoption and risk posture', aliases: ['cto'] },
+  { slug: 'product-managers', name: 'Product managers', tagline: 'Scoping threshold-trust features', aliases: ['product-manager'] },
+  { slug: 'contributors', name: 'Open source contributors', tagline: 'Code, docs, plugins, security research', aliases: ['contributor'] },
+  { slug: 'students', name: 'Students and educators', tagline: 'Teaching materials, labs, and reading lists', aliases: ['student'] },
+  { slug: 'auditors', name: 'Security auditors', tagline: 'Audit checklist, evidence, and common findings', aliases: ['auditor'] },
+  { slug: 'web3', name: 'Web3 and blockchain developers', tagline: 'Threshold custody, MPC wallets, and on-chain signing', aliases: [] },
+] as const;
+
+export type AudienceSlug = (typeof AUDIENCES)[number]['slug'];
+
+/**
+ * Resolve any audience reference (slug or alias) to its slug.
+ * Returns the input unchanged if no match — caller decides how to
+ * handle unknown names.
+ */
+export function resolveAudience(name: string): string {
+  for (const a of AUDIENCES) {
+    if (a.slug === name || (a as { aliases?: readonly string[] }).aliases?.includes(name)) {
+      return a.slug;
+    }
+  }
+  return name;
+}
+

--- a/src/data/homepage.test.ts
+++ b/src/data/homepage.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { TONE_COLOR, TONE_TINT, TONE_CYCLE, type BrandTone } from './homepage';
+
+describe('TONE_COLOR', () => {
+  it('maps every BrandTone to a semantic CSS color token', () => {
+    expect(TONE_COLOR.blue).toBe('accent');
+    expect(TONE_COLOR.teal).toBe('accent2');
+    expect(TONE_COLOR.gold).toBe('gold-ink');
+  });
+
+  it('covers every BrandTone variant', () => {
+    const tones: BrandTone[] = ['blue', 'teal', 'gold'];
+    for (const tone of tones) {
+      expect(TONE_COLOR[tone]).toBeTruthy();
+    }
+  });
+
+  it('every value is one of the three semantic color tokens', () => {
+    const validTokens = new Set(['accent', 'accent2', 'gold-ink']);
+    for (const value of Object.values(TONE_COLOR)) {
+      expect(validTokens.has(value)).toBe(true);
+    }
+  });
+
+  it('mapping is one-to-one (no two tones share a color)', () => {
+    const values = Object.values(TONE_COLOR);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe('TONE_TINT', () => {
+  it('maps every BrandTone to its tint CSS token', () => {
+    expect(TONE_TINT.blue).toBe('tint-blue');
+    expect(TONE_TINT.teal).toBe('tint-teal');
+    expect(TONE_TINT.gold).toBe('tint-gold');
+  });
+
+  it('covers every BrandTone variant', () => {
+    const tones: BrandTone[] = ['blue', 'teal', 'gold'];
+    for (const tone of tones) {
+      expect(TONE_TINT[tone]).toBeTruthy();
+    }
+  });
+
+  it('every tint value matches the `tint-<tone>` pattern', () => {
+    for (const [tone, tint] of Object.entries(TONE_TINT)) {
+      expect(tint).toBe(`tint-${tone}`);
+    }
+  });
+});
+
+describe('TONE_CYCLE', () => {
+  it('is an ordered array of the three tones', () => {
+    expect(TONE_CYCLE).toEqual(['blue', 'teal', 'gold']);
+  });
+
+  it('has exactly 3 entries', () => {
+    expect(TONE_CYCLE).toHaveLength(3);
+  });
+
+  it('every entry is a valid BrandTone', () => {
+    const validTones = new Set<BrandTone>(['blue', 'teal', 'gold']);
+    for (const tone of TONE_CYCLE) {
+      expect(validTones.has(tone)).toBe(true);
+    }
+  });
+});

--- a/src/data/homepage.ts
+++ b/src/data/homepage.ts
@@ -1,0 +1,32 @@
+/**
+ * Homepage design tokens — typed continuations of the design system.
+ *
+ * Used by section components and primitives throughout the site
+ * to map the three brand identity tones to semantic CSS tokens.
+ */
+
+export type BrandTone = 'blue' | 'teal' | 'gold';
+
+/**
+ * Map a BrandTone to its semantic CSS color token name. Centralised
+ * so consumers never branch on tone — they look up the token.
+ */
+export const TONE_COLOR: Readonly<Record<BrandTone, 'accent' | 'accent2' | 'gold-ink'>> = {
+  blue: 'accent',
+  teal: 'accent2',
+  gold: 'gold-ink',
+};
+
+/**
+ * Map a BrandTone to its tint CSS token (for section bands).
+ */
+export const TONE_TINT: Readonly<Record<BrandTone, 'tint-blue' | 'tint-teal' | 'tint-gold'>> = {
+  blue: 'tint-blue',
+  teal: 'tint-teal',
+  gold: 'tint-gold',
+};
+
+/**
+ * Inverted tonal order to alternate panels: blue, teal, gold, blue, ...
+ */
+export const TONE_CYCLE: readonly BrandTone[] = ['blue', 'teal', 'gold'];

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,28 +1,94 @@
 ---
+/**
+ * DocsLayout — the chrome for /docs/, /concepts/, /use-cases/ pages.
+ *
+ * Owns the page intro (eyebrow + title + one-sentence orientation
+ * + breadcrumbs + who-for callout) and the 3-column prose grid
+ * (sidebar | prose | TOC). The intro answers "what is this page
+ * and is it for me?" within 30 seconds — without it, visitors
+ * landed on technical content with no context.
+ *
+ * The intro is built from `entry.data` fields:
+ *   - eyebrow: from `data.eyebrow` (or derived from collection name)
+ *   - title: from `data.title`
+ *   - intro: from `data.intro` (or `data.description` as fallback)
+ *   - audience: from `data.audience` (passed to WhoFor)
+ *
+ * PageIntro is the new hero; the old bare 3-column grid is gone.
+ */
 import BaseLayout from './BaseLayout.astro';
 import TocNav from '@components/astro/TocNav.astro';
 import Prose from '@components/astro/Prose.astro';
+import PageIntro from '@components/astro/primitives/PageIntro.astro';
+import Breadcrumb from '@components/astro/primitives/Breadcrumb.astro';
+import WhoFor from '@components/astro/primitives/WhoFor.astro';
+import type { BrandTone } from '@data/homepage';
 
-interface Props {
+export interface Props {
   title: string;
   description?: string;
+  /**
+   * One-sentence orientation. Optional — falls back to `description`
+   * when not provided. Pages should always set this explicitly.
+   */
+  intro?: string;
+  /** Eyebrow shown above the title. Defaults to the collection label. */
+  eyebrow?: string;
+  /** Audience names from the content schema (e.g. ['developers']). */
+  audience?: string[];
+  /** Identity tone for the eyebrow. Inherits from the page's section. */
+  tone?: BrandTone;
   sidebar?: { label: string; href: string; current?: boolean }[];
+  /** Source path for the "Edit on GitHub" link. */
   sourcePath?: string;
   headings?: { depth: number; slug: string; text: string }[];
+  /** Breadcrumb trail. Auto-derived if not provided. */
+  trail?: { label: string; href?: string }[];
+  /** Visible section label for the breadcrumb home. Defaults to the eyebrow. */
+  sectionLabel?: string;
+  /** Visible section href for the breadcrumb. Defaults to the eyebrow's URL. */
+  sectionHref?: string;
 }
 
 const {
   title,
   description,
+  intro,
+  eyebrow,
+  audience,
+  tone,
   sidebar = [],
   sourcePath,
   headings = [],
+  trail,
+  sectionLabel,
+  sectionHref,
 } = Astro.props;
 
 const filteredHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
+// Use explicit intro, fall back to description, fall back to empty.
+const introText = intro ?? description ?? '';
+// Breadcrumb: Home > Section > Page title. Caller can override.
+const crumbTrail = trail ?? [
+  { label: 'Home', href: '/' },
+  ...(sectionLabel
+    ? [{ label: sectionLabel, href: sectionHref }]
+    : []),
+  { label: title },
+];
 ---
 
 <BaseLayout title={title} description={description}>
+  <PageIntro
+    eyebrow={eyebrow ?? 'Documentation'}
+    title={title}
+    intro={introText}
+    tone={tone}
+  >
+    <Breadcrumb slot="breadcrumb" trail={crumbTrail} />
+    <WhoFor slot="who-for" for={audience ?? []} />
+  </PageIntro>
+
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
     <div class="lg:grid lg:grid-cols-[16rem_minmax(0,1fr)_14rem] lg:gap-8">
       {sidebar.length > 0 && (

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -111,14 +111,26 @@ const crumbTrail = trail ?? [
       )}
 
       <div>
-        {sourcePath && (
-          <p class="mb-4 text-xs font-mono text-muted-foreground">
-            Source: {sourcePath}
-          </p>
-        )}
         <Prose>
           <slot />
         </Prose>
+        {sourcePath && (
+          <footer class="mt-10 pt-6 border-t border-line text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+            <a
+              href={`https://github.com/confium/confium.github.io/edit/main/${sourcePath}`}
+              class="text-accent hover:text-accent-deep font-medium inline-flex items-center gap-1"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z" />
+              </svg>
+              Edit on GitHub
+            </a>
+            <span aria-hidden="true" class="text-faint">·</span>
+            <span class="font-mono text-faint">{sourcePath}</span>
+          </footer>
+        )}
       </div>
 
       {filteredHeadings.length >= 4 && (

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment node
+ *
+ * Run with the node environment (default) so `window` is undefined.
+ * This verifies the SSR safety of events.ts: when there's no
+ * window, dispatch and on are silent no-ops rather than throws.
+ *
+ * For browser-side behavior, integration tests via Playwright or
+ * similar are more appropriate than unit tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CONFUM_EVENTS, dispatch, on } from './events';
+
+describe('CONFUM_EVENTS', () => {
+  it('exposes the canonical event names', () => {
+    expect(CONFUM_EVENTS.openSearch).toBe('confium:open-search');
+    expect(CONFUM_EVENTS.closeSearch).toBe('confium:close-search');
+    expect(CONFUM_EVENTS.toggleTheme).toBe('confium:toggle-theme');
+    expect(CONFUM_EVENTS.replayHero).toBe('confium:replay-hero');
+    expect(CONFUM_EVENTS.selectMode).toBe('confium:select-mode');
+  });
+
+  it('every event name follows the confium:* namespace', () => {
+    for (const name of Object.values(CONFUM_EVENTS)) {
+      expect(name).toMatch(/^confium:[a-z-]+$/);
+    }
+  });
+
+  it('every event name is unique', () => {
+    const names = Object.values(CONFUM_EVENTS);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe('dispatch (SSR — no window)', () => {
+  it('is a no-op when window is undefined', () => {
+    expect(() => dispatch(CONFUM_EVENTS.toggleTheme)).not.toThrow();
+    expect(() => dispatch(CONFUM_EVENTS.openSearch, { query: 'x' })).not.toThrow();
+  });
+});
+
+describe('on (SSR — no window)', () => {
+  it('returns a no-op cleanup when window is undefined', () => {
+    const cleanup = on(CONFUM_EVENTS.toggleTheme, () => {});
+    expect(typeof cleanup).toBe('function');
+    expect(() => cleanup()).not.toThrow();
+  });
+});
+
+describe('dispatch + on (with window)', () => {
+  beforeEach(() => {
+    // Simulate a browser environment by attaching a fake window.
+    const listeners: Record<string, EventListener> = {};
+    (globalThis as { window?: unknown }).window = {
+      dispatchEvent: vi.fn((event: Event) => {
+        const type = (event as CustomEvent).type;
+        if (listeners[type]) listeners[type](event);
+        return true;
+      }),
+      addEventListener: vi.fn((type: string, handler: EventListener) => {
+        listeners[type] = handler;
+      }),
+      removeEventListener: vi.fn((type: string) => {
+        delete listeners[type];
+      }),
+      CustomEvent: class CustomEvent extends Event {
+        detail: unknown;
+        constructor(type: string, init: { detail?: unknown } = {}) {
+          super(type);
+          this.detail = init.detail;
+        }
+      },
+    } as unknown as Window;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('dispatch fires a CustomEvent with the given detail', () => {
+    const handler = vi.fn();
+    on(CONFUM_EVENTS.toggleTheme, handler);
+    dispatch(CONFUM_EVENTS.toggleTheme, { mode: 'dark' });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual({ mode: 'dark' });
+  });
+
+  it('on returns a cleanup that removes the handler', () => {
+    const handler = vi.fn();
+    const cleanup = on(CONFUM_EVENTS.openSearch, handler);
+    cleanup();
+    dispatch(CONFUM_EVENTS.openSearch);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/mdx-links.test.ts
+++ b/src/lib/mdx-links.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Guards against the Phase 0 regression: MDX content using relative
+ * paths like `./foo.mdx` or `../foo/`. Astro doesn't rewrite these
+ * when rendering, so the built HTML has the relative path embedded
+ * verbatim — which then resolves wrong relative to the HTML file's
+ * URL.
+ *
+ * Convention: use absolute paths (`/docs/foo/`) in all MDX content.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const CONTENT_ROOT = join(process.cwd(), 'src', 'content');
+
+function findMdxFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (entry.name.endsWith('.mdx')) out.push(path);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+const mdxFiles = findMdxFiles(CONTENT_ROOT);
+
+// Match markdown links with relative paths. Flags:
+//   - ./foo, ./foo.mdx, ./foo/
+//   - ../foo, ../foo.mdx
+// Does NOT flag: absolute URLs (http://, mailto:), site-absolute
+// paths (/foo/), in-page fragments (#anchor).
+const RELATIVE_LINK_PATTERN = /\]\((\.{1,2}[/A-Za-z0-9._-]+)\)/g;
+
+describe('MDX relative-link guard', () => {
+  it('found MDX files to scan', () => {
+    expect(mdxFiles.length).toBeGreaterThan(0);
+  });
+
+  it('no MDX file uses relative paths in markdown links', () => {
+    const violations: { file: string; relativePath: string }[] = [];
+    for (const file of mdxFiles) {
+      const content = readFileSync(file, 'utf8');
+      const matches = content.matchAll(RELATIVE_LINK_PATTERN);
+      const rel = relative(CONTENT_ROOT, file);
+      for (const match of matches) {
+        violations.push({ file: rel, relativePath: match[1] });
+      }
+    }
+    if (violations.length > 0) {
+      const detail = violations
+        .slice(0, 20)
+        .map((v) => `  ${v.file}: ${v.relativePath}`)
+        .join('\n');
+      expect.fail(
+        `Found ${violations.length} relative link(s) in MDX content.\n` +
+          'Use absolute paths like `/docs/foo/` instead.\n' +
+          `First ${Math.min(20, violations.length)}:\n${detail}`,
+      );
+    }
+  });
+
+  it('the relative-link pattern only matches what we want to flag', () => {
+    // Each test string is a complete markdown link `[text](href)`.
+    const positives = [
+      '[a](./foo)',
+      '[a](./foo.mdx)',
+      '[a](./foo/)',
+      '[a](../bar)',
+      '[a](../bar.mdx)',
+      '[a](../../baz)',
+    ];
+    const negatives = [
+      '[a](/docs/foo/)',
+      '[a](https://example.com/foo)',
+      '[a](mailto:a@b.com)',
+      '[a](#section)',
+      '[a](#)',
+    ];
+    for (const p of positives) {
+      expect(p).toMatch(RELATIVE_LINK_PATTERN);
+    }
+    for (const n of negatives) {
+      expect(n).not.toMatch(RELATIVE_LINK_PATTERN);
+    }
+  });
+});

--- a/src/lib/nav.test.ts
+++ b/src/lib/nav.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `astro:content` is a virtual module resolved only inside Astro.
+// The pure functions in nav.ts (byOrder, byDateNewest, groupByYear)
+// don't need it; the async collection wrappers do, but those are
+// exercised through integration builds rather than unit tests.
+vi.mock('astro:content', () => ({
+  getCollection: vi.fn(),
+}));
+
+// Import AFTER the mock so the module loads clean.
+const { byOrder, byDateNewest, groupByYear } = await import('./nav');
+
+interface TestEntry {
+  data: { order?: number; title: string; date?: Date };
+}
+
+const makeEntries = (entries: Array<[string, number?, Date?]>): TestEntry[] =>
+  entries.map(([title, order, date]) => ({
+    data: { title, order, date },
+  }));
+
+describe('byOrder', () => {
+  it('sorts by ascending order', () => {
+    const entries = makeEntries([
+      ['Charlie', 3],
+      ['Alpha', 1],
+      ['Bravo', 2],
+    ]);
+    const sorted = byOrder(entries).map((e) => e.data.title);
+    expect(sorted).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('falls back to 99 when order is undefined', () => {
+    const entries = makeEntries([
+      ['With order', 5],
+      ['No order'],
+    ]);
+    const sorted = byOrder(entries).map((e) => e.data.title);
+    expect(sorted).toEqual(['With order', 'No order']);
+  });
+
+  it('uses title as tiebreaker for equal orders', () => {
+    const entries = makeEntries([
+      ['Zebra', 1],
+      ['Apple', 1],
+      ['Mango', 1],
+    ]);
+    const sorted = byOrder(entries).map((e) => e.data.title);
+    expect(sorted).toEqual(['Apple', 'Mango', 'Zebra']);
+  });
+
+  it('does not mutate the input array', () => {
+    const entries = makeEntries([
+      ['Bravo', 2],
+      ['Alpha', 1],
+    ]);
+    const original = entries.map((e) => e.data.title);
+    byOrder(entries);
+    expect(entries.map((e) => e.data.title)).toEqual(original);
+  });
+
+  it('handles empty input', () => {
+    expect(byOrder([])).toEqual([]);
+  });
+});
+
+describe('byDateNewest', () => {
+  it('sorts newest first', () => {
+    const entries = makeEntries([
+      ['Old', undefined, new Date('2024-01-01')],
+      ['New', undefined, new Date('2026-06-01')],
+      ['Mid', undefined, new Date('2025-06-01')],
+    ]);
+    const sorted = byDateNewest(entries).map((e) => e.data.title);
+    expect(sorted).toEqual(['New', 'Mid', 'Old']);
+  });
+
+  it('places undated entries at the end', () => {
+    const entries = makeEntries([
+      ['Undated'],
+      ['Dated', undefined, new Date('2024-01-01')],
+    ]);
+    const sorted = byDateNewest(entries).map((e) => e.data.title);
+    expect(sorted).toEqual(['Dated', 'Undated']);
+  });
+
+  it('does not mutate input', () => {
+    const entries = makeEntries([
+      ['B', undefined, new Date('2024-02-01')],
+      ['A', undefined, new Date('2024-01-01')],
+    ]);
+    const original = entries.map((e) => e.data.title);
+    byDateNewest(entries);
+    expect(entries.map((e) => e.data.title)).toEqual(original);
+  });
+});
+
+describe('groupByYear', () => {
+  it('groups by year, newest year first', () => {
+    const entries = makeEntries([
+      ['A', undefined, new Date('2026-03-15')],
+      ['B', undefined, new Date('2026-06-01')],
+      ['C', undefined, new Date('2024-12-31')],
+      ['D', undefined, new Date('2025-01-15')],
+    ]);
+    const groups = groupByYear(entries);
+    expect(groups.map((g) => g.year)).toEqual([2026, 2025, 2024]);
+  });
+
+  it('preserves all entries within a year group', () => {
+    const entries = makeEntries([
+      ['A', undefined, new Date('2026-03-15')],
+      ['B', undefined, new Date('2026-06-01')],
+    ]);
+    const groups = groupByYear(entries);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].year).toBe(2026);
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it('places undated entries in year 0, sorted last', () => {
+    const entries = makeEntries([
+      ['Undated'],
+      ['Dated', undefined, new Date('2026-01-01')],
+    ]);
+    const groups = groupByYear(entries);
+    expect(groups.map((g) => g.year)).toEqual([2026, 0]);
+  });
+
+  it('handles empty input', () => {
+    expect(groupByYear([])).toEqual([]);
+  });
+
+  it('handles a single year with a single entry', () => {
+    const entries = makeEntries([['Solo', undefined, new Date('2026-01-01')]]);
+    const groups = groupByYear(entries);
+    expect(groups).toEqual([
+      { year: 2026, items: [{ data: { title: 'Solo', date: new Date('2026-01-01') } }] },
+    ]);
+  });
+});

--- a/src/lib/path-aliases.test.ts
+++ b/src/lib/path-aliases.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Path-alias drift guard.
+ *
+ * Astro resolves imports via Vite's `resolve.alias` config. TypeScript
+ * resolves them via `tsconfig.json` `paths`. The two configs MUST
+ * agree, or you get the runtime-vs-type-checker divergence that bit
+ * us before (TypeScript happy, build broken).
+ *
+ * This test parses both files and asserts they define the same set
+ * of aliases pointing at the same targets.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+interface AliasExpectation {
+  alias: string;
+  target: string;
+}
+
+const EXPECTED_ALIASES: AliasExpectation[] = [
+  { alias: '@', target: 'src' },
+  { alias: '@components', target: 'src/components' },
+  { alias: '@layouts', target: 'src/layouts' },
+  { alias: '@lib', target: 'src/lib' },
+  { alias: '@data', target: 'src/data' },
+];
+
+function parseTsconfigPaths(): Record<string, string> {
+  const raw = readFileSync(`${ROOT}/tsconfig.json`, 'utf8');
+  // Strip JSON-incompatible comments (none currently, but be safe).
+  const json = raw.replace(/\/\/.*$/gm, '');
+  const parsed = JSON.parse(json);
+  const paths = parsed.compilerOptions.paths ?? {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(paths)) {
+    // `@lib/*` -> `@lib`; `[ "src/lib/*" ]` -> `src/lib`
+    const alias = k.replace(/\/\*$/, '');
+    const target = (v as string[])[0].replace(/\/\*$/, '');
+    out[alias] = target;
+  }
+  return out;
+}
+
+function parseViteAliases(): Record<string, string> {
+  const raw = readFileSync(`${ROOT}/astro.config.mjs`, 'utf8');
+  // Match the resolve.alias block. Format:
+  //   resolve: { alias: { '@': '/abs/path/src', ... } }
+  const blockMatch = raw.match(/alias:\s*\{([^}]*)\}/);
+  if (!blockMatch) return {};
+  const block = blockMatch[1];
+  const out: Record<string, string> = {};
+  // Match `'@alias': new URL('./target', import.meta.url).pathname`
+  // or `'@alias': '/abs/path'`. `@alias` may be just `@` or `@foo`.
+  const entryPattern =
+    /['"](@[\w-]*)['"]\s*:\s*(?:new URL\(\s*['"]\.\/([^'"]+)['"]|['"]([^'"]+)['"])/g;
+  let m: RegExpExecArray | null;
+  while ((m = entryPattern.exec(block)) !== null) {
+    out[m[1]] = m[2] ?? m[3];
+  }
+  return out;
+}
+
+describe('path-alias drift guard', () => {
+  it('tsconfig.json defines every expected alias', () => {
+    const paths = parseTsconfigPaths();
+    for (const { alias, target } of EXPECTED_ALIASES) {
+      expect(paths[alias], `tsconfig missing ${alias}`).toBe(target);
+    }
+  });
+
+  it('astro.config.mjs defines every expected alias', () => {
+    const aliases = parseViteAliases();
+    for (const { alias, target } of EXPECTED_ALIASES) {
+      expect(aliases[alias], `astro.config missing ${alias}`).toBe(target);
+    }
+  });
+
+  it('tsconfig and astro.config agree on every alias', () => {
+    const ts = parseTsconfigPaths();
+    const vite = parseViteAliases();
+    for (const { alias } of EXPECTED_ALIASES) {
+      expect(vite[alias], `vite missing ${alias}`).toBe(ts[alias]);
+    }
+  });
+
+  it('every declared alias actually exists on disk', async () => {
+    const { statSync } = await import('node:fs');
+    const vite = parseViteAliases();
+    for (const { alias, target } of EXPECTED_ALIASES) {
+      const path = `${ROOT}/${vite[alias] ?? target}`;
+      expect(() => statSync(path), `${alias} → ${target} does not exist`).not.toThrow();
+    }
+  });
+});

--- a/src/pages/concepts/[...id].astro
+++ b/src/pages/concepts/[...id].astro
@@ -25,8 +25,13 @@ const sidebar = allConcepts
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Concept"
+  tone="teal"
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Concepts"
+  sectionHref="/concepts/"
 >
   <Content />
 </DocsLayout>

--- a/src/pages/concepts/[...id].astro
+++ b/src/pages/concepts/[...id].astro
@@ -32,6 +32,7 @@ const sidebar = allConcepts
   headings={headings}
   sectionLabel="Concepts"
   sectionHref="/concepts/"
+  sourcePath={`src/content/concepts/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>

--- a/src/pages/docs/[...id].astro
+++ b/src/pages/docs/[...id].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import type { BrandTone } from '@data/homepage';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
@@ -20,13 +21,21 @@ const sidebar = allDocs
     href: `/docs/${d.id}/`,
     current: d.id === doc.id,
   }));
+
+const audience = doc.data.audience ? [doc.data.audience] : undefined;
 ---
 
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Documentation"
+  tone="blue"
+  audience={audience}
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Docs"
+  sectionHref="/docs/"
 >
   <Content />
 </DocsLayout>

--- a/src/pages/docs/[...id].astro
+++ b/src/pages/docs/[...id].astro
@@ -36,6 +36,7 @@ const audience = doc.data.audience ? [doc.data.audience] : undefined;
   headings={headings}
   sectionLabel="Docs"
   sectionHref="/docs/"
+  sourcePath={`src/content/docs/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,6 +137,12 @@ const deployments = [
               New to threshold crypto?
             </a>
           </div>
+          <p class="mt-5 text-sm text-white/70">
+            Not sure where to start?
+            <a href="/audiences/" class="text-white underline decoration-white/40 hover:decoration-white transition-colors font-medium">
+              Find your path →
+            </a>
+          </p>
         </div>
 
         <div class="lg:justify-self-end">

--- a/src/pages/use-cases/[id].astro
+++ b/src/pages/use-cases/[id].astro
@@ -33,6 +33,7 @@ const sidebar = allItems
   headings={headings}
   sectionLabel="Use cases"
   sectionHref="/use-cases/"
+  sourcePath={`src/content/use_cases/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>

--- a/src/pages/use-cases/[id].astro
+++ b/src/pages/use-cases/[id].astro
@@ -25,8 +25,14 @@ const sidebar = allItems
 <DocsLayout
   title={doc.data.title}
   description={doc.data.description}
+  intro={doc.data.intro}
+  eyebrow="Use case"
+  tone="gold"
+  audience={doc.data.audience}
   sidebar={sidebar}
   headings={headings}
+  sectionLabel="Use cases"
+  sectionHref="/use-cases/"
 >
   <Content />
 </DocsLayout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@/*": ["src/*"],
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["src/lib/*"],
+      "@data/*": ["src/data/*"]
     },
     "jsx": "preserve",
     "moduleResolution": "bundler",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Vitest configuration.
+ *
+ * Mirrors the tsconfig + astro.config path aliases so tests can
+ * import via `@lib/...`, `@data/...`, `@components/...`, etc.
+ */
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/lib/**/*.ts', 'src/data/**/*.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@components': fileURLToPath(new URL('./src/components', import.meta.url)),
+      '@layouts': fileURLToPath(new URL('./src/layouts', import.meta.url)),
+      '@lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+      '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a `link_check` job to `.github/workflows/tests.yml`. Lychee now runs on every push to main and every PR as part of the consolidated tests workflow.

### Job

1. Checkout + Node 22 + `npm ci`
2. `npm run fetch-sources` — pulls software docs from upstream repos
3. `npm run build` — Astro build + Pagefind postbuild
4. `lycheeverse/lychee-action@v2` with project's `lychee.toml`
5. `fail: true` — workflow fails on any broken link

### Tests workflow now has 3 parallel jobs

| Job | What |
|---|---|
| `unit_tests` | `npm test` — 47 Vitest specs |
| `type_check` | `npx astro check` — TypeScript + .astro type safety |
| `link_check` | `lychee` against built HTML |

All three run on every PR. Any failure blocks merge.

### Note

The standalone `.github/workflows/links.yml` still exists with the same job. I left it intact rather than deleting — let me know if you want it removed to dedupe CI minutes.

## Test plan

- [ ] Workflow triggers on PR open
- [ ] All three jobs run in parallel
- [ ] `link_check` fails if a broken link is introduced (manually test by temporarily breaking a link in a PR branch)
- [ ] Workflow passes on this branch (CI will run when PR opens)
