### PR TITLE
feat(polish): JSON-LD Article schema + reading time + Edit on GitHub

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -45,14 +45,26 @@ const filteredHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
       )}
 
       <div>
-        {sourcePath && (
-          <p class="mb-4 text-xs font-mono text-muted-foreground">
-            Source: {sourcePath}
-          </p>
-        )}
         <Prose>
           <slot />
         </Prose>
+        {sourcePath && (
+          <footer class="mt-10 pt-6 border-t border-line text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+            <a
+              href={`https://github.com/confium/confium.github.io/edit/main/${sourcePath}`}
+              class="text-accent hover:text-accent-deep font-medium inline-flex items-center gap-1"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z" />
+              </svg>
+              Edit on GitHub
+            </a>
+            <span aria-hidden="true" class="text-faint">·</span>
+            <span class="font-mono text-faint">{sourcePath}</span>
+          </footer>
+        )}
       </div>
 
       {filteredHeadings.length >= 4 && (

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import PageHero from '../../components/astro/PageHero.astro';
 
 export async function getStaticPaths() {
   const posts = (await getCollection('blog')).sort((a, b) => {
@@ -27,6 +26,36 @@ const sidebar = allPosts.map((p) => ({
 const dateStr = post.data.date
   ? post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
   : '';
+
+// Reading time: rough estimate from word count. ~225 wpm for technical prose.
+const body = post.body;
+const words = body.split(/\s+/).filter(Boolean).length;
+const readingMinutes = Math.max(1, Math.round(words / 225));
+
+// JSON-LD Article schema for Google rich results.
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: post.data.title,
+  description: post.data.description,
+  datePublished: post.data.date?.toISOString(),
+  dateModified: post.data.date?.toISOString(),
+  author: {
+    '@type': 'Organization',
+    name: 'Confium contributors',
+    url: 'https://github.com/confium',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Confium',
+    url: 'https://www.confium.org',
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': new URL(`/blog/${post.id}/`, Astro.site).toString(),
+  },
+  keywords: (post.data.tags ?? []).join(', '),
+};
 ---
 
 <DocsLayout
@@ -35,9 +64,19 @@ const dateStr = post.data.date
   sidebar={sidebar}
   headings={headings}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
+
   <article>
-    <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-400 mb-3">
-      {post.data.category} · {dateStr}
+    <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-400 mb-3 flex items-center gap-2 flex-wrap">
+      <span>{post.data.category}</span>
+      {dateStr && (
+        <>
+          <span aria-hidden="true">·</span>
+          <time datetime={post.data.date?.toISOString()}>{dateStr}</time>
+        </>
+      )}
+      <span aria-hidden="true">·</span>
+      <span>{readingMinutes} min read</span>
     </p>
     <h1 class="text-4xl font-bold tracking-tight mb-3">{post.data.title}</h1>
     {post.data.author && (
@@ -49,8 +88,24 @@ const dateStr = post.data.date
       <Content />
     </div>
 
+    <footer class="mt-12 pt-6 border-t border-line text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+      <a
+        href={`https://github.com/confium/confium.github.io/edit/main/src/content/blog/${post.id}.mdx`}
+        class="text-accent hover:text-accent-deep font-medium inline-flex items-center gap-1"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z" />
+        </svg>
+        Edit on GitHub
+      </a>
+      <span aria-hidden="true" class="text-faint">·</span>
+      <span class="font-mono text-faint">src/content/blog/{post.id}.mdx</span>
+    </footer>
+
     {post.data.tags && post.data.tags.length > 0 && (
-      <div class="mt-12 pt-6 border-t border-line">
+      <div class="mt-8">
         <p class="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2">Tags</p>
         <div class="flex flex-wrap gap-2">
           {post.data.tags.map((tag: string) => (

--- a/src/pages/concepts/[...id].astro
+++ b/src/pages/concepts/[...id].astro
@@ -27,6 +27,7 @@ const sidebar = allConcepts
   description={doc.data.description}
   sidebar={sidebar}
   headings={headings}
+  sourcePath={`src/content/concepts/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>

--- a/src/pages/docs/[...id].astro
+++ b/src/pages/docs/[...id].astro
@@ -27,6 +27,7 @@ const sidebar = allDocs
   description={doc.data.description}
   sidebar={sidebar}
   headings={headings}
+  sourcePath={`src/content/docs/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>

--- a/src/pages/use-cases/[id].astro
+++ b/src/pages/use-cases/[id].astro
@@ -27,6 +27,7 @@ const sidebar = allItems
   description={doc.data.description}
   sidebar={sidebar}
   headings={headings}
+  sourcePath={`src/content/use_cases/${doc.id}.mdx`}
 >
   <Content />
 </DocsLayout>


### PR DESCRIPTION
## Summary

Three site-polish improvements. No new pages — existing surfaces get better.

### JSON-LD Article schema on every blog post

Blog posts now emit schema.org `Article` structured data. Google rich-result eligibility for: headline, `datePublished`, author, publisher, `mainEntityOfPage`, keywords. Renders inline via `<script type="application/ld+json">`.

### Reading time on blog posts

Estimated from word count (~225 wpm for technical prose). Shows as "N min read" in the metadata strip alongside category + date. Helps readers decide whether to read now or bookmark.

### Edit on GitHub on every content page

`DocsLayout` now renders an Edit-on-GitHub footer when the page passes its `sourcePath`. All four content collections wired:

- `docs/[...id].astro` → `src/content/docs/<id>.mdx`
- `concepts/[...id].astro` → `src/content/concepts/<id>.mdx`
- `use-cases/[id].astro` → `src/content/use_cases/<id>.mdx`
- `blog/[...id].astro` → `src/content/blog/<id>.mdx`

Each link points at the edit URL on GitHub. One click from "found a typo" to a PR draft.

## Test plan

- [x] `npx astro build` — 154 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] JSON-LD `"@type":"Article"` renders on blog
- [x] "Edit on GitHub" renders on docs, concepts, use-cases, blog
- [x] "N min read" renders on blog
