### PR TITLE
perf(layout): SiteHeader client:load → client:idle — perf 89 → 92

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -137,7 +137,7 @@ if (schemaType === 'FAQPage' && faqEntries.length > 0) {
     </script>
   </head>
   <body class={bodyClass}>
-    <SiteHeader client:load overlay={headerOverlay} />
+    <SiteHeader client:idle overlay={headerOverlay} />
     <SiteSearch client:only="vue" />
     <main data-pagefind-body>
       <slot />


### PR DESCRIPTION
## Summary

One-line change: SiteHeader hydration from `client:load` to `client:idle`.

The header is server-rendered (Astro SSR) — it's visually correct on first paint. The Vue hydration (scroll state, theme toggle, mobile menu, Cmd+K) can safely wait until the browser is idle.

### Measured impact

| Metric | Before | After |
|---|---|---|
| **Performance** | 89 | **92** |
| FCP | 2.6s | **2.4s** |
| LCP | 3.2s | **2.9s** |

## Test plan

- [x] `npx astro build` — 154 pages, no errors
- [x] Lighthouse performance: **92**
- [x] Header still works (scroll detection, theme toggle, mobile menu, search)
