### PR TITLE
feat(polish): copy buttons on code blocks + print styles + related posts

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -178,6 +178,53 @@ if (schemaType === 'FAQPage' && faqEntries.length > 0) {
       })();
     </script>
 
+    <script is:inline>
+      // Progressive enhancement: copy button on every code block.
+      // Matches the RNP sister site's implementation.
+      (function () {
+        const enhanceCopy = () => {
+          document
+            .querySelectorAll('.prose pre:not([data-copyable])')
+            .forEach((pre) => {
+              pre.setAttribute('data-copyable', '');
+              const btn = document.createElement('button');
+              btn.type = 'button';
+              btn.className = 'copy-btn';
+              btn.textContent = 'Copy';
+              btn.setAttribute('aria-label', 'Copy code to clipboard');
+              btn.addEventListener('click', async () => {
+                const code = pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+                try {
+                  await navigator.clipboard.writeText(code);
+                } catch {
+                  const ta = document.createElement('textarea');
+                  ta.value = code;
+                  ta.style.position = 'fixed';
+                  ta.style.opacity = '0';
+                  document.body.appendChild(ta);
+                  ta.select();
+                  document.execCommand('copy');
+                  ta.remove();
+                }
+                btn.textContent = 'Copied';
+                btn.classList.add('copied');
+                setTimeout(() => {
+                  btn.textContent = 'Copy';
+                  btn.classList.remove('copied');
+                }, 1500);
+              });
+              pre.appendChild(btn);
+            });
+        };
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', enhanceCopy, { once: true });
+        } else {
+          enhanceCopy();
+        }
+        document.addEventListener('astro:after-swap', enhanceCopy);
+      })();
+    </script>
+
     <style>
       body {
         background: var(--bg);

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -116,5 +116,34 @@ const articleSchema = {
         </div>
       </div>
     )}
+
+    {(() => {
+      const scored = allPosts
+        .filter((p) => p.id !== post.id)
+        .map((p) => ({
+          post: p,
+          overlap: (p.data.tags ?? []).filter((t: string) => (post.data.tags ?? []).includes(t)).length,
+        }))
+        .sort((a, b) => b.overlap - a.overlap || (b.post.data.date?.getTime() ?? 0) - (a.post.data.date?.getTime() ?? 0));
+      // Prefer tag-matched posts; fall back to most-recent if none overlap.
+      const tagMatches = scored.filter((r) => r.overlap > 0);
+      const related = (tagMatches.length > 0 ? tagMatches : scored).slice(0, 3);
+      if (related.length === 0) return null;
+      const heading = tagMatches.length > 0 ? 'Related posts' : 'More from the blog';
+      return (
+        <section class="mt-16 pt-8 border-t border-line not-prose">
+          <p class="mono-label mb-4">{heading}</p>
+          <div class="grid sm:grid-cols-3 gap-4">
+            {related.map(({ post: rp }) => (
+              <a href={`/blog/${rp.id}/`} class="card card-hover group block p-5">
+                <p class="text-xs font-mono text-faint">{rp.data.category}</p>
+                <h3 class="mt-1 font-sans text-base font-bold group-hover:text-accent transition-colors">{rp.data.title}</h3>
+                <p class="mt-1 text-xs text-muted line-clamp-2">{rp.data.description}</p>
+              </a>
+            ))}
+          </div>
+        </section>
+      );
+    })()}
   </article>
 </DocsLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -412,3 +412,102 @@ body {
   color: var(--shiki-dark) !important;
   background-color: var(--shiki-dark-bg) !important;
 }
+
+/* ----------------------------------------------------------- code copy button */
+
+pre[data-copyable] {
+  position: relative;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid rgb(255 255 255 / 0.16);
+  border-radius: 0.4rem;
+  background: rgb(255 255 255 / 0.06);
+  color: rgb(232 234 242 / 0.65);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, opacity 0.15s;
+  opacity: 0;
+}
+pre[data-copyable]:hover .copy-btn,
+.copy-btn:focus-visible {
+  opacity: 1;
+}
+.copy-btn:hover {
+  color: #fff;
+  border-color: rgb(255 255 255 / 0.45);
+}
+.copy-btn.copied {
+  color: var(--color-teal);
+  border-color: var(--color-teal);
+  opacity: 1;
+}
+
+/* ----------------------------------------------------------- print styles */
+
+@media print {
+  .site-header,
+  .site-footer,
+  .search-btn,
+  .icon-btn,
+  .copy-btn,
+  .toc-nav,
+  aside,
+  nav[aria-label="Breadcrumb"],
+  .reveal {
+    display: none !important;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+    font-size: 11pt;
+    line-height: 1.5;
+  }
+
+  .prose {
+    max-width: 100% !important;
+  }
+
+  .prose pre,
+  .prose code {
+    background: #f4f4f4 !important;
+    color: #1a1a1a !important;
+    border: 1px solid #ccc !important;
+    white-space: pre-wrap;
+    word-break: break-word;
+    page-break-inside: avoid;
+  }
+
+  .prose h2,
+  .prose h3 {
+    page-break-after: avoid;
+  }
+
+  a {
+    text-decoration: underline;
+    color: #1a7bec;
+  }
+
+  a::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  .card,
+  .hero-gradient,
+  .page-hero-bg {
+    background: white !important;
+    border: 1px solid #ccc !important;
+    box-shadow: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Three UX improvements on existing pages. No new pages.

### Copy buttons on every code block
Ported the copy-button progressive enhancement from the RNP sister site. Every `<pre>` inside `.prose` gets a "Copy" button in the top-right corner. Appears on hover; uses the Clipboard API with a textarea fallback. Re-runs on `astro:after-swap` for view transitions.

### Print styles
`@media print` stylesheet:
- Hides nav, footer, sidebar, TOC, copy buttons, reveal wrappers
- Black-on-white, 11pt, 1.5 line-height
- Wraps long code lines (`page-break-inside: avoid`)
- Appends `href` URLs after link text (standard print convention)
- Strips card shadows + gradients to plain borders

### Related posts on blog
3-card grid at the bottom of every blog post. Algorithm: score by tag overlap → sort by overlap desc, then date desc → if tag-matched posts exist show those ("Related posts"), otherwise fall back to most-recent ("More from the blog").

## Test plan

- [x] `npx astro build` — 154 pages, no errors
- [x] `lychee --offline` — 0 errors
- [x] Copy button script (`enhanceCopy`) renders on docs pages
- [x] Print CSS (`@media print`) present in built CSS
- [x] "More from the blog" renders on the introducing-confium post (fallback case — no tag overlap)
