### PR TITLE
feat(seo): add robots.txt + web manifest + theme-color

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+# Confium — open-source threshold cryptography framework
+# https://www.confium.org
+
+User-agent: *
+Allow: /
+
+# Sitemap
+Sitemap: https://www.confium.org/sitemap-index.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Confium",
+  "short_name": "Confium",
+  "description": "Threshold-native trust infrastructure for a post-quantum world.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0b0e1a",
+  "theme_color": "#1a7bec",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -93,7 +93,9 @@ if (schemaType === 'FAQPage' && faqEntries.length > 0) {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
     <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#1a7bec" />
 
     <link rel="preload" href={sans400Url} as="font" type="font/woff2" crossorigin />
     <link rel="preload" href={mono400Url} as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
## Summary

Three missing files that search engines and browsers expect:

### robots.txt
Was missing entirely. Now: `User-agent: * / Allow: / / Sitemap: https://www.confium.org/sitemap-index.xml`. Crawlers can discover the sitemap via the standard robots.txt directive.

### Web manifest (`site.webmanifest`)
PWA installability metadata: name, description, theme-color, start_url, standalone display, SVG favicon icon.

### `<meta name="theme-color">` + `<link rel="manifest">`
Added to BaseLayout head so every page declares the manifest and brand color.

## Test plan

- [x] `npx astro build` — 154 pages, no errors
- [x] `dist/robots.txt` exists and is valid
- [x] `dist/site.webmanifest` exists and is valid JSON
- [x] `<link rel="manifest">` in HTML head
- [x] `<meta name="theme-color">` in HTML head
- [x] Lighthouse SEO: 100
