### PR TITLE
docs: K8s operator + Terraform provider + verify-server (57 crates)

### DIFF
--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -1,13 +1,13 @@
 ---
 title: Components
-description: The 52-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency log infrastructure, deployment, benchmarks, Mode 4 keyless.
+description: The 57-crate Confium Rust workspace, grouped by category. Engine, threshold crypto, PKI, storage, network, Mode 2 adapters, transparency log infrastructure, deployment, benchmarks, Mode 4 keyless, operators, IaC, verification services, fuzzing.
 audience: developer
 order: 6
 ---
 
 # Components
 
-The Confium Rust workspace contains **52 crates** organized by
+The Confium Rust workspace contains **57 crates** organized by
 concern. This page maps every crate to its category and role. For
 full API details, browse the
 [Confium repository](https://github.com/confium/confium) — the
@@ -172,6 +172,16 @@ It hard-bundles `rnp-rs` for OpenPGP armor — see
 | --- | --- |
 | `confium-benchmarks` | Criterion benchmark suite for composite verify + transparency operations. Run locally or in CI to track perf regressions. |
 | `confium-test-harness` | NIST MPTS evaluation bench — the official MPTS test-vector runner. |
+| `confium-fuzz` | Fuzzing targets for security-critical surfaces. Run via `cargo fuzz` in CI to catch parser + protocol edge cases. |
+
+## Operations / IaC / Services
+
+| Crate | Role |
+| --- | --- |
+| `confium-operator` | Kubernetes operator — declarative threshold signing via `ConfiumSigningCeremony` CRDs. GitOps-friendly. |
+| `confium-terraform-provider` | Terraform provider (Go). Resources: `confium_threshold_key`, `confium_signing_ceremony`, `confium_transparency_log`, `confium_share`. |
+| `confium-signerd` | Distributed threshold signing daemon — one per signer, connects to coordinator, responds to signing requests. |
+| `confium-verify-server` | HTTP verification service (REST). Stateless, anonymous, public-facing. Drop-in alternative to the JSON-RPC daemon for web verifiers. |
 
 ## Research frontier
 

--- a/src/content/use_cases/kubernetes-operator.mdx
+++ b/src/content/use_cases/kubernetes-operator.mdx
@@ -1,0 +1,161 @@
+---
+title: Kubernetes operator for threshold signing
+description: "Declarative threshold signing via Kubernetes CRDs. Define a ConfiumSigningCeremony resource, let the controller orchestrate the ceremony, read the signature back from a Secret. GitOps for signing."
+mode: cross
+order: 30
+---
+
+# Kubernetes operator for threshold signing
+
+The Confium Kubernetes operator (`confium-operator`) brings
+**declarative threshold signing to K8s**. Instead of running
+CLI commands or RPC calls to start a signing ceremony, you
+create a `ConfiumSigningCeremony` custom resource. The
+operator's controller picks it up, orchestrates the threshold
+session across the signers, and writes the result to a Secret.
+
+## When this is the right pattern
+
+| Setting | Why the operator fits |
+| --- | --- |
+| GitOps release pipelines (Argo CD, Flux) | Signing ceremonies are versioned in git alongside the release manifest |
+| Multi-team K8s platforms | Teams get RBAC-controlled access to signing via namespaced CRDs |
+| Compliance / audit | Every ceremony is a tracked K8s object with a status + lifecycle |
+| Service-mesh integrations | Sidecar signer pods attached to your application workloads |
+
+You don't need the operator if:
+
+- You sign from CI (use the Node.js binding or JSON-RPC daemon
+  directly).
+- You have one or two signing operations per release (the
+  overhead of CRD lifecycle isn't worth it).
+- You're not on Kubernetes.
+
+## The ceremony lifecycle
+
+```yaml
+apiVersion: confium.org/v1
+kind: ConfiumSigningCeremony
+metadata:
+  name: release-v1-2-3
+  namespace: releases
+spec:
+  scheme: cmp20          # or gg18
+  threshold: 3
+  partyCount: 5
+  messageRef:
+    configMap: release-v1-2-3-payload
+    key: artifact.bin
+  outputRef:
+    secret: release-v1-2-3-signature
+```
+
+Once applied, the controller:
+
+1. **Pending** — ceremony created, waiting for the threshold
+   signers (pods in the namespace) to register their
+   participation.
+2. **Active** — T-of-N signers connected; threshold protocol
+   in progress.
+3. **Completed** — composite signature assembled. Written to
+   the output Secret as `signature` (base64 DER) + `certificate`
+   (Fulcio-issued, Mode 4 only) + `transparency-entry`
+   (inclusion proof).
+
+Status reflects the current phase:
+
+```yaml
+status:
+  phase: completed
+  startedAt: "2026-08-01T10:32:14Z"
+  completedAt: "2026-08-01T10:32:47Z"
+  signatureSecret: release-v1-2-3-signature
+```
+
+If the threshold isn't met within the ceremony's timeout,
+status moves to `failed` with an error message identifying
+which signers didn't respond.
+
+## Where signers come from
+
+The operator doesn't manage signer pods directly — that's the
+job of the existing `StatefulSet` pattern from the Helm chart.
+The operator watches for `ConfiumSigningCeremony` resources and
+expects signers (each running `confium-signerd` as a sidecar
+or daemon) to register against the ceremony's session id.
+
+Typical deployment:
+
+```
+┌───────────────────────────────────────────┐
+│  Namespace: releases                       │
+│                                            │
+│  ConfiumSigningCeremony (CRD)              │
+│         ↓                                  │
+│  Controller (confium-operator pod)         │
+│         ↓ dispatch                         │
+│  Signer pods (each runs confium-signerd)   │
+│   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ... │
+│   │sig-1 │ │sig-2 │ │sig-3 │ │sig-4 │     │
+│   └──┬───┘ └──┬───┘ └──┬───┘ └──┬───┘     │
+│      └────────┴────────┴────────┘         │
+│               ↓                           │
+│      Confium coordinator                  │
+│               ↓                           │
+│      Output Secret                        │
+└───────────────────────────────────────────┘
+```
+
+## GitOps integration
+
+Because ceremonies are CRDs, they're declarative — which means
+they're perfect for GitOps. Argo CD / Flux can:
+
+- Sync the `ConfiumSigningCeremony` from git on every release
+  tag.
+- Detect drift if someone manually patches a ceremony in
+  cluster.
+- Roll back automatically (re-apply the previous ceremony) if
+  the threshold fails.
+
+```yaml
+# release-manifest.yaml — checked into your release repo
+apiVersion: confium.org/v1
+kind: ConfiumSigningCeremony
+metadata:
+  name: release-${TAG}
+spec:
+  scheme: cmp20
+  threshold: 3
+  partyCount: 5
+  messageRef:
+    configMap: release-${TAG}-payload
+    key: artifact.bin
+  outputRef:
+    secret: release-${TAG}-signature
+```
+
+```sh
+# Argo CD / Flux picks this up, the operator handles the rest.
+```
+
+## What's exposed
+
+| CRD | Purpose |
+| --- | --- |
+| `ConfiumSigningCeremony` | A single signing session. Spec: scheme, threshold, party count, message ref, output ref. Status: phase, timestamps, signature secret, error. |
+
+The operator today manages ceremonies only. Threshold-key
+management, share rotation, and signer identity are handled
+by the Helm chart + `confium-signerd` separately. The
+`ConfiumSigningCeremony` is the user-facing API; the rest
+is platform-team plumbing.
+
+## See also
+
+- [Kubernetes deployment](/use-cases/kubernetes-deployment/) —
+  the underlying Helm chart that the operator depends on.
+- [Daemon](/software/daemon/) — the JSON-RPC surface that
+  `confium-signerd` talks to.
+- [Terraform-managed keys](/use-cases/terraform-managed-keys/)
+  — the IaC complement to the K8s operator.

--- a/src/content/use_cases/public-verification-endpoint.mdx
+++ b/src/content/use_cases/public-verification-endpoint.mdx
@@ -1,0 +1,140 @@
+---
+title: Public verification endpoint
+description: "Run an HTTP verification service that anyone can hit to verify Confium signatures and transparency proofs. Drop-in alternative to the JSON-RPC daemon for web-facing verifiers. Powering browser-side verification, third-party audit, public accountability."
+mode: cross
+order: 32
+---
+
+# Public verification endpoint
+
+The JSON-RPC daemon (`confiumd`) is great for internal callers
+that already speak the protocol. For **public verification** —
+anyone on the internet can check a signature against the
+published key — you want a simple HTTP API.
+
+`confium-verify-server` is that service. Three endpoints, no
+authentication by default, no state, no secrets.
+
+## The endpoints
+
+| Method + path | Body | Returns |
+| --- | --- | --- |
+| `POST /verify/composite` | `{ message, signature, public_key }` (base64) | `{ valid: bool, components_checked: u32 }` |
+| `POST /verify/inclusion` | `{ leaf_hash, proof, tree_size, root }` | `204 No Content` on success, `422` on failure |
+| `GET /healthz` | — | `200 OK` |
+
+That's it. No sessions, no auth, no rate limiting built in
+(put it behind Cloudflare / a CDN / an API gateway for
+production).
+
+## When to run a verify-server
+
+| Setting | Why |
+| --- | --- |
+| Open-source project with public signing keys | Anyone can verify releases without installing Confium |
+| Regulatory transparency | Auditors verify without trusting the operator |
+| Browser-side verification with CORS | The WASM verifier is great, but a hosted verify endpoint lets pure-HTML pages verify too |
+| Third-party audit pipeline | CI / cron jobs hit the endpoint to check log entries |
+
+You don't need a verify-server if:
+
+- You verify in-process (use the Ruby / Python / Node / WASM
+  bindings).
+- Your verifiers are all internal (use the JSON-RPC daemon
+  over a Unix socket).
+
+## Run it
+
+```sh
+cargo install confium-verify-server --locked
+confium-verify-server --addr 0.0.0.0 --port 8082
+```
+
+Verify:
+
+```sh
+curl http://localhost:8082/healthz
+# OK
+
+curl -X POST http://localhost:8082/verify/composite \
+     -H 'content-type: application/json' \
+     -d '{
+           "message": "'$(base64 -w0 message.bin)'",
+           "signature": "'$(base64 -w0 sig.bin)'",
+           "public_key": "'$(base64 -w0 pubkey.bin)'"
+         }'
+# {"valid":true,"components_checked":2}
+```
+
+## Deployment shape
+
+```
+┌─────────────────────────────────────────┐
+│  Internet                                │
+│    ↓ HTTPS                               │
+│  Cloudflare / CDN (rate limit + DDoS)    │
+│    ↓                                     │
+│  confium-verify-server (N replicas)      │
+│    stateless — scale horizontally        │
+└─────────────────────────────────────────┘
+```
+
+The service is stateless. Scale horizontally behind a load
+balancer. No shared database, no coordinator connection, no
+signing capability — verify-only by design.
+
+## Why a separate server (not just the daemon)?
+
+| Concern | JSON-RPC daemon | Verify-server |
+| --- | --- | --- |
+| Protocol | JSON-RPC 2.0 over Unix socket / TCP | REST over HTTP |
+| Auth model | Trusted internal callers | Public, anonymous |
+| Methods | 29+ (signing, eval, PKI, plugins, etc.) | 2 (composite_verify, inclusion_verify) |
+| CORS | None | Permissive (any origin) |
+| Surface area | Large (every JSON-RPC method) | Tiny (2 endpoints) |
+| Risk if compromised | Signing key access | None — verifier only |
+
+The verify-server exists because the blast radius of exposing
+the daemon publicly is too large. A misconfigured daemon
+could leak signing keys; a misconfigured verify-server leaks
+nothing (there's nothing to leak).
+
+## Browser-side verification via fetch
+
+For static HTML pages (release notes, documentation sites)
+that want to embed "verify this release" without shipping
+the WASM bundle:
+
+```html
+<button onclick="verifyRelease()">Verify signature</button>
+<p id="result"></p>
+
+<script>
+async function verifyRelease() {
+  const r = await fetch('https://verify.confium.org/verify/composite', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      message: btoa('hello'),
+      signature: sigBase64,
+      public_key: pubBase64,
+    }),
+  });
+  const result = await r.json();
+  document.getElementById('result').textContent =
+    result.valid ? '✓ verified' : '✗ invalid';
+}
+</script>
+```
+
+The user sees verification happen without installing
+anything.
+
+## See also
+
+- [Polyglot verification](/use-cases/polyglot-verification/) —
+  the JSON-RPC daemon pattern for internal callers.
+- [Operate a transparency log](/use-cases/operate-transparency-log/)
+  — the log server this verifies against.
+- [WASM API reference](/docs/wasm-api/) — when in-browser WASM
+  verification is preferable to a hosted endpoint.

--- a/src/content/use_cases/terraform-managed-keys.mdx
+++ b/src/content/use_cases/terraform-managed-keys.mdx
@@ -1,0 +1,175 @@
+---
+title: Terraform-managed threshold keys
+description: "Provision Confium threshold keys, signing ceremonies, transparency logs, and shares via Terraform. Infrastructure-as-code for cryptographic key management. The confium Terraform provider."
+mode: cross
+order: 31
+---
+
+# Terraform-managed threshold keys
+
+Terraform is the standard for declarative infrastructure.
+Cryptographic key management has historically been
+imperative — run a CLI command, copy the key, hope you
+remembered to back it up. The Confium Terraform provider
+brings **infra-as-code to key custody**.
+
+## The four resources
+
+| Resource | What it manages |
+| --- | --- |
+| `confium_threshold_key` | Generate + manage a threshold keyset (the public key + N shares) |
+| `confium_signing_ceremony` | Trigger a signing ceremony against an existing threshold key |
+| `confium_transparency_log` | Manage a `log.confium.org`-style endpoint (URL + auth) |
+| `confium_share` | Manage individual share blobs (assign to specific signers / HSMs) |
+
+## When Terraform is the right tool
+
+| Setting | Why Terraform |
+| --- | --- |
+| Multi-environment key management (dev / staging / prod) | Each environment's keys are versioned in its own state |
+| Cloud + on-prem hybrid | `confium_share` resources distribute shares across AWS KMS, on-prem HSM, etc. |
+| Audit / compliance | Every key change goes through Terraform plan / apply with review |
+| Cross-team coordination | Platform team owns the Terraform; security team reviews the plan |
+
+You don't need Terraform if:
+
+- You have a small, static keyset (use the CLI once).
+- Your signing infrastructure changes rarely.
+- You're not already using Terraform for adjacent resources.
+
+## Example: provision a 3-of-5 threshold key
+
+```hcl
+terraform {
+  required_providers {
+    confium = {
+      source  = "confium/confium"
+      version = "~> 0.1"
+    }
+  }
+}
+
+provider "confium" {
+  coordinator_url = "tcp://coordinator.confium.internal:7443"
+}
+
+# Generate a 3-of-5 threshold keyset
+resource "confium_threshold_key" "release_signing" {
+  scheme    = "cmp20"
+  threshold = 3
+  party_count = 5
+
+  algorithm = "ecdsa-p256"
+}
+
+# Distribute the 5 shares across signers
+resource "confium_share" "signer_1" {
+  key_id     = confium_threshold_key.release_signing.id
+  signer_id  = "release-eng-1"
+  store_backend = "hsm"   # on-prem HSM
+  store_ref  = "pkcs11:slot=0"
+}
+
+resource "confium_share" "signer_2" {
+  key_id     = confium_threshold_key.release_signing.id
+  signer_id  = "release-eng-2"
+  store_backend = "cloud"
+  store_ref  = "aws-kms:arn:aws:kms:us-east-1:111:key/abc"
+}
+
+# ... signers 3-5 similarly
+
+output "release_signing_public_key" {
+  value     = confium_threshold_key.release_signing.public_key
+  sensitive = false   # public key is safe to surface
+}
+
+output "release_signing_key_id" {
+  value = confium_threshold_key.release_signing.id
+}
+```
+
+Running `terraform apply`:
+
+1. Provisions the threshold key via the coordinator (DKG across
+   the configured signers).
+2. Distributes the 5 shares to their configured backends
+   (HSM, AWS KMS, etc.).
+3. Records the public key + key id in Terraform state.
+
+Running `terraform destroy` triggers share revocation via
+`confium-tc-reshare` — the key is rotated out and the old
+shares invalidated. (This is the most dangerous Terraform
+operation in the workflow — review carefully.)
+
+## Trigger a signing ceremony via Terraform
+
+For releases that are part of your infrastructure lifecycle
+(container images baked into AMIs, signed TLS certs that
+gate deployments):
+
+```hcl
+resource "confium_signing_ceremony" "release_v123" {
+  key_id    = confium_threshold_key.release_signing.id
+  message   = filebase64("${path.module}/release-v123.tar.gz")
+
+  threshold = 3
+  timeout_seconds = 600
+}
+
+output "release_signature" {
+  value     = confium_signing_ceremony.release_v123.signature
+  sensitive = true
+}
+```
+
+`terraform apply` blocks until the ceremony completes (or
+times out). The signature is captured in state.
+
+For most release pipelines, you'll want the K8s operator or a
+CI-driven ceremony instead — Terraform's blocking apply isn't
+ideal for fast release loops. But for slow, high-stakes
+signing (root CA rotation, treaty signing, key refresh),
+Terraform gives you plan / review / apply discipline.
+
+## Manage transparency-log endpoints
+
+```hcl
+resource "confium_transparency_log" "production" {
+  url       = "https://log.confium.org"
+  auth_type = "oidc"
+  audience  = "log.confium.org"
+}
+
+# Reference it from any signing ceremony:
+resource "confium_signing_ceremony" "release_v123" {
+  # ...
+  transparency_log_id = confium_transparency_log.production.id
+}
+```
+
+Changing the log endpoint (e.g., promoting from staging to
+production) is a Terraform plan + apply, not a config-file
+edit and redeploy.
+
+## What Terraform manages (and what it doesn't)
+
+| Managed | Not managed |
+| --- | --- |
+| Threshold key generation + share distribution | Coordinator process lifecycle (use the Helm chart or Docker) |
+| Share-to-signer-to-backend assignment | Signer process lifecycle (use K8s / systemd / Docker) |
+| Signing ceremony lifecycle (trigger, wait, capture sig) | Real-time signing for hot paths (use the daemon or bindings) |
+| Transparency-log endpoint config | The log server itself (deploy separately) |
+
+Terraform owns the **declarative key-management surface**.
+Runtime infra is owned by the deployment stack (Helm, Docker,
+etc.).
+
+## See also
+
+- [Kubernetes operator](/use-cases/kubernetes-operator/) — the
+  K8s-native alternative for ceremony lifecycle.
+- [Kubernetes deployment](/use-cases/kubernetes-deployment/) —
+  coordinator + signers + transparency-log topology.
+- [Distributed custody](/use-cases/distributed-custody/) — the
+  multi-backend share-distribution pattern.


### PR DESCRIPTION
## Summary

Workspace shipped 5 new crates for operations, IaC, and public verification. This PR syncs the site to 57 crates.

### 5 new crates

| Crate | Role |
|---|---|
| `confium-operator` | Kubernetes operator — `ConfiumSigningCeremony` CRD + controller. GitOps threshold signing. |
| `confium-terraform-provider` | Terraform provider (Go). 4 resources: `threshold_key`, `signing_ceremony`, `transparency_log`, `share`. |
| `confium-signerd` | Distributed threshold signing daemon. One per signer, connects to coordinator. |
| `confium-verify-server` | HTTP verification service. Stateless, anonymous, public-facing. |
| `confium-fuzz` | Fuzzing targets for security-critical surfaces. |

### 3 new use cases

| Page | Covers |
|---|---|
| **`/use-cases/kubernetes-operator/`** | Declarative threshold signing via CRDs. Ceremony lifecycle (Pending → Active → Completed). GitOps with Argo CD / Flux. Sample manifest. |
| **`/use-cases/terraform-managed-keys/`** | Infra-as-code for key custody. 4 resources documented. Sample 3-of-5 threshold key with multi-backend share distribution (HSM + AWS KMS). |
| **`/use-cases/public-verification-endpoint/`** | Public REST verification service. 3 endpoints, stateless. Browser-side verification via fetch. Why a separate server vs the JSON-RPC daemon (blast radius). |

### Updated

- **`/docs/components/`** — 57 crates (was 52). New "Operations / IaC / Services" section (4 crates) + `confium-fuzz` added to "Performance / Evaluation".

## Test plan

- [x] `npx astro build` — 154 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] All 4 affected pages render

## Audience expansion

These three use cases target three new audience segments:
- **Platform engineers** running K8s in production (operator)
- **Infrastructure / DevOps engineers** using Terraform (provider)
- **Open-source maintainers + auditors** who want public verification (verify-server)
