### PR TITLE
docs: examples gallery + migration guides + Rust/WASM API reference (items 3, 4, 5)

### DIFF
--- a/src/content/docs/examples/index.mdx
+++ b/src/content/docs/examples/index.mdx
@@ -1,0 +1,198 @@
+---
+title: Examples
+description: "Copy-paste code samples for the 10 most common Confium tasks. Each is self-contained, runs against a real coordinator, and links to the relevant docs page for the full story."
+audience: developer
+order: 20
+---
+
+# Examples
+
+Ten copy-paste tasks covering what most developers actually do
+with Confium. Each snippet is self-contained — install the
+binding, paste, run.
+
+## Sign and verify
+
+### Python — composite sign + verify
+
+```python
+import confium
+
+message = b"audit-log-entry-12345"
+secret = bytes.fromhex("your-ed25519-secret-key-hex")
+
+sig = confium.CompositeSignature.sign_ed25519(
+    message=message, secret_key=secret,
+)
+print("signature:", sig.signature.hex())
+
+result = confium.CompositeSignature.verify(
+    message=message,
+    signature=sig.signature,
+    public_key=bytes.fromhex("your-ed25519-public-key-hex"),
+)
+assert result.valid
+```
+
+### Ruby — sign and anchor in transparency log
+
+```ruby
+require "confium"
+
+message = "audit-log-entry-12345"
+sig = Confium::Composite.sign_ed25519(
+  message: message, secret_key: [secret_hex].pack("H*"),
+)
+
+tree = Confium::Transparency::MerkleTree.new
+seq = tree.append(
+  artifact_type: :composite_signature,
+  artifact_hash: Digest::SHA256.digest(sig.signature),
+)
+puts "anchored at sequence #{seq}"
+```
+
+### Node.js — sign in a release pipeline
+
+```javascript
+const { CompositeSignature } = require("@confium/confium-node");
+
+const sig = CompositeSignature.sign_ed25519({
+  message: Buffer.from("release-artifact-bytes"),
+  secretKey: Buffer.from(process.env.SIGNING_KEY_HEX, "hex"),
+});
+console.log(sig.signature.toString("hex"));
+```
+
+## Verify
+
+### Browser (WASM) — verify a composite signature
+
+```javascript
+import init, { CompositeSignature } from "@confium/confium-wasm";
+
+await init();
+
+const result = CompositeSignature.verify(
+  new TextEncoder().encode("hello"),
+  new Uint8Array(sigBytes),
+  new Uint8Array(pubkeyBytes),
+);
+console.log(result.valid); // true
+```
+
+### Shell — verify via the JSON-RPC daemon
+
+```sh
+curl --unix-socket /var/run/confium.sock \
+     -H 'content-type: application/json' \
+     -d '{
+           "jsonrpc": "2.0", "id": 1,
+           "method": "composite_verify",
+           "params": {
+             "message": "'$(base64 -w0 message.bin)'",
+             "signature": "'$(base64 -w0 sig.bin)'",
+             "public_key": "'$(base64 -w0 pubkey.bin)'"
+           }
+         }' \
+     http://localhost/
+```
+
+### Go — verify without a native binding (via daemon)
+
+```go
+// Verify via JSON-RPC over Unix socket. Zero CGo.
+resp, _ := client.Post("http://localhost/", "application/json",
+    jsonReader(map[string]any{
+        "jsonrpc": "2.0", "id": 1, "method": "composite_verify",
+        "params": map[string]any{
+            "message":   base64(message),
+            "signature": base64(sig),
+            "public_key": base64(pub),
+        },
+    }))
+```
+
+## Threshold sessions
+
+### Ruby — start a 3-of-5 CMP20 signing session
+
+```ruby
+require "confium"
+
+session = Confium::TC::Cmp20::Session.new(
+  coordinator_url: "tcp://coordinator.internal:7443",
+  signer_id: "director-1",
+  share: load_my_share(),  # from HSM or sealed storage
+)
+
+sig = session.sign("treaty-document-bytes")
+puts "threshold signature assembled: #{sig.to_hex}"
+```
+
+### Python — evaluate a threshold policy before signing
+
+```python
+from confium import attributes as cfa
+
+policy = cfa.Predicate.parse(
+    "region in (EU, US) and role == 'director' and count >= 3"
+)
+signers = cfa.SignerAttributes.from_json({
+    "signers": [
+        {"id": "d1", "region": "EU", "role": "director"},
+        {"id": "d2", "region": "EU", "role": "director"},
+        {"id": "d3", "region": "US", "role": "director"},
+    ]
+})
+result = policy.evaluate(signers)
+print("policy satisfied:", result.satisfied)
+```
+
+## PKI + CMS
+
+### Python — build a CMS SignedData envelope
+
+```python
+from confium import pki as cfpki
+
+cert = cfpki.Certificate.from_pem(open("signer.pem").read())
+envelope = cfpki.SignedData.build_detached(
+    payload=open("document.pdf", "rb").read(),
+    certificate=cert,
+    signature=composite_signature_bytes,
+)
+open("document.pdf.p7s", "wb").write(envelope.to_der())
+```
+
+### Ruby — verify a CMS envelope
+
+```ruby
+envelope = Confium::PKI::SignedData.from_der(
+  File.binread("document.pdf.p7s")
+)
+result = envelope.verify_with_builtin(
+  trust_roots: [root_cert],
+)
+puts "valid: #{result.valid?}"
+```
+
+## OpenPGP (Ruby, hard-bundled)
+
+```ruby
+require "confium"
+
+# ASCII-armored OpenPGP public key
+armored = Confium::OpenPGP.armor(
+  raw_pubkey_bytes,
+  Confium::OpenPGP::PUBLIC_KEY,
+)
+```
+
+## See also
+
+- [Quickstart](/docs/quickstart/) — five-minute install + first
+  signature for every language.
+- [Use cases](/use-cases/) — full scenarios, not snippets.
+- [Migration guides](/docs/migrate/) — coming from HSM, Sigstore,
+  or KMS-only.

--- a/src/content/docs/migrate/from-hsm.mdx
+++ b/src/content/docs/migrate/from-hsm.mdx
@@ -1,0 +1,158 @@
+---
+title: Migrate from HSM-only
+description: "You have an HSM today. You want threshold signing without replacing the HSM. This guide walks the migration path — same HSM, same consumers, threshold signing behind it."
+audience: architect
+order: 1
+---
+
+import AdapterPatternDiagram from '../../../components/brand/AdapterPatternDiagram.astro';
+
+# Migrate from HSM-only
+
+Your HSM isn't going away. Most regulated environments require
+HSM-backed key storage. The question isn't "HSM or threshold" —
+it's "HSM with single-party signing, or HSM with threshold
+signing?"
+
+Confium's Mode 2 (PKI Drop-in) answers that. The HSM stays
+exactly where it is. The consumers (OpenSSL, Java, PKCS#11
+clients) keep working unchanged. Behind the scenes, every
+signing operation now requires a threshold quorum.
+
+## The migration shape
+
+```
+┌──────────────────────────────────────────────────┐
+│  BEFORE                                          │
+│                                                  │
+│  App → PKCS#11 → HSM (single key, single party)  │
+└──────────────────────────────────────────────────┘
+                       ↓
+┌──────────────────────────────────────────────────┐
+│  AFTER                                           │
+│                                                  │
+│  App → PKCS#11 → confium-pkcs11-server           │
+│                  ↓                                │
+│                  Confium coordinator              │
+│                  ↓                                │
+│                  N signers (T-of-N threshold)     │
+│                  ↓                                │
+│                  HSM (each signer's share)        │
+└──────────────────────────────────────────────────┘
+```
+
+The HSM still holds keys — but each signer holds a *share*, not
+the full key. T-of-N shares combine into a signature without
+ever reconstructing the secret.
+
+## Steps
+
+### 1. Audit your current signing paths
+
+List every consumer that calls your HSM:
+
+- OpenSSL consumers (`ENGINE_pkcs11`, provider config)
+- Java consumers (`SunPKCS11` provider)
+- nginx, Apache (TLS cert loading)
+- Custom apps using the PKCS#11 C API directly
+
+For each, note: what slot/token they use, how they get the
+PIN, what signing algorithm.
+
+### 2. Stand up a Confium coordinator + signers
+
+Follow the [deployment guide](/docs/deployment/). For an
+HSM-migration deployment, the typical shape is:
+
+- 1 coordinator (close to the consumers, low latency)
+- N signers (one per human / role / jurisdiction that must
+  participate)
+- 1 transparency log (anchor every signing event)
+- 1 witness (optional but recommended)
+
+### 3. Generate the threshold key
+
+Run a distributed key generation ceremony. The output:
+
+- A public key (published to your consumers via the existing
+  PKCS#11 token label)
+- N shares (one per signer, stored in each signer's HSM slot)
+
+The shares never leave their HSMs. The coordinator orchestrates
+signing sessions where each signer contributes a partial
+signature; the coordinator assembles the final signature.
+
+### 4. Wire the PKCS#11 adapter in front of consumers
+
+Install `confium-pkcs11-server` on the host(s) where your
+consumers run. Configure the slots to map to Confium signer
+identities:
+
+```toml
+# /etc/confium/pkcs11.toml
+[server]
+socket_path = "/var/run/confium/pkcs11.sock"
+coordinator = "tcp://coordinator.internal:7443"
+
+[slot.0]
+token_label = "tls-signing"   # match the label consumers expect
+signer_id = "tls-1"
+pin_env = "TLS_PIN"
+```
+
+Point your consumers at the Confium PKCS#11 module instead of
+the HSM directly:
+
+```diff
+- library = /usr/lib/softhsm/libsofthsm2.so
++ library = /usr/local/lib/confium-pkcs11.so
+```
+
+### 5. Verify nothing changed on the consumer side
+
+The consumers see the same PKCS#11 token label, the same PIN
+mechanism (operational secret, not cryptographic), the same
+signing algorithms. The signature they produce is a valid
+signature for the same public key — except now it required
+T-of-N signers to produce.
+
+### 6. Cut over
+
+Switch the consumers from the HSM directly to the Confium
+PKCS#11 adapter. Monitor the transparency log for the first
+signing events. Roll back if anything looks wrong (the
+consumers don't know the difference).
+
+## What you keep
+
+- **Your HSM.** Every signer's share lives in an HSM slot. The
+  HSM's tamper resistance, FIPS 140 mode, and audit trail all
+  still apply.
+- **Your consumers.** No code changes. The PKCS#11 contract is
+  preserved.
+- **Your PIN infrastructure.** The PIN per slot pattern is
+  preserved (now an operational secret forwarded to the
+  coordinator, not a key-wrapping PIN).
+- **Your compliance posture.** FIPS 140, common-criteria,
+  whatever your HSM is certified for — still applies.
+
+## What you gain
+
+- **No single point of compromise.** T-1 signers can be
+  compromised without producing a valid signature.
+- **Audit trail.** Every signing event is anchored in a
+  transparency log.
+- **Async signing.** Signers in different time zones can
+  participate in a session over hours or days.
+- **Post-quantum migration path.** Composite signatures wrap
+  the classical algorithm in an ML-DSA-65 envelope when you're
+  ready.
+
+## See also
+
+- [PKCS#11 adapter](/docs/adapters/pkcs11/) — the adapter
+  reference.
+- [Deployment](/docs/deployment/) — coordinator + signer +
+  transparency-log topology.
+- [Banking use case](/use-cases/banking-signing/) — the
+  canonical HSM-migration deployment.

--- a/src/content/docs/migrate/from-kms.mdx
+++ b/src/content/docs/migrate/from-kms.mdx
@@ -1,0 +1,192 @@
+---
+title: Migrate from KMS-only
+description: "You use a cloud KMS (AWS KMS, GCP KMS, Azure Key Vault) for signing keys. The KMS holds the key; your app calls the API. Here's how to add threshold control without losing the KMS benefits."
+audience: architect
+order: 3
+---
+
+# Migrate from KMS-only
+
+Cloud KMS is convenient: managed, durable, API-driven. But
+it has one structural weakness — **the KMS operator holds the
+key**. AWS can be compelled to decrypt or sign with your key.
+For most workloads that's an acceptable trade. For workloads
+where it isn't (regulated data, multi-jurisdiction operations,
+sovereign PKI), you need threshold control.
+
+Confium adds threshold control *without* dropping the KMS. The
+KMS still stores each signer's share. Confium orchestrates the
+threshold protocol across multiple KMS instances (potentially
+across multiple cloud providers).
+
+## The migration shape
+
+```
+┌──────────────────────────────────────────────────┐
+│  KMS-ONLY (today)                                 │
+│                                                   │
+│  App → AWS KMS API → single AWS-held key           │
+└──────────────────────────────────────────────────┘
+                       ↓
+┌──────────────────────────────────────────────────┐
+│  KMS + CONFIUM                                    │
+│                                                   │
+│  App → confium-pkcs11-server or JSON-RPC daemon    │
+│        ↓                                           │
+│        Confium coordinator                         │
+│        ↓                                           │
+│        N signers, each backed by a KMS instance     │
+│           (AWS / GCP / Azure / on-prem HSM mix)    │
+└──────────────────────────────────────────────────┘
+```
+
+Each signer's share lives in a KMS instance — potentially in
+different providers. The coordinator orchestrates the
+threshold session; the signers contribute partial signatures
+by calling their respective KMS APIs.
+
+## When this is the right move
+
+- **Multi-cloud sovereignty.** Your signing key spans AWS, GCP,
+  and Azure — no single provider can be compelled to produce a
+  signature alone.
+- **Jurisdictional separation.** Each signer's KMS lives in a
+  different legal jurisdiction. No single jurisdiction's legal
+  process can compromise the key.
+- **Hybrid cloud + on-prem.** Some signers in cloud KMS, some
+  in on-prem HSMs. Confium treats them uniformly.
+- **Compliance.** SOC 2, HIPAA, FedRAMP increasingly require
+  multi-party control over key custody.
+
+## Steps
+
+### 1. Inventory your current KMS usage
+
+For each signing operation:
+
+- Which KMS provider holds the key?
+- What's the key ARN / URI?
+- What algorithm?
+- What IAM role does the calling app use?
+
+### 2. Stand up a Confium coordinator + N signers
+
+Follow the [deployment guide](/docs/deployment/). Configure
+each signer to use a different KMS-backed share store:
+
+```toml
+# signer-1: AWS KMS
+[store]
+backend = "cloud"
+provider = "aws"
+key_id = "arn:aws:kms:us-east-1:111:key/abc-123"
+```
+
+```toml
+# signer-2: GCP KMS
+[store]
+backend = "cloud"
+provider = "gcp"
+key_id = "projects/my-project/locations/global/keyRings/confium/cryptoKeys/signer-2"
+```
+
+```toml
+# signer-3: on-prem HSM (PKCS#11)
+[store]
+backend = "pkcs11"
+library = "/usr/lib/softhsm/libsofthsm2.so"
+slot = 0
+```
+
+### 3. Generate the threshold key
+
+Each signer generates its share in its own KMS / HSM via the
+[confium-store-cloud](/docs/components/) backend. The shares
+never leave their respective stores. The coordinator sees
+only public commitments.
+
+### 4. Replace KMS API calls in your app
+
+Where you previously had:
+
+```python
+# Direct KMS call (single-party)
+client = boto3.client("kms")
+response = client.sign(
+    KeyId="arn:aws:kms:us-east-1:111:key/abc-123",
+    Message=message,
+    SigningAlgorithm="ECDSA_SHA_256",
+)
+signature = response["Signature"]
+```
+
+now use Confium:
+
+```python
+# Confium threshold signing (multi-party)
+import confium
+
+sig = confium.CompositeSignature.sign_ed25519(
+    message=message,
+    secret_key=confium_share,  # your local share (not the KMS key directly)
+)
+# Or, if you want the full threshold session:
+session = confium.TC.FrostP256.Session(
+    coordinator_url="tcp://coordinator:7443",
+    signer_id="app-server-1",
+    share=load_my_share(),
+)
+sig = session.sign(message)
+```
+
+### 5. Verify
+
+The signature is a composite signature against the published
+Confium public key. Any Confium verifier (Python, Ruby, WASM,
+JSON-RPC daemon) checks it.
+
+## Hybrid deployment: KMS + HSM
+
+A common pattern for regulated industries:
+
+- **2 signers in cloud KMS** (AWS us-east-1, GCP us-central1)
+  — for availability and cost-efficiency.
+- **1 signer in an on-prem HSM** — for sovereignty (the cloud
+  providers cannot produce a signature alone).
+- **Threshold 3-of-3** for the highest-assurance operations.
+
+Confium's `confium-store-cloud` + `confium-store-pkcs11`
+backends coexist in the same deployment. The coordinator
+treats them uniformly.
+
+## What you keep
+
+- **Your KMS instances.** They still store keys, still provide
+  durability, still have the cloud provider's IAM and audit
+  trail.
+- **Your cloud provider's compliance certifications.** AWS KMS
+  is FIPS 140-2 Level 3; GCP Cloud KMS similar. Confium doesn't
+  change that.
+- **Your existing IAM / RBAC.** Each signer authenticates to
+  its KMS via the same IAM role it always has.
+
+## What you gain
+
+- **No single cloud operator can produce a signature.** A
+  subpoena to AWS doesn't compromise a key that also requires
+  shares in GCP and on-prem HSM.
+- **Cross-cloud key custody.** Mix providers without lock-in.
+- **Async threshold sessions.** Signers in different clouds,
+  different regions, different time zones.
+- **Post-quantum migration path.** Composite signatures wrap
+  the cloud KMS's classical algorithm in an ML-DSA-65
+  envelope.
+
+## See also
+
+- [Confium store cloud](/docs/components/) — the AWS/GCP/Azure
+  KMS backend.
+- [Distributed custody use case](/use-cases/distributed-custody/)
+  — the cross-cloud pattern.
+- [Sovereign PKI use case](/use-cases/sovereign-pki/) — when
+  the threshold key governs an entire PKI.

--- a/src/content/docs/migrate/from-sigstore.mdx
+++ b/src/content/docs/migrate/from-sigstore.mdx
@@ -1,0 +1,175 @@
+---
+title: Migrate from Sigstore
+description: "You use Sigstore (cosign + Rekor + Fulcio) for container / artifact signing. Here's what Confium adds, what to keep, and how to run both side-by-side during migration."
+audience: architect
+order: 2
+---
+
+# Migrate from Sigstore
+
+[Sigstore](https://www.sigstore.dev) is the standard for
+keyless, OIDC-backed signing of container images and
+artifacts. For individual developers and small teams, it's
+excellent. For organizations that need **multi-party control
+over release keys**, Sigstore alone isn't enough.
+
+Confium doesn't replace Sigstore — it complements it. You
+keep Rekor (the transparency log), you keep cosign's
+verification UX, and you add threshold signing behind the
+release key.
+
+## What each is good at
+
+| Need | Sigstore | Confium |
+| --- | --- | --- |
+| Sign an artifact as yourself (keyless via GitHub OIDC) | ✓ | n/a |
+| Verify an artifact's signature in a CI admission check | ✓ cosign verify | ✓ WASM verifier |
+| Public transparency log of what's been signed | ✓ Rekor | ✓ RFC 6962 |
+| Multi-maintainer control over the release key | ✗ | ✓ |
+| Async signing across time zones | ✗ | ✓ |
+| Standards-only adapters (PKCS#11, OpenSSL, JCE) | ✗ | ✓ |
+| Post-quantum migration via composite signatures | ✗ | ✓ |
+| FIPS 140 mode | ✗ | ✓ via plugin |
+
+## When to add Confium to a Sigstore workflow
+
+You're a fit for adding Confium if:
+
+- Your release key is high-value (base images, language
+  runtimes, critical infrastructure).
+- A single compromised maintainer laptop could ship a
+  malicious release.
+- Compliance (FedRAMP, FIPS 140, SOC 2) requires multi-party
+  control over release keys.
+- You want to migrate to post-quantum signatures without a
+  flag day.
+
+You don't need Confium if:
+
+- Your release process is single-maintainer by design (a
+  solo project, a personal container).
+- Keyless Sigstore with short-lived OIDC-bound keys is
+  enough — that's a different threat model (you're trusting
+  GitHub OIDC, not a static key).
+
+## The migration shape
+
+```
+┌────────────────────────────────────────────────┐
+│  SIGSTORE-ONLY (today)                          │
+│                                                │
+│  CI runner                                     │
+│    ↓ cosign sign --key (ephemeral OIDC)        │
+│  Artifact + cosign signature                   │
+│    ↓                                           │
+│  Rekor transparency log entry                  │
+└────────────────────────────────────────────────┘
+                     ↓ add Confium
+┌────────────────────────────────────────────────┐
+│  SIGSTORE + CONFIUM                             │
+│                                                │
+│  N release maintainers                         │
+│    ↓ each contributes a share via Confium      │
+│  Confium coordinator (T-of-N threshold)        │
+│    ↓ composite signature (Ed25519 + ML-DSA-65) │
+│  CI runner                                     │
+│    ↓ cosign sign --key <composite-pubkey>      │
+│  Artifact + cosign signature (now threshold)   │
+│    ↓                                           │
+│  Rekor transparency log entry                  │
+└────────────────────────────────────────────────┘
+```
+
+## Steps
+
+### 1. Keep Rekor and cosign's verification path
+
+Don't rip out what works. cosign verify, the Rekor entry, the
+OIDC binding — all stay. You're changing what gets signed,
+not how it's verified.
+
+### 2. Generate a composite Confium key
+
+Run a distributed key generation across your N release
+maintainers. Output:
+
+- A composite public key (Ed25519 + ECDSA-P256, optionally +
+  ML-DSA-65)
+- N shares (one per maintainer, on their own hardware)
+
+The public key is what cosign will sign with.
+
+### 3. Replace cosign's single-key signing with Confium-backed signing
+
+Where you previously had:
+
+```sh
+cosign sign --key cosign.key my-image
+```
+
+now run:
+
+```sh
+# Each maintainer signs the image digest with their share
+confium sign --coordinator tcp://coord:7443 \
+             --signer maintainer-$(whoami) \
+             $(image_digest)
+
+# Coordinator assembles the composite signature
+confium assemble --wait
+
+# cosign attaches the composite signature to the image
+cosign attach signature --key <composite-pubkey> my-image
+```
+
+The signature is now a composite Confium signature, not a
+single-key cosign signature. The cosign verify side checks it
+against the composite public key you publish.
+
+### 4. Publish the composite public key
+
+Distribute the composite public key the same way you
+distributed the single-key public key: in your
+`cosign.pub`, your SBOM, your release notes. cosign verify
+checks it as usual.
+
+### 5. Verify
+
+Existing `cosign verify` calls continue to work — they check
+the signature against the published public key. The signature
+happens to require T-of-N maintainers to produce, but the
+verifier doesn't need to know that.
+
+### 6. Optional: anchor in Confium's transparency log
+
+Rekor already records the signature. If you also want a
+Confium transparency-log entry (for split-view detection via
+witness gossip), the coordinator can append to both
+automatically.
+
+## What stays the same
+
+- **cosign verify** — your CI admission webhook doesn't change.
+- **Rekor entry** — every signing event is still publicly
+  logged.
+- **OIDC binding for non-release signing** — individual
+  maintainer commits can still use keyless Sigstore. The
+  threshold signing is for *release* keys only.
+
+## What changes
+
+- **The signing key** — single-key cosign key → composite
+  Confium key held across maintainers.
+- **The release process** — `cosign sign` → multi-maintainer
+  Confium session + cosign attach.
+- **The threat model** — single-maintainer compromise no longer
+  produces a valid signature.
+
+## See also
+
+- [Container image signing](/use-cases/container-image-signing/)
+  — the full Confium-without-Sigstore pattern.
+- [Composite signatures concept](/concepts/composite-signatures/)
+  — why a composite signature is a single envelope, not two
+  separate signatures.
+- [Sigstore](https://www.sigstore.dev) — the upstream project.

--- a/src/content/docs/rust-api.mdx
+++ b/src/content/docs/rust-api.mdx
@@ -1,0 +1,164 @@
+---
+title: Rust API reference
+description: "The Confium Rust API surface — confium-core, confium-composite, confium-transparency, confium-pki, confium-attributes. Types, traits, and entry points for embedded use."
+audience: developer
+order: 21
+---
+
+# Rust API reference
+
+Confium is Rust-native. The Rust API is the most complete and
+the source of truth for every other binding. This page covers
+the public entry points across the main interface crates.
+
+## Crate map
+
+| Crate | Role |
+| --- | --- |
+| `confium-core` | Engine entry points — plugin loader, registry, FFI |
+| `confium-composite` | Composite signature types + verifiers |
+| `confium-transparency` | Merkle tree, inclusion / consistency proofs, OTS, ERS |
+| `confium-pki` | X.509, CSR, CMS SignedData, XMLDSig, delegation |
+| `confium-attributes` | Threshold-policy predicate DSL + evaluation |
+| `confium-api` | Shared plugin-author types (`OpaqueHandle`, `OptionMap`, `PluginMetadata`) |
+| `confium-macros` | Proc-macros (`#[plugin_interface]`, `#[export]`) |
+
+For the full 48-crate list, see
+[Components](/docs/components/).
+
+## Composite signatures
+
+```rust
+use confium_composite::{
+    CompositeSignature, ComponentSignature,
+    build_ed25519_component, build_p256_component,
+    ed25519_verifier, p256_verifier,
+    ED25519, ECDSA_P256,
+};
+
+// Build a composite signature from individual component signatures.
+let ed_component = build_ed25519_component(&signing_key, message)?;
+let p256_component = build_p256_component(&p256_signing_key, message)?;
+let composite = CompositeSignature::new(vec![ed_component, p256_component]);
+
+// Serialize for storage / transport.
+let wire_bytes = composite.to_der()?;
+
+// Verify: deserialize, then verify each component with its callback.
+let parsed = CompositeSignature::from_der(&wire_bytes)?;
+let result = parsed.verify_with(message, &[
+    ed25519_verifier(&public_key),
+    p256_verifier(&p256_public_key),
+]);
+```
+
+## Transparency log
+
+```rust
+use confium_transparency::merkle::{MerkleTree, InclusionProof};
+
+let mut tree = MerkleTree::new();
+
+// Append entries — returns the sequence number.
+let seq = tree.append(b"artifact bytes")?;
+let root = tree.root();  // 32-byte SHA-256 root
+
+// Generate an inclusion proof for a specific entry.
+let proof: InclusionProof = tree.inclusion_proof(seq)?;
+
+// Verify (auditor side):
+proof.verify(leaf_hash, tree.size(), &root)?;
+```
+
+## Consistency proofs (RFC 6962 §2.1.3)
+
+```rust
+// On the log operator side:
+let old_size = 12345;
+let consistency = tree.consistency_proof(old_size)?;
+
+// On the auditor side:
+tree.verify_consistency(
+    old_root,       // published yesterday
+    new_root,       // published today
+    old_size,       // 12345
+    tree.size(),    // current size
+    &consistency,
+)?;
+```
+
+The 0.4.0 release rewrote `consistency_proof` +
+`verify_consistency` per RFC 6962 §2.1.3. The 0.3.x proof shape
+is incompatible — see the
+[changelog](https://github.com/confium/confium/blob/main/CHANGELOG.md).
+
+## PKI — certificate + CMS
+
+```rust
+use confium_pki::{Certificate, SignedData};
+
+let cert = Certificate::from_pem(pem_str)?;
+println!("subject: {:?}", cert.subject());
+println!("valid until: {}", cert.not_after());
+
+// Build a CMS SignedData envelope.
+let envelope = SignedData::builder()
+    .payload(document_bytes)
+    .certificate(cert.clone())
+    .signature(composite_sig_bytes)
+    .build_detached()?;
+
+let der = envelope.to_der()?;
+```
+
+## Attributes DSL
+
+```rust
+use confium_attributes::{Predicate, SignerAttributes};
+
+let policy = Predicate::parse(
+    "region in (EU, US) and role == 'director' and count >= 3"
+)?;
+
+let signers = SignerAttributes::from_json(signers_json)?;
+let result = policy.evaluate(&signers)?;
+println!("satisfied: {}", result.satisfied);
+println!("matched: {:?}", result.matched_signer_ids);
+```
+
+## Plugin authoring
+
+```rust
+use confium_api::plugin::hash::HashPlugin;
+use confium_macros::plugin_interface;
+
+pub struct MyHasher { /* ... */ }
+
+impl HashPlugin for MyHasher {
+    fn new(_opts: &OptionMap) -> Result<Self, PluginError> { /* ... */ }
+    fn update(&mut self, data: &[u8]) -> Result<(), PluginError> { /* ... */ }
+    fn finalize(&self) -> Result<Vec<u8>, PluginError> { /* ... */ }
+}
+
+#[plugin_interface(name = "hash", version = 0)]
+impl HashPlugin for MyHasher { /* trait impl above */ }
+
+#[confium_macros::export(
+    interfaces(hash = 0),
+    metadata(name = "my-hash", version = "0.1.0")
+)]
+pub struct MyHasher;
+```
+
+The macros emit the eight canonical `cfmp_hash_*` extern "C"
+entry points plus the lifecycle symbols. The plugin loads
+through the standard Confium loader.
+
+## See also
+
+- [Components](/docs/components/) — every crate in the
+  workspace.
+- [Plugin author guide](https://github.com/confium/confium/blob/main/docs/plugin-author-guide.mdx)
+  — the full plugin-authoring walkthrough.
+- [Confium repository](https://github.com/confium/confium) —
+  the rustdoc lives inline in each crate's source.

--- a/src/content/docs/wasm-api.mdx
+++ b/src/content/docs/wasm-api.mdx
@@ -1,0 +1,160 @@
+---
+title: WASM API reference
+description: "The @confium/confium-wasm API surface — browser-side verifier for composite signatures, transparency logs, attribute predicates, and PKI. Verifier-only by design: browsers verify, servers sign."
+audience: developer
+order: 22
+---
+
+# WASM API reference
+
+`@confium/confium-wasm` is the browser / Node.js verifier
+package. It wraps the same Rust engine as the Ruby / Python /
+Node bindings but exposes **verification only** — signing and
+threshold sessions live on the server. This split is
+deliberate: browsers verify; servers sign.
+
+## Install
+
+```sh
+npm install @confium/confium-wasm
+```
+
+Or tree-shake to just the subsystems you need:
+
+```sh
+npm install @confium/confium-wasm-composite       # verify-composite only
+npm install @confium/confium-wasm-transparency    # verify-transparency only
+npm install @confium/confium-wasm-attributes      # verify-attributes only
+npm install @confium/confium-wasm-pki             # verify-pki only
+```
+
+## Composite signatures
+
+```typescript
+import init, { CompositeSignature } from "@confium/confium-wasm";
+
+await init();  // load the WASM module once
+
+const message = new TextEncoder().encode("hello");
+const signature = new Uint8Array(/* composite sig bytes */);
+const publicKey = new Uint8Array(/* public key bytes */);
+
+const result = CompositeSignature.verify(message, signature, publicKey);
+console.log(result.valid);  // → true
+console.log(result.componentsChecked);  // → 2 (Ed25519 + ECDSA-P256)
+```
+
+### Per-component verification
+
+If you want to verify only some components (e.g., accept a
+signature that's valid for Ed25519 even if the PQ component
+is unsupported in this browser build):
+
+```typescript
+const result = CompositeSignature.verifyWith(
+    message,
+    signature,
+    [
+        { algorithm: "Ed25519", publicKey: ed_pubkey },
+        // skip the ECDSA-P256 component
+    ],
+);
+```
+
+## Transparency log
+
+```typescript
+import { verifyInclusionWithHead, InclusionProof } from "@confium/confium-wasm";
+
+// Verify an artifact is in a published log checkpoint.
+const leafHash = new Uint8Array(/* SHA-256 of the leaf */);
+const proof = InclusionProof.fromJson(proofJson);
+const root = new Uint8Array(/* published root hash */);
+const treeSize = 12345;
+
+verifyInclusionWithHead(leafHash, proof, treeSize, root);  // throws on failure
+```
+
+### Consistency proof (RFC 6962 §2.1.3)
+
+```typescript
+import { verifyConsistency } from "@confium/confium-wasm";
+
+verifyConsistency(
+    oldRoot,       // Uint8Array(32) — yesterday's published root
+    newRoot,       // Uint8Array(32) — today's published root
+    oldSize,       // 12345
+    newSize,       // 12678
+    consistencyProof,
+);  // throws on failure — log wasn't append-only
+```
+
+## Attribute predicates
+
+```typescript
+import { Predicate } from "@confium/confium-wasm";
+
+const policy = Predicate.parse(
+    "region in (EU, US) and role == 'director' and count >= 3"
+);
+
+const signers = {
+    signers: [
+        { id: "d1", region: "EU", role: "director" },
+        { id: "d2", region: "EU", role: "director" },
+        { id: "d3", region: "US", role: "director" },
+    ],
+};
+
+const result = policy.evaluate(signers);
+console.log(result.satisfied);  // → true
+console.log(result.matched);    // → ["d1", "d2", "d3"]
+```
+
+## PKI — certificate parse + verify
+
+```typescript
+import { Certificate, SignedData } from "@confium/confium-wasm";
+
+const cert = Certificate.fromPem(pemString);
+console.log(cert.subject());
+console.log(cert.notBefore(), cert.notAfter());
+
+const envelope = SignedData.fromDer(derBytes);
+const result = envelope.verify({ trustRoots: [rootCert] });
+console.log(result.valid);
+```
+
+## What's NOT in the WASM package
+
+- **Signing** — composite sign, CMS build, threshold sessions.
+  These run on the server (Ruby, Python, Node, Rust). Browsers
+  receive signatures and verify them.
+- **Coordinator client** — the WASM package doesn't speak the
+  coordinator's QUIC protocol. It verifies artifacts produced
+  elsewhere.
+- **OpenPGP (RFC 9580)** — for OpenPGP in the browser, use
+  [`@rnpgp/rnp`](https://www.npmjs.com/package/@rnpgp/rnp).
+  See [Confium and RNP](/concepts/confium-and-rnp/) for the
+  sibling-project relationship.
+
+## Bundle size
+
+The full package is ~120 KB gzipped. The per-subsystem subset
+packages are smaller:
+
+| Subset | Gzipped size |
+| --- | --- |
+| `verify-composite` | ~25 KB |
+| `verify-transparency` | ~30 KB |
+| `verify-attributes` | ~15 KB |
+| `verify-pki` | ~45 KB |
+
+Ship only what your browser code calls.
+
+## See also
+
+- [Polyglot verification use case](/use-cases/polyglot-verification/)
+  — when to use the WASM verifier vs the JSON-RPC daemon.
+- [WASM binding source](https://github.com/confium/confium/tree/main/crates/confium-wasm).
+- [@confium/confium-wasm on npm](https://www.npmjs.com/package/@confium/confium-wasm).


### PR DESCRIPTION
## Summary

Items 3, 4, 5 of the developer-content expansion. Adds 6 new pages.

### Item 3: Examples gallery (`/docs/examples/`)

Ten copy-paste tasks. Each snippet is self-contained. Sections: sign+verify (Python/Ruby/Node), verify (browser-WASM/shell/Go), threshold sessions (Ruby/Python), PKI+CMS (Python/Ruby), OpenPGP (Ruby).

### Item 4: Migration guides (`/docs/migrate/`)

Three guides for teams coming from incumbent solutions:

| Guide | What it covers |
|---|---|
| `/docs/migrate/from-hsm/` | Same HSM, threshold signing behind it via the PKCS#11 adapter. Mode 2 pattern. Before/after diagram + step-by-step. |
| `/docs/migrate/from-sigstore/` | Keep Rekor + cosign verify, add threshold signing behind the release key. Hybrid Sigstore+Confium flow. |
| `/docs/migrate/from-kms/` | Multi-cloud threshold key custody. Each signer's share in a different KMS provider (AWS/GCP/Azure/on-prem mix). |

### Item 5: Per-language API reference

| Page | What |
|---|---|
| `/docs/rust-api/` | Rust API surface across confium-core, composite, transparency, PKI, attributes, plugin authoring. Code samples for each. |
| `/docs/wasm-api/` | `@confium/confium-wasm` browser-side verifier. Per-subsystem tree-shaking sizes, what's NOT included (signing, coordinator, OpenPGP — point at `@rnpgp/rnp`). |

## Test plan

- [x] `npx astro build` — 133 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] All 6 new pages render

## Related

Builds on PR #63 (Go + Node bindings) and PR #62 (Quickstart hub). Together these give developers a clear path: quickstart → examples → API reference → migration guide.
