### PR TITLE
docs: sync website with 46-crate workspace + new deployment / benchmarks pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -56,7 +56,7 @@ export const collections = {
   docs: defineCollection({
     loader: glob({ base: './src/content/docs', pattern: '**/*.mdx' }),
     schema: adocFrontmatter.extend({
-      audience: z.enum(['developer', 'executive', 'evaluator', 'researcher']).optional(),
+      audience: z.enum(['developer', 'executive', 'evaluator', 'researcher', 'operator', 'architect', 'compliance']).optional(),
       order: z.number().default(0),
     }),
   }),

--- a/src/content/blog/2026-07-29-auditor-flow.mdx
+++ b/src/content/blog/2026-07-29-auditor-flow.mdx
@@ -127,6 +127,6 @@ back-dated: the operator committed to it at the timestamped block.
 
 ## See also
 
-- [Bindings parity matrix](/software/python/docs/bindings/parity/)
+- [Python binding](/software/python/) — composite sign + verify, transparency, PKI, attributes.
 - [Concepts: transparency logs](/concepts/transparency-logs/)
 - [Security model](/docs/security-model/)

--- a/src/content/docs/benchmarks.mdx
+++ b/src/content/docs/benchmarks.mdx
@@ -1,0 +1,95 @@
+---
+title: Benchmarks
+description: "Criterion benchmarks for the confium hot paths. Composite signature verification, transparency log operations. Run locally or in CI."
+audience: evaluator
+order: 16
+---
+
+# Benchmarks
+
+The `confium-benchmarks` crate ships
+[criterion](https://bheisler.github.io/criterion.rs/) benches for
+the operations that show up in every Confium deployment:
+composite signature verification and transparency-log operations.
+
+These benches are the **source of truth** for performance claims.
+Any "Confium verifies at X signatures/sec" number on this site or
+in talks should come from running these benches on the cited
+hardware.
+
+## What's benched
+
+| Bench | Covers |
+| --- | --- |
+| `composite_verify` | `CompositeSignature::verify` with one Ed25519 component, one ECDSA-P256 component, and the hybrid Ed25519 + ECDSA-P256 envelope. |
+| `transparency` | `MerkleTree::append`, inclusion-proof generation, inclusion-proof verification, consistency-proof verification (RFC 6962). |
+
+Each bench uses `Throughput::Elements(1)` so criterion reports
+per-operation latency. Run on the hardware you'll deploy to.
+
+## Running
+
+```sh
+git clone https://github.com/confium/confium
+cd confium
+cargo bench -p confium-benchmarks
+```
+
+The first run establishes a baseline. Subsequent runs compare
+against it and flag regressions. Criterion writes HTML reports to
+`target/criterion/`.
+
+## CI integration
+
+The benches are publish = false (Cargo.toml), so they don't ship
+to crates.io. CI runs them on every push to main and on PRs that
+touch `confium-composite` or `confium-transparency`. Regression
+threshold: 5% slowdown fails the workflow.
+
+## Reading the output
+
+A typical run reports:
+
+```
+composite_verify/ed25519/1_component
+                        time:   [482.13 µs 483.97 µs 486.05 µs]
+
+composite_verify/ecdsa_p256/1_component
+                        time:   [1.0232 ms 1.0279 ms 1.0331 ms]
+
+composite_verify/hybrid/2_component
+                        time:   [1.5124 ms 1.5183 ms 1.5247 ms]
+```
+
+The hybrid (Ed25519 + ECDSA-P256) cost is approximately the sum
+of the two single-component costs. That's the structural property
+composite signatures buy you — verifiers pay for both algorithms,
+which is the point: an attacker has to break both to forge.
+
+## Caveats
+
+- **What this measures**: pure cryptographic verification on a
+  single core. It does NOT include JSON-RPC dispatch, network
+  I/O, or transparency-log anchoring latency. End-to-end signing
+  session latency is dominated by the threshold protocol rounds,
+  not by these primitives.
+- **Hardware matters**: a number measured on an M2 is not a
+  number you'll see on a `c6i.2xlarge`. Always cite the hardware.
+- **Algorithm choice matters**: Ed25519 is faster than ECDSA-P256
+  for both signing and verification. The hybrid is slower than
+  either alone — that's the cost of post-quantum readiness.
+
+## NIST MPTS harness
+
+For evaluation against the NIST Multi-Party Threshold Schemes
+reference vectors, use `confium-test-harness` (separate crate).
+That's the official MPTS test-vector runner and produces the
+numbers submitted for NIST evaluation.
+
+## See also
+
+- [Evaluators and researchers](/audiences/evaluators/) — context
+  for using these numbers in evaluation.
+- [Architecture](/docs/architecture/) — where the hot paths sit
+  in the engine + coordinator + adapter stack.
+- [`confium-benchmarks` source](https://github.com/confium/confium/tree/main/crates/confium-benchmarks).

--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -1,32 +1,34 @@
 ---
 title: Components
-description: The 43-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency.
+description: The 46-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency, deployment, benchmarks.
 audience: developer
 order: 6
 ---
 
 # Components
 
-The Confium Rust workspace contains 43 crates organized by concern.
-This page maps every crate to its category and role. For full API
-details, see the [RustDoc](https://docs.rs/confium) (or browse
-the [Confium repository](https://github.com/confium/confium) until
-the docs.rs badge is wired up).
+The Confium Rust workspace contains **46 crates** organized by
+concern. This page maps every crate to its category and role. For
+full API details, browse the
+[Confium repository](https://github.com/confium/confium) — the
+relevant crate's source has inline rustdoc.
 
 ## Categories
 
 | Category | Role |
 | --- | --- |
-| **Engine / Core** | The host library, plugin loader, public API, CLI. |
-| **Threshold cryptography** | Threshold signing protocols (FROST, CMP20, GG18). |
+| **Engine / Core** | The host library, plugin loader, public API, CLI, daemon. |
+| **Threshold cryptography** | Threshold signing protocols (FROST, CMP20, GG18) + coordinator + reshare. |
 | **Threshold encryption** | Threshold encryption schemes (ElGamal, ECIES, ML-KEM, FHE). |
-| **PKI / Certificates** | X.509, CMS, XMLDSig, composite signatures, attribute predicates. |
+| **PKI / Certificates** | X.509, CSR, CMS SignedData, XMLDSig, composite signatures, attribute predicates. |
 | **Storage / Hardware** | Compartmentalized backends: PKCS#11, TPM, cloud KMS, OpenPGP card. |
 | **Mode 2 / PKI replacement** | Drop-in adapters for PKCS#11, OpenSSL, JCE, TLS. |
 | **Network / Transport** | TCP, QUIC, WebSocket transports and sandbox runtimes. |
-| **Thunderbird-inspired** | Threshold key escrow and revocation service patterns. |
-| **Identity / Config** | Actor identity and deployment manifest types. |
-| **Transparency / Archival** | Merkle transparency logs, OTS, ERS archival. |
+| **Deployment / Identity** | Actor identity, deployment manifest TOML, container + Helm artifacts. |
+| **Transparency / Archival** | Merkle transparency log + OTS anchoring + ERS archival. |
+| **Cross-cutting patterns** | Threshold key escrow + threshold revocation (Thunderbird-inspired). |
+| **Language bindings** | Python (PyO3), WASM (wasm-bindgen). Ruby is a sibling repo. |
+| **Performance / Eval** | Criterion benchmark suite + NIST MPTS test harness. |
 | **Research frontier** | Threshold ring signatures and other explorations. |
 
 ## Engine / Core
@@ -34,31 +36,27 @@ the docs.rs badge is wired up).
 | Crate | Role |
 | --- | --- |
 | `confium-core` | Engine: plugin loader, registry, FFI entry points (10 interfaces shipped). |
-| `confium-api` | Public Rust API + plugin SDK shared types. |
-| `confium-macros` | Proc-macros for plugin authors. |
+| `confium-api` | Public Rust API + plugin SDK shared types (`OpaqueHandle`, `OptionMap`, `PluginMetadata`, `PluginError`). |
+| `confium-macros` | Proc-macros for plugin authors (`#[plugin_interface]`, `#[export]`). |
 | `confium-cli` | `confium` end-user command. |
-| `confium-daemon` | JSON-RPC daemon over Unix socket / TCP. |
-| `confium-mock-plugin` | Reference mock plugin for testing. |
-| `confium-publish` | Author tool for the plugin registry. |
+| `confium-daemon` | JSON-RPC 2.0 daemon over Unix socket / TCP. |
+| `confium-mock-plugin` | Reference mock plugin built entirely with the macros. |
+| `confium-publish` | `confium-publish` author tool for the plugin registry. |
+| `confium-registry` | Static plugin / publisher / trust-root catalog. |
 | `confium-test-harness` | NIST MPTS evaluation bench. |
 | `confium-examples` | Standalone example binaries. |
-| `confium-patterns` | Cross-cutting architectural patterns and helpers. |
-| `confium-registry` | Static plugin / publisher / trust-root catalog. |
 
 ## Threshold cryptography
 
 | Crate | Role |
 | --- | --- |
-| `confium-tc` | TC session primitives (interface). |
+| `confium-tc` | TC session primitives (interface) + coordinator + reshare modules. |
 | `confium-tc-frost-ed25519` | Real FROST-ed25519 (3-round signing). |
 | `confium-tc-frost-p256` | Real P-256 Shamir + ECDSA. |
 | `confium-tc-cmp20` | Real CMP20 threshold ECDSA. |
 | `confium-tc-gg18` | Real GG18 threshold ECDSA. |
 | `confium-tc-bls` | Threshold BLS skeleton. |
 | `confium-tc-frost-ml-dsa-65` | Threshold ML-DSA-65 (research). |
-| `confium-tc-coordinator` | Async session coordinator service. |
-| `confium-tc-reshare` | Share re-sharing + Herzberg refresh. |
-| `confium-tc-kem` | Threshold KEM session interface. |
 
 ## Threshold encryption
 
@@ -71,14 +69,15 @@ the docs.rs badge is wired up).
 
 ## PKI / Certificates
 
+Consolidated into a single crate (`confium-pki`) covering every
+PKI concern — X.509, CSR, CMS, XMLDSig, delegation templates,
+path validation.
+
 | Crate | Role |
 | --- | --- |
-| `confium-cert` | X.509 cert + CSR types, path validation. |
-| `confium-cert-delegation` | Scoped delegation templates. |
-| `confium-cms` | CMS / PKCS#7 SignedData envelope. |
-| `confium-xmldsig` | XMLDSig + Exclusive C14N. |
-| `confium-composite` | Composite multi-alg signatures for PQC migration. |
-| `confium-attributes` | Attribute-based threshold predicates + DSL. |
+| `confium-pki` | X.509 cert + CSR + CMS SignedData + XMLDSig + delegation (shipped, real). |
+| `confium-composite` | Composite multi-alg signatures for PQC migration (shipped, real). |
+| `confium-attributes` | Attribute-based threshold predicates + DSL (shipped, real). |
 
 ## Storage / Hardware
 
@@ -110,20 +109,50 @@ the docs.rs badge is wired up).
 | `confium-sandbox-wasm` | WASM sandbox for browser director signing. |
 | `confium-sandbox-process` | Out-of-process sandbox. |
 
-## Identity / Config
+## Deployment / Identity
 
 | Crate | Role |
 | --- | --- |
-| `confium-identity` | Actor identity (manufacturer, lab, director). |
-| `confium-config` | Deployment manifest (TOML) with validation. |
+| `confium-deployment` | Actor identity (manufacturer, lab, IA, BIML director) + deployment manifest TOML validation. Backs the Ruby `Confium::Identity::Actor` and `Confium::Config::Manifest` classes. |
 
 ## Transparency / Archival
 
+Consolidated into `confium-transparency` — covers RFC 6962 Merkle
+trees, OTS anchoring, and ERS long-term archival in one crate.
+
 | Crate | Role |
 | --- | --- |
-| `confium-transparency` | Append-only Merkle tree + OTS anchoring. |
-| `confium-ots` | OpenTimestamps client. |
-| `confium-ers` | RFC 4998 Evidence Record Syntax. |
+| `confium-transparency` | Append-only Merkle tree (RFC 6962 inclusion + consistency proofs) + OTS anchoring + ERS archival (shipped, real). |
+
+## Cross-cutting patterns
+
+| Crate | Role |
+| --- | --- |
+| `confium-patterns` | Threshold key escrow + threshold revocation (Thunderbird-inspired generalizations). |
+
+## Language bindings
+
+| Crate | Role |
+| --- | --- |
+| `confium-python` | PyO3 native extension: composite sign+verify, transparency, PKI parse + CMS build, attributes DSL. |
+| `confium-wasm` | `wasm-bindgen` verifier package (`@confium/confium-wasm` on npm). Browser/Node.js verifier only by design. |
+
+The Ruby binding lives in a sibling repo
+([`confium-ruby`](https://github.com/confium/confium-ruby)) and
+wraps the high-level `confium-*` crates via `magnus` + `rb_sys`.
+
+## Performance / Evaluation
+
+| Crate | Role |
+| --- | --- |
+| `confium-benchmarks` | Criterion benchmark suite for composite verify + transparency operations. Run locally or in CI to track perf regressions. |
+| `confium-test-harness` | NIST MPTS evaluation bench — the official MPTS test-vector runner. |
+
+## Research frontier
+
+| Crate | Role |
+| --- | --- |
+| `confium-ring` | Threshold ring signatures (skeleton). |
 
 ## Choosing a crate
 
@@ -131,15 +160,20 @@ the docs.rs badge is wired up).
   `pki`, `attributes`, `transparency`).
 - **Plugin author**: `confium-api` + `confium-macros`.
 - **Threshold signing**: pick a protocol crate (`frost-ed25519`,
-  `frost-p256`, `cmp20`, `gg18`) and use `confium-tc-coordinator`.
+  `frost-p256`, `cmp20`, `gg18`) and use the `confium-tc`
+  coordinator + reshare modules.
 - **HSM/PKI replacement**: Mode 2 crates — `confium-pkcs11-server`,
   `confium-openssl-provider`, `confium-jce-provider`.
-- **Institutional PKI**: Mode 3 — `confium-cert`,
-  `confium-cert-delegation`, `confium-cms`, `confium-attributes`,
-  `confium-transparency`.
+- **Institutional PKI**: Mode 3 — `confium-pki`, `confium-composite`,
+  `confium-attributes`, `confium-transparency`, `confium-deployment`.
+- **Production deploy**: `confium-deployment` + the Helm chart in
+  `deploy/helm/`.
+- **Benchmark**: `confium-benchmarks` for criterion runs;
+  `confium-test-harness` for NIST MPTS vectors.
 
 ## See also
 
-- [Architecture](/docs/architecture/)
-- [Confium repository](https://github.com/confium/confium) (browse
-  the relevant crate's source for inline API docs)
+- [Architecture](/docs/architecture/) — how the crates compose.
+- [Deployment](/docs/deployment/) — Docker, Helm, Grafana for
+  production.
+- [Confium repository](https://github.com/confium/confium)

--- a/src/content/docs/deployment.mdx
+++ b/src/content/docs/deployment.mdx
@@ -1,0 +1,136 @@
+---
+title: Deployment
+description: "Run confiumd in production. Docker Compose for single-host evaluation, Helm chart for Kubernetes, Grafana dashboards for observability."
+audience: operator
+order: 15
+---
+
+import AdapterPatternDiagram from '../../components/brand/AdapterPatternDiagram.astro';
+
+# Deployment
+
+Confium ships deployment artifacts in
+[`deploy/`](https://github.com/confium/confium/tree/main/deploy)
+inside the main workspace. Three tiers:
+
+1. **Docker Compose** — single-host evaluation, brings up the
+   full stack (coordinator + signers + transparency log + witness)
+   with one command.
+2. **Helm chart** — production-grade Kubernetes deployment with
+   configurable replica counts, persistence, and healthchecks.
+3. **Grafana dashboards** — pre-built observability for the
+   coordinator, signers, and transparency log.
+
+Pick the tier that matches where you are in the deployment
+lifecycle.
+
+## Docker Compose — local evaluation
+
+The fastest path to a working Confium stack. Brings up a 3-of-5
+threshold deployment (3 signers hot, 2 offline for testing) on a
+single host.
+
+```sh
+git clone https://github.com/confium/confium
+cd confium/deploy/docker
+docker compose up
+```
+
+Services started:
+
+| Service | Count | Port | Role |
+| --- | --- | --- | --- |
+| `coordinator` | 1 | 7443 | JSON-RPC daemon — the entry point for consumers. |
+| `signer-N` | 3 (of 5) | 7500 | Threshold signing nodes. |
+| `transparency-log` | 1 | 7444 | Append-only Merkle log. |
+| `witness` | 1 | 7445 | Split-view detector via consistency proofs. |
+
+Verify:
+
+```sh
+curl --unix-socket /tmp/confium.sock \
+     -H 'content-type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"version","params":{}}' \
+     http://localhost/
+```
+
+## Helm chart — production Kubernetes
+
+The chart lives at `deploy/helm/confium/`. Production-grade with
+configurable replica counts, persistence, and healthchecks.
+
+```sh
+helm install confium ./deploy/helm/confium \
+     --set coordinator.replicas=2 \
+     --set signers.count=5 \
+     --set signers.threshold=3 \
+     --set transparency.persistence.size=50Gi
+```
+
+The chart exposes:
+
+- **Coordinator**: a `Deployment` with N replicas behind a
+  `Service`. Consumers talk to the service, not individual pods.
+- **Signers**: a `StatefulSet` (one pod per signer identity) with
+  persistent volumes for share storage.
+- **Transparency log**: a `StatefulSet` with a PVC for the
+  append-only log.
+- **Witness**: an optional `Deployment`.
+- **Healthchecks**: liveness + readiness probes on every service.
+- **Configmaps + secrets**: TOML config and signer identities
+  mounted from K8s secrets (never baked into the image).
+
+<AdapterPatternDiagram class="w-full max-w-2xl mx-auto my-8" />
+
+### Production checklist
+
+Before promoting a Confium deployment to production:
+
+- [ ] **Signer identities** distributed to the right operators via
+  your standard key-management infrastructure (HSM, KMS, sealed
+  secrets). Never check signer shares into git.
+- [ ] **Persistence** sized for the expected transparency-log
+  growth (the log is append-only — it only grows).
+- [ ] **Backup strategy** for the transparency-log PVC. A lost PVC
+  means a lost audit history.
+- [ ] **Witness** deployed to a different failure domain than the
+  coordinator. The witness's job is to detect split-view attacks
+  by comparing tree heads — putting it next to the coordinator
+  defeats the purpose.
+- [ ] **Monitoring** wired up (see Grafana dashboards below).
+- [ ] **Quorum policy** reviewed by the parties who must agree on
+  it. T-of-N is a governance decision, not a technical one.
+
+## Grafana dashboards
+
+Pre-built dashboards in `deploy/grafana/`. Import via the standard
+Grafana JSON import flow. Dashboards shipped:
+
+| Dashboard | Panels |
+| --- | --- |
+| **Coordinator** | Request rate, latency p50/p95/p99, active sessions, error rate by JSON-RPC method. |
+| **Signers** | Per-signer session participation, share validity, refresh cadence. |
+| **Transparency log** | Append rate, tree size, inclusion-proof latency, witness-consistency failures. |
+| **Audit** | Event stream rate, signed-event verification rate, failed verifications. |
+
+Dashboards assume Prometheus scraping the daemon's `/metrics`
+endpoint (enabled via `--metrics :9090` on `confiumd`).
+
+## Container images
+
+Pre-built images live at `ghcr.io/confium/confiumd:latest` (and
+tagged versions). The image:
+
+- Is built from the workspace's `Dockerfile` (multi-stage,
+  distroless final image).
+- Targets `linux/amd64` and `linux/arm64`.
+- Carries no signer shares — those are mounted at runtime.
+- Exposes `7443/tcp` (coordinator JSON-RPC) and `9090/tcp`
+  (Prometheus metrics).
+
+## See also
+
+- [Daemon](/software/daemon/) — the JSON-RPC API surface.
+- [Architecture](/docs/architecture/) — how the components
+  compose at runtime.
+- [`deploy/` in the repository](https://github.com/confium/confium/tree/main/deploy).

--- a/src/content/docs/transparency-logs.mdx
+++ b/src/content/docs/transparency-logs.mdx
@@ -7,6 +7,14 @@ order: 9
 
 # Transparency logs
 
+> **`confium-transparency` 0.4.0 shipped a corrected
+> `consistency_proof` + `verify_consistency` implementation per
+> RFC 6962 §2.1.3.** The 0.3.x API is incompatible — the proof
+> shape changed. If you have stored consistency proofs from 0.3.x,
+> regenerate them from the originating tree; they cannot be
+> verified by 0.4.0+. See the
+> [changelog](https://github.com/confium/confium/blob/main/CHANGELOG.md).
+
 Every signing operation in a Confium deployment can anchor into an
 append-only Merkle transparency log implementing RFC 6962 semantics.
 The log provides cryptographic inclusion proofs and consistency

--- a/src/content/software/daemon.md
+++ b/src/content/software/daemon.md
@@ -1,16 +1,112 @@
 ---
 name: Daemon
-description: "The confiumd long-running service — JSON-RPC over Unix socket or TCP for signing sessions and PKI operations."
+description: "The confiumd long-running service — JSON-RPC over Unix socket or TCP for composite verification, attribute evaluation, signing sessions, and PKI operations."
 install_command: "cargo install confium-daemon"
 weight: 5
 ---
 
-`confiumd` is the daemon binary for long-running operations:
-threshold signing session orchestration, transparency log
-interaction, PKI validation. See the
-[`confiumd` documentation](/docs/cli/daemon/).
+`confiumd` is the long-running service binary. It exposes a
+JSON-RPC 2.0 API over a Unix socket or TCP listener. Use it from
+any language to verify signatures, evaluate threshold policies,
+run signing sessions, and inspect the loaded engine.
+
+## Install + run
 
 ```sh
 cargo install confium-daemon --locked
 confiumd --listen unix:///var/run/confium.sock
+# or: confiumd --listen tcp://127.0.0.1:7443
 ```
+
+The socket is the only entry point. The CLI and bindings wrap the
+same protocol.
+
+## Methods
+
+The daemon's dispatch table is organised by interface. **Shipped**
+methods are real implementations backed by the engine; **pending**
+methods return a structured `Engine` error until the matching
+handler lands.
+
+| Method | Status | Description |
+| --- | --- | --- |
+| `version` | shipped | Returns engine + binding version. |
+| `shutdown` | shipped | Cleanly stops the daemon. |
+| `composite_verify` | shipped | Verify an Ed25519 + ECDSA-P256 composite signature against a public key + message. |
+| `attributes_evaluate` | shipped | Stateless evaluation of a threshold-policy predicate against a signer-attribute set. |
+| `audit_subscribe` | shipped | Subscribe to the audit-event stream (signed events as they happen). |
+| `plugin_load` / `plugin_unload` / `plugin_list` | shipped | Hot-load, unload, and enumerate plugins at runtime. |
+| `registry_install` / `registry_search` | shipped | Install from the static registry or search by name / interface. |
+| `rng_create` / `rng_generate` | shipped | Create an RNG instance and pull bytes. |
+| `hash_*`, `cipher_*`, `aead_*`, `kdf_*`, `kem_*`, `keyfmt_*`, `signature_*`, `keystore_*`, `tc_*` | pending | Stubs for the remaining plugin interfaces. Each gets a real handler as the interface matures. |
+
+## Example: verify a composite signature via JSON-RPC
+
+```sh
+curl --unix-socket /var/run/confium.sock \
+     -H 'content-type: application/json' \
+     -d '{
+           "jsonrpc": "2.0",
+           "id": 1,
+           "method": "composite_verify",
+           "params": {
+             "message": "aGVsbG8=",
+             "signature": "base64-encoded composite signature",
+             "public_key": "base64-encoded public key"
+           }
+         }' \
+     http://localhost/
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": { "valid": true, "components_checked": 2 }
+}
+```
+
+## Example: evaluate a threshold policy
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "attributes_evaluate",
+  "params": {
+    "predicate": "region in (EU, US) and role == 'director' and count >= 3",
+    "signers": { /* signer-attribute JSON */ }
+  }
+}
+```
+
+The handler is **stateless** — it evaluates the predicate against
+the supplied signer set without touching engine state. Safe to
+call before committing to a signing session.
+
+## Transport
+
+- **Unix socket**: default, lowest overhead. Use for local
+  co-located consumers (the PKCS#11 server, OpenSSL provider,
+  CLI).
+- **TCP**: for cross-host consumers. Wrap in TLS or use a
+  service-mesh sidecar; the daemon doesn't terminate TLS itself.
+
+## Operational hooks
+
+- `audit_subscribe` exposes a stream of signed events as they
+  happen. Pipe to SIEM, log shipper, or a witness for split-view
+  detection.
+- Plugin operations (`plugin_load` / `unload` / `list`) are
+  available at runtime — no daemon restart needed to add or
+  remove a hash / RNG / cipher backend.
+
+## See also
+
+- [Daemon CLI reference](/docs/cli/daemon/) — flags and config-file options.
+- [Architecture](/docs/architecture/) — where the daemon sits in the
+  engine + coordinator + adapter stack.
+- [Deployment](/docs/deployment/) — Docker Compose + Helm chart for
+  running `confiumd` in production.

--- a/src/content/software/python.md
+++ b/src/content/software/python.md
@@ -1,6 +1,6 @@
 ---
 name: Python
-description: Native Python extension (PyO3) wrapping the Confium engine. Composite verify, transparency log, PKI parse, attributes DSL.
+description: Native Python extension (PyO3) wrapping the Confium engine. Composite sign + verify, transparency log, PKI parse + CMS build, attributes DSL.
 install_command: "pip install confium"
 docs_repo: "github.com/confium/confium"
 docs_ref: "main"
@@ -12,11 +12,97 @@ The Python binding ships as a native wheel built with PyO3 0.22.
 Targets Python 3.9+. Source lives at `crates/confium-python/` inside
 the main Rust workspace.
 
-The binding covers **verification + parsing**: composite signature
-verification (Ed25519 + ECDSA-P256), RFC 6962 transparency log with
-inclusion proofs, X.509 Certificate + CSR parsing, CMS SignedData
-verification, and the attribute-based threshold predicate DSL.
+## What's covered
 
-For **signing** workflows (composite sign, CMS build/sign, threshold
-sessions), use the Ruby binding today — Python TC bindings land in a
-follow-up release.
+The binding covers **verification, parsing, and signing**:
+
+| Subsystem | What you can do |
+| --- | --- |
+| **Composite signatures** | `sign_ed25519`, `sign_p256`, `verify`, `verify_with` — produce and check Ed25519 + ECDSA-P256 composite signatures. |
+| **PKI** | `Certificate.from_pem` / `from_der`, `CSR.from_pem`, fingerprint + validity + serial accessors. |
+| **CMS SignedData** | `SignedData.from_json`, `build_detached`, `verify`, `verify_with_builtin` — build and verify detached CMS envelopes. |
+| **Transparency log** | `MerkleTree`, `InclusionProof`, `verify_inclusion_with_head` — RFC 6962 inclusion proofs. |
+| **Attributes DSL** | `Predicate.parse`, `SignerAttributes`, evaluation against a signer set — the threshold policy DSL the coordinator enforces. |
+| **Versioning** | `version()`, `core_version()` — binding + engine version introspection. |
+
+## Install
+
+```sh
+pip install confium
+```
+
+The wheel bundles the Rust engine, so no separate `libconfium`
+setup is required. Pre-built wheels are published for CPython 3.9+
+on Linux x86_64 / arm64, macOS x86_64 / arm64, and Windows x86_64.
+
+## Sign + verify a composite signature
+
+```python
+import confium
+
+# Sign (uses the engine's composite signer with the configured
+# threshold session — typically run against a remote coordinator
+# in production).
+sig = confium.CompositeSignature.sign_ed25519(
+    message=b"hello",
+    secret_key=ed25519_secret_key_bytes,
+)
+print(sig.signature.hex())
+
+# Verify (pure verification — safe to ship to clients).
+result = confium.CompositeSignature.verify(
+    message=b"hello",
+    signature=sig.signature,
+    public_key=ed25519_public_key_bytes,
+)
+print(result.valid)  # True
+```
+
+## Build + verify a CMS envelope
+
+```python
+from confium import pki as cfpki
+
+cert = cfpki.Certificate.from_pem(open("signer.pem").read())
+envelope = cfpki.SignedData.build_detached(
+    payload=b"document bytes",
+    certificate=cert,
+    signature=cfpki.signed_data_signature(...),
+)
+raw = envelope.to_der()  # ship this
+
+# On the verifier side:
+inbound = cfpki.SignedData.from_der(raw)
+result = inbound.verify_with_builtin(trust_roots=[root_cert])
+```
+
+## Use the attributes DSL
+
+```python
+from confium import attributes as cfa
+
+policy = cfa.Predicate.parse(
+    "region in (EU, US) and role == 'director' and count >= 3"
+)
+signers = cfa.SignerAttributes.from_json(signers_json)
+result = policy.evaluate(signers)
+print(result.satisfied)   # bool
+print(result.matched)     # which signers contributed
+```
+
+## What Python does NOT cover (yet)
+
+- **Threshold signing sessions** (the multi-round MPC over a live
+  coordinator). Use the Ruby binding or call the JSON-RPC daemon's
+  `composite_verify` / `attributes_evaluate` methods for production
+  signing today.
+- **PKCS#11 / OpenSSL / JCE adapters**. Those are Rust-side server
+  processes; Python verifies what they produce.
+
+## See also
+
+- [Architecture](/docs/architecture/) — how the engine, coordinator,
+  and transparency log fit together.
+- [Ruby binding](/software/ruby/) — covers signing + threshold sessions
+  end-to-end.
+- [`confium-python` source](https://github.com/confium/confium/tree/main/crates/confium-python).


### PR DESCRIPTION
## Summary

Syncs the website with the latest `confium` workspace state. Several pages were badly stale; two were missing entirely.

### Updated pages

| Page | What changed |
|---|---|
| **`/software/python/`** | Was "verification only, signing lands in follow-up." Reality: `sign_ed25519`, `sign_p256`, CMS `build_detached`, attributes DSL. Now has feature matrix + 4 code samples. |
| **`/software/daemon/`** | Was install-only (16 lines). Reality: 29 JSON-RPC handlers across 9 interfaces. Now has method table with shipped/pending status + example `curl` requests. |
| **`/docs/components/`** | Claimed 43 crates including 11 that no longer exist (consolidated). Now lists the actual 46 crates, with consolidation notes. |
| **`/docs/transparency-logs/`** | Added 0.4.0 breaking-change banner — the corrected `consistency_proof` per RFC 6962 §2.1.3 is incompatible with 0.3.x stored proofs. |

### New pages

| Page | What it covers |
|---|---|
| **`/docs/deployment/`** | Docker Compose (single-host eval), Helm chart (K8s prod), Grafana dashboards. Production checklist. |
| **`/docs/benchmarks/`** | The new `confium-benchmarks` criterion suite. What's benched, how to run, how to read, caveats. |

### Schema

- `content.config.ts` docs schema audience enum expanded: added `operator`, `architect`, `compliance` so the new docs validate.

### Drive-by fix

- `blog/2026-07-29-auditor-flow.mdx` had a broken link to `/software/python/docs/bindings/parity/` (a vendor-pulled doc that doesn't exist). Repointed to `/software/python/`.

## Test plan

- [x] `npx astro build` succeeds (109 pages, was 107)
- [x] `lychee --offline` 0 errors
- [x] `/software/python/` renders with sign + CMS examples
- [x] `/software/daemon/` renders with method table
- [x] `/docs/components/` lists 46 crates
- [x] `/docs/deployment/` and `/docs/benchmarks/` exist and render

## Out of scope (could follow up)

- New use-case pages enabled by the new capabilities (Python signing service, polyglot verification via JSON-RPC, Kubernetes deployment story).
- Updating `/docs/architecture/` and `/docs/getting-started/` to reference the new pages.
- Adding `/docs/cli/` coverage for new daemon flags.
