### PR TITLE
docs(use-cases): 6 new use cases — container signing, VCs, DNSSEC, banking, confidential computing, SBOM

### DIFF
--- a/src/content/use_cases/banking-signing.mdx
+++ b/src/content/use_cases/banking-signing.mdx
@@ -1,0 +1,94 @@
+---
+title: Banking and SWIFT message signing
+description: Sign SWIFT MT/MX messages and payment instructions with a threshold of officers. No single officer can authorize a payment alone. Drop-in for existing SWIFT Alliance and payment hub infrastructure.
+mode: 2
+order: 24
+---
+
+# Banking and SWIFT message signing
+
+Payment authorization in banking has always been a threshold
+problem. The "four-eyes principle" — two officers must sign
+every wire above a threshold amount — predates computers. Most
+banking IT systems implement it as a database flag: `authorized_by_user_2 = true`. That's not cryptography; it's a
+promise.
+
+Confium turns the four-eyes principle into a cryptographic
+guarantee. The payment instruction is the message. T-of-N
+officers must participate in a threshold signing session.
+**The signature cannot exist without the quorum.**
+
+## Where this fits
+
+| Message type | Threshold rule |
+| --- | --- |
+| SWIFT MT103 (customer payment) | 2 officers for amounts < $1M; 3 officers above |
+| SWIFT MX / ISO 20022 pacs.008 | Same, with role constraints (front-office + compliance + operations) |
+| Fedwire / TARGET2 instructions | 2-of-3 from the operations team |
+| Internal letter-of-credit issuance | 3-of-5 from the credit committee |
+| FX deal confirmation | 2 traders + 1 risk officer |
+
+The threshold and the role constraints live in Confium's
+attribute-based DSL:
+
+```
+amount < 1000000 and role == 'officer' and count >= 2
+or amount >= 1000000
+   and role == 'officer' and count >= 1
+   and role == 'compliance' and count >= 1
+   and role == 'operations' and count >= 1
+```
+
+## What the bank gets
+
+- **Cryptographic proof of authorization.** Every payment has
+  a composite signature proving the threshold was met.
+  Auditors, regulators, and counterparties can verify
+  independently.
+- **No single point of compromise.** A compromised officer
+  laptop cannot authorize a payment alone. The attacker needs
+  T officers' shares.
+- **Non-repudiation.** Officers cannot later deny authorizing
+  a payment — their share is in the signature.
+- **Transparency-log anchoring.** Every authorization event
+  appends to a Merkle log. Internal audit and external
+  regulators can verify the complete payment history.
+- **Standards compliance.** Composite signatures wrap classical
+  algorithms the bank's HSMs already support, plus an optional
+  ML-DSA-65 component for post-quantum readiness.
+
+## Integration: SWIFT Alliance and payment hubs
+
+Most banks run SWIFT Alliance (or an equivalent payment hub)
+on top of an HSM via PKCS#11. Confium drops in as an
+alternative PKCS#11 backend:
+
+```
+SWIFT Alliance → PKCS#11 → confium-pkcs11-server → coordinator → officers
+```
+
+No changes to the SWIFT Alliance side. The HSM's signing
+operations become threshold operations transparently.
+
+For ISO 20022 XML messages, the signature can also be wrapped
+as an XMLDSig — Confium's PKI crate covers canonicalization.
+
+## Regulatory alignment
+
+| Framework | How Confium maps |
+| --- | --- |
+| **SOX 404** (internal controls over financial reporting) | Threshold signing is the control. Audit log is the evidence. |
+| **PCI DSS** (card payment security) | Multi-party control over payment key custody. |
+| **PSD2** (EU payment services directive) | Strong customer authentication; the bank-side half of 2FA. |
+| **Basel III operational risk** | Reduced loss-given-fraud because single-officer compromise cannot move funds. |
+| **DORA** (EU digital operational resilience) | Threshold signing is a documented control for key-management resilience. |
+
+## See also
+
+- [Financial settlement use case](/use-cases/financial-settlement/)
+  — the general threshold pattern for capital-markets
+  infrastructure.
+- [PKCS#11 adapter](/docs/adapters/pkcs11/) — how Confium
+  drops in as an HSM backend.
+- [Attributes DSL concept](/concepts/attribute-based-threshold/)
+  — encoding four-eyes and quorum rules.

--- a/src/content/use_cases/confidential-computing.mdx
+++ b/src/content/use_cases/confidential-computing.mdx
@@ -1,0 +1,135 @@
+---
+title: Confidential computing attestation
+description: Sign attestation documents for confidential computing (TEE) workloads with a threshold of attestation authorities. No single hardware vendor or cloud provider can forge an attestation. Verifiable by any relying party.
+mode: 3
+order: 25
+---
+
+# Confidential computing attestation
+
+Confidential computing (Intel SGX, AMD SEV-SNP, ARM CCA,
+Azure Confidential VMs, AWS Nitro Enclaves) runs workloads
+inside hardware-protected enclaves. The hardware produces an
+**attestation document** proving the enclave ran the right
+code on genuine hardware.
+
+Today, relying parties verify attestations by trusting the
+hardware vendor's signing key directly. That creates two
+problems:
+
+1. **Single-vendor trust.** If you trust Intel's key, you
+   trust every system Intel has ever signed for — including
+   systems Intel may be compelled to attest under legal
+   process.
+2. **No multi-stakeholder governance.** A regulated workload
+   (healthcare data inside an enclave, government computation)
+   may require attestation from multiple authorities: the
+   hardware vendor, the cloud operator, and an independent
+   auditor.
+
+Confium's threshold attestation wraps the vendor's attestation
+in a composite signature that requires T-of-N authorities to
+sign off. **No single authority — including the hardware
+vendor — can forge an attestation alone.**
+
+## The pattern
+
+```
+┌──────────────────────────────────────────────┐
+│  Enclave (TEE)                               │
+│  Runs the sensitive workload.                │
+│  Produces hardware attestation document.     │
+└──────────────────────────────────────────────┘
+                    ↓
+┌──────────────────────────────────────────────┐
+│  Attestation authorities (Confium signers)   │
+│                                              │
+│  1. Hardware vendor (Intel / AMD / ARM)      │
+│  2. Cloud operator (Azure / AWS / GCP)       │
+│  3. Independent auditor (your org's crypto    │
+│     officer, or a third-party auditor)       │
+│                                              │
+│  T-of-3 must sign the attestation.           │
+└──────────────────────────────────────────────┘
+                    ↓
+┌──────────────────────────────────────────────┐
+│  Composite attestation (Confium signature)   │
+│                                              │
+│  Wrapped attestation document + threshold    │
+│  proof + transparency-log entry.             │
+└──────────────────────────────────────────────┘
+                    ↓
+                Relying party verifies.
+```
+
+## When threshold attestation applies
+
+| Workload | Why threshold |
+| --- | --- |
+| Healthcare data processing in a TEE | HIPAA: don't trust the cloud operator alone |
+| Cross-border data residency computation | Regulator in each jurisdiction signs off |
+| Government / defense computation in commercial cloud | Multiple clearance authorities |
+| Financial matching engines in enclaves | Exchange + regulator + independent observer |
+| ML model training on sensitive data | Model owner + data owner + compute provider |
+
+## What to use
+
+| Component | Role |
+| --- | --- |
+| `confium-composite` | Wrap the raw attestation in a composite signature |
+| `confium-attributes` | Encode the role constraints (vendor + operator + auditor) |
+| `confium-transparency` | Append every attestation to a Merkle log |
+| `confium-tc-coordinator` | Orchestrate the multi-authority signing session |
+| `@confium/confium-wasm` | Browser-side attestation verification for end users |
+
+## Verification flow
+
+```python
+from confium import composite, transparency
+
+# Relying party receives a composite attestation
+attestation = composite.CompositeSignature.from_json(payload)
+
+# Verify the composite signature against the published
+# multi-authority public key
+result = attestation.verify(
+    message=raw_attestation_document,
+    public_key=multi_authority_pubkey,  # published by the consortium
+)
+assert result.valid
+
+# Verify the threshold was met (3-of-3 in this example)
+assert result.signers == {"vendor", "operator", "auditor"}
+
+# Verify the attestation is in the transparency log
+transparency.verify_inclusion_with_head(
+    leaf_hash=sha256(payload),
+    proof=inclusion_proof,
+    root=published_root,
+)
+```
+
+The relying party has now verified:
+1. The attestation is cryptographically genuine.
+2. All three authorities participated.
+3. The attestation is publicly logged.
+
+## Why this matters
+
+Confidential computing promises "your data is safe even from
+the cloud operator." But the trust model still has a single
+point — the attestation signing key. Threshold attestation
+removes that single point by requiring multiple authorities to
+agree. The hardware still attests to the enclave's integrity;
+the threshold layer attests to the *governance* around the
+hardware.
+
+## See also
+
+- [Composite signatures concept](/concepts/composite-signatures/)
+  — how a composite signature wraps multiple algorithms and
+  signers.
+- [IoT attestation use case](/use-cases/iot-attestation/) —
+  the analogous pattern for constrained devices.
+- [Government identity use case](/use-cases/government-identity/)
+  — multi-authority signing for sovereign workloads.

--- a/src/content/use_cases/container-image-signing.mdx
+++ b/src/content/use_cases/container-image-signing.mdx
@@ -1,0 +1,106 @@
+---
+title: Container image signing
+description: Sign container images with a threshold of maintainers. No single maintainer can push a malicious image. Compatible with OCI signatures, cosign verification, and Sigstore's certificate model.
+mode: 2
+order: 21
+---
+
+# Container image signing
+
+Container image signing today usually means one of two things:
+
+1. **Single-maintainer PGP / cosign key** — whoever holds the
+   key can sign anything. Compromise the key, ship malware.
+2. **Keyless Sigstore with OIDC** — the signer's identity is
+   bound to an ephemeral key. Better, but each signing event
+   is still single-party.
+
+For images that many people rely on (base images, language
+runtimes, critical infrastructure), neither is enough. A
+release should require multiple maintainers to agree. That's
+threshold signing.
+
+## The pattern
+
+```
+┌─────────────────────────────────────────────┐
+│  Release pipeline                           │
+│                                             │
+│  1. Build image                             │
+│  2. Compute digest                         │
+│  3. Send digest to Confium coordinator      │
+│     ↓                                       │
+│  4. T-of-N maintainers sign the digest      │
+│     (via their own signers, on their own    │
+│      hardware)                              │
+│  5. Coordinator assembles composite sig     │
+│  6. Attach signature to image (cosign,      │
+│     OCI ref, or transparency log)           │
+└─────────────────────────────────────────────┘
+```
+
+The signature is a Confium composite signature (Ed25519 +
+ECDSA-P256, optionally + ML-DSA-65 for post-quantum readiness).
+The verification side can be:
+
+- **Native Confium verifier** (Python, Ruby, WASM) for apps
+  that want full composite verification.
+- **A cosign-compatible wrapper** that extracts the classical
+  component for cosign's verification path.
+- **A transparency-log entry** so every signing event is
+  publicly auditable.
+
+## Why threshold for container signing
+
+- **Insider threat.** A single rogue maintainer — or a single
+  compromised laptop — cannot ship a malicious image. T-of-N
+  must agree.
+- **Compliance.** Regulated environments (FedRAMP, FIPS 140)
+  increasingly require multi-party control over release keys.
+  Threshold signing is the operational answer.
+- **Post-quantum migration.** Composite signatures add an
+  ML-DSA-65 component alongside the classical one. Verifiers
+  that haven't upgraded still accept the classical component;
+  verifiers that have already migrated. No flag day.
+
+## What to use
+
+| Need | Use |
+| --- | --- |
+| The signing orchestrator | `confium-tc-coordinator` (Rust) or the JSON-RPC daemon |
+| Maintainer signers | `confium` Ruby gem or Python binding on each maintainer's workstation |
+| Image-side verification | `@confium/confium-wasm` in a cosign policy controller, or the Python binding in an admission webhook |
+| Audit / transparency | `confium-transparency` — every signing event appended to a Merkle tree |
+
+## Example: cosign-compatible threshold signing
+
+```python
+# In the release pipeline
+import confium
+from cosign import compute_digest
+
+digest = compute_digest("registry.example.com/app:v1.2.3")
+
+# Threshold signing via the coordinator
+sig = confium.CompositeSignature.sign_ed25519(
+    message=digest,
+    secret_key=maintainer_share,  # this maintainer's share
+)
+
+# Send to coordinator, which combines T shares into the final
+# composite signature. Coordinator returns the assembled envelope.
+final_sig = coordinator.combine(sig)
+```
+
+The final signature attaches to the image as an OCI ref or via
+cosign's signature storage.
+
+## See also
+
+- [Code signing use case](/use-cases/code-signing/) — the
+  general threshold code-signing pattern (not container-
+  specific).
+- [Supply-chain provenance](/use-cases/supply-chain/) —
+  attestation chaining via the transparency log.
+- [PKCS#11 adapter](/docs/adapters/pkcs11/) — for HSM-backed
+  maintainer shares.

--- a/src/content/use_cases/dnssec-signing.mdx
+++ b/src/content/use_cases/dnssec-signing.mdx
@@ -1,0 +1,113 @@
+---
+title: DNSSEC threshold signing
+description: Sign DNS zone updates with a threshold of operators. No single operator can hijack a zone. Drop-in for existing DNSSEC validators via the PKCS#11 adapter.
+mode: 2
+order: 23
+---
+
+# DNSSEC threshold signing
+
+DNSSEC signs DNS records so resolvers can verify they haven't
+been tampered with. The zone-signing key (ZSK) and key-signing
+key (KSK) are typically held by a single DNS operator. Compromise
+the operator, forge any record in the zone.
+
+For critical zones (TLDs, enterprise root zones, infrastructure
+domains), single-operator trust is a structural weakness.
+**Threshold DNSSEC signing** spreads the KSK across N operators;
+T-of-N must participate to sign a keyset.
+
+## The pattern
+
+```
+┌─────────────────────────────────────────────┐
+│  Zone signing pipeline                      │
+│                                             │
+│  Existing DNS server (BIND, Knot, PowerDNS) │
+│     ↓ (PKCS#11 calls)                       │
+│  Confium PKCS#11 adapter                    │
+│     ↓                                       │
+│  Confium coordinator (T-of-N threshold)     │
+│     ↓                                       │
+│  N operator signers (each holds a share)    │
+└─────────────────────────────────────────────┘
+```
+
+The DNS server speaks PKCS#11 — it doesn't know the signing
+key is threshold-protected. Confium's PKCS#11 adapter
+intercepts the signing call, dispatches it to the coordinator,
+which orchestrates the threshold protocol across N operator
+signers.
+
+## Why threshold for DNSSEC
+
+- **TLD security.** A country-code TLD is critical national
+  infrastructure. Threshold signing means a single compromised
+  registrar cannot redirect the entire ccTLD.
+- **Multi-stakeholder zones.** Infrastructure zones
+  (root-servers.net, in-addr.arpa) are operated by
+  consortia. Threshold signing encodes the consortium
+  governance into the key.
+- **Emergency key rollover.** If one operator's share is
+  compromised, the remaining T-1 operators can re-share
+  without freezing the zone.
+- **Audit trail.** Every signing event lands in a
+  transparency log. The zone's history is publicly
+  verifiable.
+
+## What to use
+
+| Component | Role |
+| --- | --- |
+| DNS server | Your existing BIND, Knot, PowerDNS, NSD — unchanged |
+| `confium-pkcs11-server` | The adapter that intercepts PKCS#11 calls |
+| `confium-tc-coordinator` | Orchestrates the T-of-N signing sessions |
+| Operator signers | One per operator, on operator-controlled hardware (HSM, OpenPGP card, TPM) |
+| `confium-transparency` | Optional but recommended — append every signing event to a Merkle log |
+
+## Configuration sketch
+
+```toml
+# /etc/confium/pkcs11.toml — on the DNS server
+[server]
+socket_path = "/var/run/confium/pkcs11.sock"
+coordinator = "tcp://coordinator.dnsops.internal:7443"
+
+[slot.0]
+token_label = "zone-signing"
+signer_id = "zsk-1"
+pin_env = "DNS_ZSK_PIN"
+
+[slot.1]
+token_label = "key-signing"
+signer_id = "ksk-1"
+pin_env = "DNS_KSK_PIN"
+```
+
+```toml
+# /etc/confium/coordinator.toml — on the coordinator
+[quorum]
+threshold = 3
+total = 5
+policy = "role == 'dns_operator' and count >= 3"
+
+[[signers]]
+id = "operator-1"
+endpoint = "tls://signer-1.dnsops.internal:7500"
+role = "dns_operator"
+
+# ... 4 more signers
+```
+
+The DNS server loads `confium-pkcs11.so` via its standard
+PKCS#11 mechanism. Everything else is transparent.
+
+## See also
+
+- [PKCS#11 adapter](/docs/adapters/pkcs11/) — how the adapter
+  exposes Confium as a virtual HSM.
+- [Mode 2 — PKI Drop-in](/docs/mode2-pki-drop-in/) — the
+  general "drop Confium in front of existing PKCS#11
+  consumers" pattern.
+- [Web TLS use case](/use-cases/web-tls/) — the analogous
+  threshold pattern for TLS certificate signing.

--- a/src/content/use_cases/sbom-signing.mdx
+++ b/src/content/use_cases/sbom-signing.mdx
@@ -1,0 +1,145 @@
+---
+title: Software Bill of Materials (SBOM) signing
+description: Sign SBOMs with a threshold of build-system components. No single build agent or CI runner can forge an SBOM. Verifiable by anyone in the software supply chain. Drop-in for existing CycloneDX and SPDX tooling.
+mode: 2
+order: 26
+---
+
+# Software Bill of Materials signing
+
+An SBOM (CycloneDX, SPDX, SWID) lists every component in a
+software artifact — direct and transitive dependencies, their
+versions, their licenses, their known vulnerabilities. The
+SBOM is how downstream consumers know what they're running.
+
+Today, SBOMs are typically produced by the build system and
+shipped unsigned or signed by a single CI key. That's a
+problem: if the CI key is compromised, an attacker can ship a
+malicious build with a "valid" SBOM claiming it has no known
+vulnerabilities.
+
+**Threshold SBOM signing** ties the SBOM's signature to
+multiple independent observations of the build:
+
+- The build orchestrator (CI runner)
+- The dependency resolver (lockfile / manifest tool)
+- The vulnerability scanner (Trivy, Grype, OSV)
+- The release engineer (a human or gated automation)
+
+T-of-N must sign the SBOM. No single compromised component
+can forge one.
+
+## The pattern
+
+```
+┌────────────────────────────────────────────┐
+│  Build pipeline                            │
+│                                            │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐ │
+│  │ CI       │  │ Dep      │  │ Vuln     │ │
+│  │ runner   │  │ resolver │  │ scanner  │ │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘ │
+│       │              │              │      │
+│       └──────────────┼──────────────┘      │
+│                      ↓                     │
+│         ┌────────────────────────┐         │
+│         │ Confium coordinator    │         │
+│         │ T-of-N threshold       │         │
+│         └───────────┬────────────┘         │
+│                     ↓                      │
+│         ┌────────────────────────┐         │
+│         │ Composite signature    │         │
+│         │ on the SBOM document   │         │
+│         └────────────────────────┘         │
+└────────────────────────────────────────────┘
+                  ↓
+        Verifier (downstream consumer,
+        security team, regulator) checks
+        the composite signature against
+        the project's published key.
+```
+
+Each signer observes a different facet of the build:
+
+- **CI runner**: "this is the actual artifact that came out
+  of the pipeline"
+- **Dependency resolver**: "these are the actual resolved
+  versions from the lockfile"
+- **Vulnerability scanner**: "as of the scan, here's the
+  known-vuln status"
+- **Release engineer**: "a human (or gated automation)
+  authorized this release"
+
+The composite signature proves all of them agreed.
+
+## What you get
+
+- **Tamper-evident SBOM.** Any change to the SBOM document
+  after signing is detectable.
+- **Multi-observation proof.** A consumer can verify the SBOM
+  reflects what the build system actually saw — not just what
+  one component claims.
+- **Audit trail.** Every SBOM signing event lands in a
+  transparency log. Consumers can prove an SBOM existed at a
+  specific time (OpenTimestamps anchor in Bitcoin optional).
+- **Compliance.** Executive Order 14028 (US federal supply
+  chain security) and the EU Cyber Resilience Act both
+  require SBOMs for critical software. Threshold signing
+  gives regulators evidence the SBOM is trustworthy, not
+  just present.
+
+## What to use
+
+| Component | Role |
+| --- | --- |
+| `confium-tc-coordinator` | Orchestrates the multi-component signing |
+| `confium-composite` | The composite signature type that wraps each component's signature |
+| `confium-transparency` | Anchors each SBOM in a Merkle log |
+| Python / Ruby / WASM verifier | Consumer-side SBOM verification |
+
+## Example: CycloneDX + Confium
+
+```python
+import json
+import confium
+
+# Build system produces a CycloneDX SBOM
+sbom = json.dumps({
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "components": [...],
+})
+
+# Each signer signs the SBOM independently
+ci_sig = confium.CompositeSignature.sign_ed25519(
+    message=sbom.encode(),
+    secret_key=ci_runner_share,
+)
+dep_sig = confium.CompositeSignature.sign_p256(
+    message=sbom.encode(),
+    secret_key=dep_resolver_share,
+)
+vuln_sig = confium.CompositeSignature.sign_ed25519(
+    message=sbom.encode(),
+    secret_key=vuln_scanner_share,
+)
+
+# Coordinator assembles the composite signature
+final = coordinator.assemble([ci_sig, dep_sig, vuln_sig])
+
+# Attach to the artifact
+artifact.attach_sbom(sbom, signature=final.to_der())
+```
+
+Consumers verify with the project's published multi-component
+public key.
+
+## See also
+
+- [Container image signing](/use-cases/container-image-signing/)
+  — the natural companion: sign the image, then sign its
+  SBOM.
+- [Supply-chain provenance](/use-cases/supply-chain/) —
+  attestation chaining via the transparency log.
+- [Code signing](/use-cases/code-signing/) — the general
+  threshold code-signing pattern.

--- a/src/content/use_cases/verifiable-credentials.mdx
+++ b/src/content/use_cases/verifiable-credentials.mdx
@@ -1,0 +1,103 @@
+---
+title: Verifiable credentials issuance
+description: Issue W3C Verifiable Credentials with a threshold of issuers. No single issuer can mint a credential alone. Compatible with DID resolution, LD-Proofs, and JWT-VC formats.
+mode: 3
+order: 22
+---
+
+# Verifiable credentials issuance
+
+The W3C Verifiable Credentials Data Model lets any issuer sign
+a claim about a subject. Most VC issuers today use a single
+signing key — compromise the key, forge any credential.
+
+For high-assurance credentials (university degrees, professional
+licenses, government IDs), a single issuer is a single point of
+failure. **Threshold issuance** spreads the signing authority
+across N parties; T-of-N must agree to issue.
+
+## When threshold VC issuance applies
+
+| Credential | Why threshold |
+| --- | --- |
+| University degree | Registrar + department head + dean must all agree |
+| Professional license (medical, legal, engineering) | Licensing board quorum required |
+| Government-issued ID | Multi-office approval workflow |
+| Corporate appointment letter | HR + legal + executive signoff |
+| Audit certification | Lead auditor + partner + independence reviewer |
+
+The threshold isn't a technical decision — it's the
+**governance rule** the institution already follows. Confium's
+attribute-based threshold DSL encodes it directly:
+
+```
+role == 'registrar' and count >= 1
+and role == 'department_head' and count >= 1
+and role == 'dean' and count >= 1
+```
+
+## What the issued credential looks like
+
+A Confium-issued VC is a standard W3C Verifiable Credential
+with a composite signature proof:
+
+```json
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "did:web:university.example.edu",
+  "issuanceDate": "2026-07-31T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:alice.example.com",
+    "degree": { "type": "BachelorDegree", "name": "B.S. Computer Science" }
+  },
+  "proof": {
+    "type": "ConfiumCompositeSignature2026",
+    "created": "2026-07-31T00:00:00Z",
+    "verificationMethod": "did:web:university.example.edu#confium-key",
+    "proofValue": "base64-encoded composite signature",
+    "threshold": { "of": 3, "parties": ["registrar", "department_head", "dean"] }
+  }
+}
+```
+
+The `proof.threshold` block is the audit trail — anyone
+verifying the credential can see who participated.
+
+## Verification
+
+Verifiers use the standard Confium verifier (WASM in the
+browser, Python / Ruby server-side) to check the composite
+signature. The DID resolver fetches the issuer's public key
+from `did:web:university.example.edu` and the verifier checks
+the composite signature against it.
+
+No new DID method required — `did:web`, `did:key`, `did:ion`
+all work. The Confium composite signature is just another
+proof type.
+
+## Anchoring in a transparency log
+
+Every credential issuance appends to a Confium Merkle
+transparency log:
+
+- The subject can prove their credential was issued (inclusion
+  proof).
+- The issuer can prove they didn't silently issue additional
+  credentials (consistency proof).
+- Third-party watchdogs can mirror the log and detect split-view
+  attacks.
+
+For regulated credentials (medical licenses, government IDs),
+this is the difference between "we promise we issued N
+credentials" and "here's the cryptographic proof."
+
+## See also
+
+- [Sovereign PKI](/use-cases/sovereign-pki/) — institutional
+  PKI with custom certificate formats. VC issuance is one
+  shape of Sovereign PKI.
+- [Academic credentials use case](/use-cases/academic-credentials/)
+  — the higher-ed application in detail.
+- [Attributes DSL concept](/concepts/attribute-based-threshold/)
+  — encoding governance rules as predicates.


### PR DESCRIPTION
## Summary

Six new use case pages, each targeting an audience segment the site didn't address before. The site now covers 26 use cases spanning threshold signing, transparency logs, post-quantum migration, and now: container signing, verifiable credentials, DNSSEC, banking/SWIFT, confidential computing, and SBOM signing.

### What's new

| Use case | New audience | What it covers |
|---|---|---|
| **`/use-cases/container-image-signing/`** | DevOps / platform engineering | Threshold signing for OCI images. Targets teams using single-key cosign or keyless Sigstore who need multi-maintainer control. Release-pipeline diagram + cosign-compatible example. |
| **`/use-cases/verifiable-credentials/`** | SSI / digital identity ecosystem | Threshold issuance of W3C VCs. Targets universities, licensing boards, governments. Issued-VC JSON with `proof.threshold` audit block + transparency-log anchoring. |
| **`/use-cases/dnssec-signing/`** | DNS operators / registrars | Threshold KSK/ZSK signing via the PKCS#11 adapter. Targets TLD operators, enterprise DNS, critical-infrastructure zones. DNS server unchanged. |
| **`/use-cases/banking-signing/`** | Fintech / SWIFT member banks | Cryptographic four-eyes principle for SWIFT MT/MX, Fedwire, TARGET2, FX confirmations. Maps to SOX, PCI DSS, PSD2, Basel III, DORA. |
| **`/use-cases/confidential-computing/`** | Cloud security / regulated workloads | Threshold attestation for SGX / SEV-SNP / CCA / Nitro. Composite attestation requires hardware vendor + cloud operator + independent auditor. |
| **`/use-cases/sbom-signing/`** | Software supply chain / compliance | Threshold SBOM signing tying CI + dep resolver + vuln scanner + release engineer to a composite signature. For CycloneDX/SPDX, federal EO 14028 + EU CRA compliance. |

### Design notes

- Each page opens with the **status quo** (the broken thing today) before introducing Confium. Reader recognizes their problem first.
- Each has a **diagram or table** showing the deployment shape. ASCII diagrams are inline so they survive Markdown rendering.
- Each names the **standards / regulatory frameworks** it maps to. Compliance teams need this mapping to justify adoption.
- Each cross-links to the **concepts and docs** the reader would need next. No dead ends.

## Test plan

- [x] `npx astro build` — 121 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] All 6 new pages render
- [x] No new broken links
