### PR TITLE
perf+a11y: Lighthouse fixes — performance 88→91, accessibility 91→96 (item 1)

### DIFF
--- a/src/components/vue/QuorumPlayground.vue
+++ b/src/components/vue/QuorumPlayground.vue
@@ -127,11 +127,11 @@ const partyClass = (signed: boolean) =>
           'w-11 h-11 rounded-full font-mono text-sm border transition-all',
           partyClass(p.signed),
         ]"
-        :title="`Party ${p.id + 1}${p.signed ? ' (signed)' : ''}`"
         :aria-pressed="p.signed"
+        :aria-label="`Party ${p.id + 1}${p.signed ? ' (signed)' : ''}`"
         @click="setParticipating(p.signed ? p.id : p.id + 1)"
       >
-        {{ p.id + 1 }}
+        <span aria-hidden="true">{{ p.id + 1 }}</span>
       </button>
     </div>
 

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -114,6 +114,7 @@ onUnmounted(() => {
             type="button"
             class="icon-btn md:hidden p-2 rounded-full transition-colors"
             :aria-expanded="isMobileOpen"
+            aria-label="Open menu"
             @click="isMobileOpen = !isMobileOpen"
           >
             <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import '../styles/global.css';
 import '@fontsource/ibm-plex-sans/400.css';
-import '@fontsource/ibm-plex-sans/500.css';
 import '@fontsource/ibm-plex-sans/600.css';
 import '@fontsource/ibm-plex-sans/700.css';
 import '@fontsource/ibm-plex-mono/400.css';


### PR DESCRIPTION
## Summary

Item 1: Lighthouse audit + targeted fixes.

### Before → After

| Category | Before | After |
|---|---|---|
| Performance | 88 | **91** |
| Accessibility | 91 | **96** |
| Best Practices | 100 | 100 |
| SEO | 100 | 100 |
| LCP | 3.2s | **2.9s** |
| FCP | 2.9s | **2.7s** |
| CLS | 0 | 0 |
| TBT | 0ms | 0ms |

### What changed

**Accessibility** — fixed the two failing audits:
- SiteHeader mobile-menu button: added `aria-label="Open menu"` (was icon-only, no accessible name).
- QuorumPlayground party buttons: replaced `title` with `aria-label` and marked visible text `aria-hidden`. Fixes label-content-name-mismatch (visible "1" didn't match accessible name "Party 1").

**Performance** — dropped one font weight:
- Removed `@fontsource/ibm-plex-sans/500` import. The 600 weight covers every place 500 was used. One less render-blocking font file.

## Test plan

- [x] `npx astro build` — 127 pages, no errors
- [x] Lighthouse scores: perf 91, a11y 96, best-practices 100, seo 100
