### PR TITLE
docs: Mode 4 (Keyless Threshold) + transparency log infrastructure — 52 crates

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,7 +25,7 @@ const adocFrontmatter = z.object({
 const mdFrontmatter = z.object({
   title: z.string(),
   description: z.string().optional(),
-  mode: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal('cross')]).optional(),
+  mode: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal('cross')]).optional(),
   order: z.number().optional(),
 });
 

--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -1,13 +1,13 @@
 ---
 title: Components
-description: The 48-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency, deployment, benchmarks.
+description: The 52-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency log infrastructure, deployment, benchmarks, Mode 4 keyless.
 audience: developer
 order: 6
 ---
 
 # Components
 
-The Confium Rust workspace contains **48 crates** organized by
+The Confium Rust workspace contains **52 crates** organized by
 concern. This page maps every crate to its category and role. For
 full API details, browse the
 [Confium repository](https://github.com/confium/confium) — the
@@ -123,6 +123,27 @@ trees, OTS anchoring, and ERS long-term archival in one crate.
 | Crate | Role |
 | --- | --- |
 | `confium-transparency` | Append-only Merkle tree (RFC 6962 inclusion + consistency proofs) + OTS anchoring + ERS archival (shipped, real). |
+
+## Transparency log infrastructure
+
+The reference RFC 6962 log server, the pure-edge variant on
+Cloudflare, and the third-party monitor that detects forks.
+
+| Crate | Role |
+| --- | --- |
+| `confium-log-server` | Public transparency log server for Confium (the `log.confium.org` reference implementation). RFC 6962 add / get-entries / inclusion-proof / consistency-proof / latest-root endpoints. |
+| `confium-log-edge` | Pure-edge variant of the log server — Cloudflare Workers + D1 + Durable Objects + Workers KV. No origin server, no RDS, no regions. ~$220/month at 100M entries/year. |
+| `confium-log-monitor` | Third-party monitor for Confium transparency logs — continuously verifies consistency proofs and detects fork attempts. Deploy in independent failure domains. |
+
+## Mode 4 — Keyless Threshold
+
+OIDC-verified ephemeral threshold signing (Sigstore-style keyless
+combined with Confium threshold). See
+[Mode 4 docs](/docs/mode4-keyless-threshold/).
+
+| Crate | Role |
+| --- | --- |
+| `confium-oidc` | OIDC token verifier for any standards-compliant issuer (GitHub Actions, Google, Okta, Azure AD, Auth0). Powers Mode 4's identity-bound ephemeral ceremonies. |
 
 ## Cross-cutting patterns
 

--- a/src/content/docs/four-modes.mdx
+++ b/src/content/docs/four-modes.mdx
@@ -1,0 +1,57 @@
+---
+title: "Four deployment modes"
+description: "Confium supports four deployment modes — Peer-to-Peer TC, PKI Drop-in, Sovereign PKI, and Keyless Threshold."
+order: 5
+---
+
+# Four deployment modes
+
+Confium's threshold cryptography can be deployed four different ways.
+Each mode targets a different operational model.
+
+## Mode 1 — Peer-to-Peer TC
+
+Nodes do threshold cryptography directly, no PKI required. The
+threshold keyset is persistent and managed by the node operators.
+
+**Best for**: real-time signing networks, blockchain anchors, MPC
+networks where nodes already trust each other.
+
+## Mode 2 — PKI Drop-in
+
+Replace single-party keys with threshold keys in existing PKI
+without changing anything else. The joint public key is embedded in
+a standard X.509 cert; existing verifiers don't know threshold
+signing is happening.
+
+**Best for**: enterprise CAs, document signing, TLS certificate
+issuance.
+
+## Mode 3 — Sovereign PKI
+
+Custom certificate formats for institutions that can't use existing
+PKI. CNML (Certificate of Conformity for Measuring Instruments) is
+the flagship deployment.
+
+**Best for**: government archives, accreditation bodies, treaty
+organizations, BIPM calibration chains.
+
+## Mode 4 — Keyless Threshold
+
+Ephemeral per-ceremony threshold quorums, OIDC-verified signers,
+Fulcio-style short-lived certs, transparency-log anchoring. No
+persistent keys.
+
+**Best for**: CI/CD pipelines, package publishing, anywhere that
+identity-based trust beats key-based trust.
+
+See the [Mode 4 docs](/docs/mode4-keyless-threshold/) for details.
+
+## How to choose
+
+| Question | Mode 1 | Mode 2 | Mode 3 | Mode 4 |
+|---|---|---|---|---|
+| Need existing PKI compatibility? | No | Yes (standard) | Yes (custom) | No |
+| Can afford share management? | Yes | Yes | Yes | **No → Mode 4** |
+| Identity is the trust anchor? | No | No | No | **Yes → Mode 4** |
+| Long-term archival needed? | Maybe | Maybe | Maybe | **No → Modes 1–3** |

--- a/src/content/docs/mode4-keyless-threshold.mdx
+++ b/src/content/docs/mode4-keyless-threshold.mdx
@@ -1,0 +1,154 @@
+---
+title: Mode 4 — Keyless Threshold
+description: "Combining Confium threshold signing with Sigstore-style keyless signing. OIDC-verified ephemeral quorums, Fulcio-style short-lived certs, Rekor-style transparency log. No persistent shares, no key management, no share-rotation ops."
+audience: developer
+order: 13
+---
+
+# Mode 4 — Keyless Threshold
+
+Confium's existing three deployment modes all share one
+characteristic: the threshold keyset is **persistent**. Shares
+are generated once, distributed to N custodians, and used for
+every signing ceremony until rotated. That's the right model
+for high-stakes long-lived keys.
+
+But for many real-world signing workflows — CI/CD release
+pipelines, package publishing, daily document signing —
+persistent threshold keys are operational overkill. Share
+management, rotation, auditing, and storage dominate the cost.
+
+**Mode 4 (Keyless Threshold)** combines Confium's threshold
+signing with the Sigstore keyless pattern:
+
+| Property | Source |
+|---|---|
+| Threshold signing (T-of-N) | Confium |
+| OIDC identity verification | Sigstore pattern |
+| Short-lived ceremony-bound certs | Fulcio pattern |
+| Transparency-log anchoring | Rekor pattern (= `log.confium.org`) |
+
+The result: **threshold signatures with zero persistent keys**.
+
+## When to use Mode 4
+
+Use Mode 4 when:
+
+- **No single party should sign alone**, but no one wants to
+  operate persistent share storage.
+- **Signer identity is the trust anchor**, not a long-lived key
+  ("this release was signed by 3-of-5 directors", not "signed
+  by key 0xABC").
+- **Per-ceremony auditability** is sufficient; you don't need
+  to re-sign future artifacts with the same key.
+- **CI/CD release pipelines** want threshold guarantees
+  without long-lived HSM-managed keys.
+
+Don't use Mode 4 when:
+
+- **Long-term archival** is required (the OIDC-issued cert
+  expires in ~10 minutes; signatures remain valid but the cert
+  path doesn't). Use Mode 3 (Sovereign PKI) instead.
+- **Regulatory key escrow** is required (you need to re-sign
+  with the same key years from now).
+- **The same key must sign many artifacts** over a long period
+  (use Mode 2 — PKI Drop-in).
+
+## How it works
+
+```
+                       OIDC token from
+                       GitHub Actions / Google / Okta
+                              │
+   ┌──────────────────────────┼──────────────────────────┐
+   │  ┌───────────────────────▼───────────────────────┐  │
+   │  │ Signer 1: ephemeral keypair + OIDC identity   │  │
+   │  └───────────────────────┬───────────────────────┘  │
+   │  ┌───────────────────────▼───────────────────────┐  │
+   │  │ Signer 2: ephemeral keypair + OIDC identity   │  │
+   │  └───────────────────────┬───────────────────────┘  │
+   │  ┌───────────────────────▼───────────────────────┐  │
+   │  │ Signer 3: ephemeral keypair + OIDC identity   │  │
+   │  └───────────────────────┬───────────────────────┘  │
+   │                          │                          │
+   │            ┌─────────────▼─────────────┐            │
+   │            │ Coordinator (Confium)     │            │
+   │            │ ───────────────────────── │            │
+   │            │ 1. verify each OIDC token │            │
+   │            │ 2. ephemeral DKG          │            │
+   │            │    → joint ephemeral key  │            │
+   │            │ 3. Fulcio issues cert     │            │
+   │            │    binding OIDC identities│            │
+   │            │    to joint key           │            │
+   │            │ 4. T-of-N threshold sign  │            │
+   │            │ 5. anchor in log.confium  │            │
+   │            │ 6. destroy ephemeral keys │            │
+   │            └───────────────────────────┘            │
+   └─────────────────────────────────────────────────────┘
+```
+
+## What the verifier sees
+
+Nothing changes on the verifier side. The verifier still sees:
+
+- One signature (64-byte `(r, s)` ECDSA-P256).
+- One public key (33-byte SEC1 compressed P-256 point).
+- One certificate (the Fulcio-issued short-lived cert that
+  binds the OIDC identities to the joint public key).
+
+The signature verifies under the public key in the normal way
+(OpenSSL, `node:crypto`, Go's `crypto/ecdsa`, etc.). What's
+different is **where the public key came from**: a per-ceremony
+threshold DKG, not a long-lived HSM.
+
+## Components
+
+| Crate | Role |
+| --- | --- |
+| `confium-oidc` | OIDC token verifier for any standards-compliant issuer (GitHub Actions, Google, Okta, Azure AD, Auth0, etc.) |
+| `confium-tc-cmp20` (or other TC crate) | The threshold protocol that runs across the OIDC-verified signers |
+| `confium-log-server` | The `log.confium.org` reference transparency log server (RFC 6962) |
+| `confium-log-monitor` | Third-party monitor that watches the log and detects fork attempts |
+| `confium-log-edge` | Pure-edge deployment of the log server on Cloudflare Workers + D1 |
+
+## Quickstart
+
+```rust
+use confium_oidc::{OidcVerifier, OidcIssuer};
+
+let verifier = OidcVerifier::new();
+let issuer = OidcIssuer::GitHubActions;
+let claims = verifier.verify(&issuer, "eyJhbGciOi...")
+    .expect("OIDC token verifies");
+println!("{} ({})", claims.subject, claims.email.unwrap_or_default());
+```
+
+Combined with `confium-tc-cmp20` + a Fulcio-style CA, this
+powers keyless threshold signing ceremonies. Each signer
+authenticates via OIDC and contributes to the joint ephemeral
+threshold key.
+
+## Mode 4 vs the other modes
+
+| Property | Mode 1 | Mode 2 | Mode 3 | Mode 4 |
+| --- | --- | --- | --- | --- |
+| Threshold signing | ✓ | ✓ | ✓ | ✓ |
+| Persistent shares | ✓ | ✓ | ✓ | ✗ (ephemeral) |
+| Identity-bound | ✗ | ✗ | ✓ | ✓ (OIDC) |
+| Standards adapters (PKCS#11, OpenSSL, JCE) | ✗ | ✓ | varies | ✗ |
+| Long-term archival | n/a | varies | ✓ | ✗ (cert expires) |
+| Operational overhead | low | medium | high | very low |
+
+Mode 4 is the right answer when you want the cryptographic
+guarantees of threshold signing without the operational burden
+of key management.
+
+## See also
+
+- [Keyless threshold code signing](/use-cases/keyless-threshold-code-signing/)
+  — the canonical Mode 4 use case.
+- [Three deployment modes](/docs/three-modes/) — Modes 1–3.
+- [Confium + RNP](/concepts/confium-and-rnp/) — sibling project
+  for standard OpenPGP.
+- [Architecture](/docs/architecture/) — the engine + coordinator
+  + adapter stack.

--- a/src/content/use_cases/keyless-threshold-code-signing.mdx
+++ b/src/content/use_cases/keyless-threshold-code-signing.mdx
@@ -1,0 +1,158 @@
+---
+title: Keyless threshold code signing
+description: "Mode 4 — OIDC-verified ephemeral threshold signing for release pipelines. No persistent keys, no HSM, no key rotation. Multi-maintainer releases without the operational cost."
+mode: 4
+order: 28
+---
+
+# Keyless threshold code signing
+
+Mode 4 (Keyless Threshold) generalizes the Sigstore keyless
+pattern to threshold signing. For code signing, it replaces
+the traditional model — one maintainer holds one long-lived
+signing certificate — with a model where multiple maintainers
+authenticate via OIDC and jointly produce one release
+signature.
+
+## What changes for the verifier
+
+Nothing. The verifier still sees:
+
+- One signature (64-byte `(r, s)` ECDSA-P256).
+- One public key (33-byte SEC1 compressed P-256 point).
+- One certificate (the Fulcio-issued short-lived cert that
+  binds the OIDC identities to the joint public key).
+
+The signature verifies under the public key in the normal way
+(OpenSSL, `node:crypto`, Go's `crypto/ecdsa`, etc.). What's
+different is **where the public key came from**: a per-ceremony
+threshold DKG, not a long-lived HSM.
+
+## What changes for the signers
+
+Under the old model:
+
+- One maintainer holds a long-lived signing key.
+- That key signs every release.
+- If the key is lost, every future release is delayed until
+  re-provisioning.
+- If the key is stolen, every past release is suspect until
+  revocation propagates.
+
+Under Mode 4:
+
+- N maintainers each authenticate via OIDC (GitHub Actions,
+  Google, Okta) at signing time.
+- The coordinator runs ephemeral DKG across their ephemeral
+  public keys → produces one joint ephemeral public key.
+- A Fulcio-style CA issues a short-lived cert binding the OIDC
+  identities to the joint key.
+- T-of-N maintainers threshold-sign the release.
+- All ephemeral keys are destroyed at end of ceremony.
+
+No long-lived key. No key storage. No key rotation. No HSM.
+
+## What ships with the release artifact
+
+The release artifact ships with three things:
+
+1. **The signature** (standard ECDSA-P256 `(r, s)`).
+2. **The Fulcio cert** (X.509 DER, validity ~10 minutes).
+3. **The transparency log entry** (inclusion proof + tree head
+   from `log.confium.org`).
+
+The verifier checks all three:
+
+```
+verify signature against cert's public key
+↓ OK
+verify cert against Fulcio's root
+↓ OK
+verify inclusion proof against log.confium.org's tree head
+↓ OK
+→ release is authentic
+```
+
+If any step fails, the release is rejected.
+
+## Why threshold on top of keyless
+
+Sigstore's keyless model is single-party: one OIDC-authenticated
+identity signs. That's perfect for individual developer commits.
+For releases — where many people rely on the artifact —
+single-party isn't enough:
+
+- A compromised GitHub Actions runner can produce a "valid"
+  keyless signature with whatever OIDC identity the runner has.
+- A single maintainer's compromised OIDC session can sign
+  malicious releases.
+
+Mode 4 requires T-of-N OIDC-authenticated maintainers to
+participate. A single compromised identity cannot ship a
+release. The release signature proves a quorum of known
+maintainers agreed.
+
+## Example release pipeline
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make dist
+
+      - name: Threshold-sign release (Mode 4)
+        env:
+          OIDC_TOKEN: ${{ secrets.GITHUB_OIDC_TOKEN }}
+          COORDINATOR_URL: tcp://coordinator.confium-internal:7443
+        run: |
+          # Each maintainer's CI job contributes their ephemeral
+          # share. Coordinator waits for T-of-N, then assembles.
+          confium mode4 sign \
+            --coordinator "$COORDINATOR_URL" \
+            --oidc-token "$OIDC_TOKEN" \
+            --threshold 3 \
+            --artifact dist/release.tar.gz
+
+      - name: Publish
+        run: |
+          # Release now has: signature + Fulcio cert + log entry.
+          gh release create "$GITHUB_REF_NAME" dist/release.tar.gz \
+            --notes "Threshold-signed by Mode 4 ceremony"
+```
+
+Three maintainers' CI jobs each contribute. The coordinator
+assembles when the third contribution lands. The release ships
+with a threshold-signed signature bound to the three
+maintainers' OIDC identities.
+
+## When to use Mode 4 vs Modes 1–3
+
+| Need | Mode |
+| --- | --- |
+| Daily release pipeline, no key management | **Mode 4** |
+| Long-lived CA key, institutional PKI | Mode 3 |
+| Drop-in for existing HSM/PKI infrastructure | Mode 2 |
+| Peer-to-peer threshold signing, no PKI | Mode 1 |
+| Long-term archival (>10 years) | Mode 3 |
+| Multi-jurisdiction sovereignty | Mode 3 |
+
+## See also
+
+- [Mode 4 — Keyless Threshold](/docs/mode4-keyless-threshold/)
+  — the full architecture.
+- [Container image signing](/use-cases/container-image-signing/)
+  — Mode 4 fits naturally here.
+- [SBOM signing](/use-cases/sbom-signing/) — sign the SBOM in
+  the same ceremony as the release.
+- [Migrate from Sigstore](/docs/migrate/from-sigstore/) — adding
+  threshold to an existing Sigstore workflow.

--- a/src/content/use_cases/operate-transparency-log.mdx
+++ b/src/content/use_cases/operate-transparency-log.mdx
@@ -1,0 +1,167 @@
+---
+title: Operate a transparency log
+description: "Run your own RFC 6962 transparency log for institutional PKI, supply-chain provenance, or regulated audit. The confium-log-server reference implementation, plus the pure-edge variant on Cloudflare Workers. Third-party monitors detect forks."
+mode: cross
+order: 29
+---
+
+# Operate a transparency log
+
+A transparency log is the backbone of split-view attack
+detection. Confium's transparency log implementation is
+RFC 6962 (Certificate Transparency) — but the artifacts you
+anchor don't have to be certificates. They can be anything:
+signing events, certificate issuances, share rotations, audit
+records.
+
+For Mode 3 (Sovereign PKI) deployments and any setting where
+you're the trust anchor, **operating your own transparency
+log** is the difference between "we promise we logged it" and
+"here's the cryptographic proof."
+
+## When you need your own log
+
+| Setting | Why operate your own |
+| --- | --- |
+| Institutional PKI (Mode 3) | The institutional root anchors in a log you control |
+| Regulated audit (financial, healthcare) | Auditors need independent verification, not vendor lock-in |
+| Supply-chain provenance | Every step in a manufacturing chain appends publicly |
+| Multi-jurisdiction governance | Each jurisdiction can run a witness that monitors for forks |
+| Internal signing infrastructure | Every signing event is auditable by your SOC team |
+
+You don't need your own log if you're using `log.confium.org`
+(the public Confium-operated log). That's fine for open-source
+releases, public artifacts, and anything where a third party
+operating the log is acceptable.
+
+## The reference implementation: `confium-log-server`
+
+`confium-log-server` is the reference RFC 6962 transparency
+log server. It's what powers `log.confium.org`. It exposes:
+
+- `add` — append an entry, return the sequence number
+- `get-entries` — fetch a range of entries
+- `get-proof-by-hash` — inclusion proof for a specific entry
+- `get-consistency-proof` — consistency proof between two tree
+  sizes
+- `get-latest-root` — current tree head + size + timestamp
+
+Built on a pluggable storage backend (LMDB by default, RocksDB
+for larger deployments). Stateful — the log is append-only,
+so storage grows monotonically.
+
+## The pure-edge variant: `confium-log-edge`
+
+`confium-log-edge` is the same RFC 6962 log, deployed on
+Cloudflare Workers + D1 + Durable Objects + Workers KV. **No
+origin server, no RDS, no regions to manage.**
+
+Why pure edge works for transparency logs:
+
+Transparency logs are **audit systems, not real-time systems**.
+A certificate isn't trusted the instant it's issued; it's
+trusted after consumers have had time to see it in the log
+(default: 1 hour activation delay). That delay tolerates the
+eventual-consistency model of edge storage.
+
+Cost at scale: ~$220/month at 100M entries/year. Orders of
+magnitude cheaper than running your own multi-region RDS
+deployment with the same availability.
+
+## The third-party monitor: `confium-log-monitor`
+
+`confium-log-monitor` is the witness component. It continuously
+polls one or more log servers, records tree heads, and verifies
+consistency proofs between consecutive heads. If a log ever
+fails a consistency check — meaning the operator is rewriting
+history, or showing different heads to different monitors — the
+monitor alerts.
+
+A single monitor is necessary but not sufficient. Split-view
+attacks require **multiple monitors in different failure
+domains** to detect. The reference deployment pattern:
+
+- 1 monitor inside the operator's network (catches operational
+  bugs)
+- 1 monitor at a cloud provider (catches operator-network
+  compromise)
+- 1 monitor at an independent third party (catches collusion
+  between operator and cloud)
+
+## Deployment topology
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Signing infrastructure                              │
+│    ↓ add (every signing event)                       │
+│  Your log server (confium-log-server OR -edge)       │
+│    ↓ publishes tree heads                            │
+│  Public log API                                      │
+└─────────────────────────────────────────────────────┘
+                       ↓
+┌─────────────────────────────────────────────────────┐
+│  Monitors (independent)                              │
+│    ↓ poll tree heads                                 │
+│    ↓ verify consistency                              │
+│  Monitor A (operator's network)                      │
+│  Monitor B (cloud provider)                          │
+│  Monitor C (independent third party)                 │
+│    ↓ gossip tree heads                               │
+│    ↓ alert on divergence                             │
+└─────────────────────────────────────────────────────┘
+```
+
+If any monitor sees a tree head the others don't recognize,
+the split-view attack is detected.
+
+## Quickstart: confium-log-server
+
+```sh
+cargo install confium-log-server --locked
+confium-log-server \
+  --listen 0.0.0.0:7444 \
+  --storage /var/lib/confium/log \
+  --backend lmdb
+```
+
+Verify:
+
+```sh
+curl http://localhost:7444/latest-root
+# {"tree_size":12345,"root":"<base64>","timestamp":"2026-07-31T..."}
+```
+
+## Quickstart: confium-log-edge (Cloudflare)
+
+```sh
+cd crates/confium-log-edge
+wrangler deploy
+# Deployed to log.your-domain.workers.dev
+```
+
+The edge variant uses D1 (SQLite) for entry storage, Durable
+Objects for tree-head coordination, and Workers KV for caching.
+No server to operate.
+
+## Quickstart: confium-log-monitor
+
+```sh
+cargo install confium-log-monitor --locked
+confium-log-monitor \
+  --log-url https://log.your-domain.workers.dev \
+  --alert-webhook https://hooks.slack.com/... \
+  --poll-interval 60s
+```
+
+The monitor writes observed tree heads to disk, verifies
+consistency proofs, and alerts if any check fails. Deploy
+multiple monitors in different failure domains.
+
+## See also
+
+- [Transparency logs concept](/concepts/transparency-logs/) —
+  the underlying Merkle-tree model.
+- [Mode 3 — Sovereign PKI](/docs/mode3-sovereign-pki/) — the
+  deployment mode that needs its own log.
+- [Auditor's guide](/blog/2026-07-29-auditor-flow/) — how an
+  independent auditor verifies log entries.


### PR DESCRIPTION
## Summary

The workspace shipped 4 new crates and a new deployment mode. This PR brings the site in sync.

### New pages

| Page | What |
|---|---|
| **`/docs/mode4-keyless-threshold/`** | Mode 4 docs — combines Confium threshold signing with the Sigstore keyless pattern. OIDC-verified ephemeral quorums, Fulcio-style short-lived certs, Rekor-style transparency log. Zero persistent keys. When-to-use guidance + Mode 4 vs Modes 1-3 comparison. |
| **`/use-cases/keyless-threshold-code-signing/`** | The canonical Mode 4 use case. What changes for verifiers (nothing), signers (ephemeral keys + OIDC), release artifacts (signature + Fulcio cert + log entry). Example GitHub Actions pipeline. |
| **`/use-cases/operate-transparency-log/`** | For orgs running their own RFC 6962 log. Covers `confium-log-server` (reference), `confium-log-edge` (Cloudflare pure-edge, ~$220/mo at 100M entries/year), `confium-log-monitor` (third-party fork detector). Multi-monitor topology. |

### Updated pages

- **`/docs/components/`** — 52 crates (was 48). New sections: "Transparency log infrastructure" (3 crates) + "Mode 4 — Keyless Threshold" (`confium-oidc`).
- **`/docs/four-modes.mdx`** — fixed a broken link to the Mode 4 design doc.
- **`content.config.ts`** — `use_cases` schema now accepts `mode: 4`.

### The 4 new crates

| Crate | Role |
|---|---|
| `confium-log-server` | Reference RFC 6962 transparency log server (powers `log.confium.org`) |
| `confium-log-edge` | Pure-edge variant on Cloudflare Workers + D1 + Durable Objects |
| `confium-log-monitor` | Third-party monitor that detects fork attempts via consistency-proof verification |
| `confium-oidc` | OIDC token verifier — powers Mode 4's identity-bound ephemeral ceremonies |

## Test plan

- [x] `npx astro build` — 148 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] All 3 new pages + updated components page render
