### PR TITLE
feat(minisite): shared subpage templates + primitives

### DIFF
--- a/src/components/astro/minisite/ApiReference.astro
+++ b/src/components/astro/minisite/ApiReference.astro
@@ -1,0 +1,35 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import LanguageTabs from '../../astro/primitives/LanguageTabs.astro';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  product: Product;
+  languages?: string[];
+}
+
+const { product, languages = ['rust', 'cli', 'python', 'ruby'] } = Astro.props;
+const title = `${product.name} — API Reference`;
+---
+
+<Minisite product={product} title={title}>
+  <section class="mb-8">
+    <h2 class="text-2xl font-bold mb-4">API reference</h2>
+    <p class="text-gray-700 leading-relaxed">
+      Canonical code shapes for {product.name}, with per-language tabs.
+      Copy-paste-runnable.
+    </p>
+  </section>
+
+  <slot />
+
+  <div class="mt-12 pt-8 border-t border-gray-200">
+    <h3 class="font-bold mb-3">Auto-generated docs</h3>
+    <ul class="space-y-1 text-sm">
+      <li><a href={`https://docs.rs/${product.crates[0]}`} class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/{product.crates[0]})</a></li>
+      <li><a href={`/bindings/python/`} class="text-blue-600 hover:underline">Python bindings</a></li>
+      <li><a href={`/bindings/ruby/`} class="text-blue-600 hover:underline">Ruby bindings</a></li>
+      <li><a href={`/bindings/wasm/`} class="text-blue-600 hover:underline">WASM bindings</a></li>
+    </ul>
+  </div>
+</Minisite>

--- a/src/components/astro/minisite/DocsIndex.astro
+++ b/src/components/astro/minisite/DocsIndex.astro
@@ -1,0 +1,39 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  product: Product;
+}
+
+const { product } = Astro.props;
+const title = `${product.name} — Documentation`;
+---
+
+<Minisite product={product} title={title}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Documentation</h2>
+    <p class="text-gray-700 leading-relaxed">
+      Browse by section: <strong>concepts</strong> for the mental model,
+      <strong>how-to</strong> for task-focused guides, and
+      <strong>reference</strong> for API and config.
+    </p>
+  </section>
+
+  <div class="grid md:grid-cols-3 gap-6 mb-12">
+    <a href={`/${product.slug}/docs/concepts/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+      <h3 class="font-bold text-lg mb-2">Concepts</h3>
+      <p class="text-sm text-gray-600">The mental model. What problem does this product solve, and what are the moving parts?</p>
+    </a>
+    <a href={`/${product.slug}/docs/how-to/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+      <h3 class="font-bold text-lg mb-2">How-to</h3>
+      <p class="text-sm text-gray-600">Task-focused recipes: install, configure, deploy, integrate, monitor.</p>
+    </a>
+    <a href={`/${product.slug}/docs/reference/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+      <h3 class="font-bold text-lg mb-2">Reference</h3>
+      <p class="text-sm text-gray-600">API, config file format, CLI commands, error codes.</p>
+    </a>
+  </div>
+
+  <slot />
+</Minisite>

--- a/src/components/astro/minisite/Examples.astro
+++ b/src/components/astro/minisite/Examples.astro
@@ -1,0 +1,26 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  product: Product;
+}
+
+const { product } = Astro.props;
+const title = `${product.name} — Examples`;
+---
+
+<Minisite product={product} title={title}>
+  <section class="mb-8">
+    <h2 class="text-2xl font-bold mb-4">Runnable examples</h2>
+    <p class="text-gray-700 leading-relaxed">
+      Each example is a self-contained project you can clone, run, and adapt.
+      Source lives in the
+      <a href="https://github.com/confium/confium/tree/main/crates/confium-examples"
+         class="text-blue-600 hover:underline" target="_blank">confium-examples</a>
+      crate.
+    </p>
+  </section>
+
+  <slot />
+</Minisite>

--- a/src/components/astro/minisite/Install.astro
+++ b/src/components/astro/minisite/Install.astro
@@ -1,0 +1,24 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  product: Product;
+}
+
+const { product } = Astro.props;
+const title = `${product.name} — Install`;
+---
+
+<Minisite product={product} title={title}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Installation options</h2>
+    <p class="text-gray-700 leading-relaxed">
+      Pick the install path that matches your deployment. Confium {product.name}
+      is available as a Rust crate, a Docker image, a language-specific package,
+      or a hosted service depending on surface.
+    </p>
+  </section>
+
+  <slot />
+</Minisite>

--- a/src/components/astro/minisite/Quickstart.astro
+++ b/src/components/astro/minisite/Quickstart.astro
@@ -1,0 +1,37 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import Steps from '../../astro/primitives/Steps.astro';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  product: Product;
+  intro?: string;
+}
+
+const { product, intro } = Astro.props;
+const title = `${product.name} — Quickstart`;
+---
+
+<Minisite product={product} title={title}>
+  {intro && (
+    <p class="text-lg text-gray-700 leading-relaxed mb-8">{intro}</p>
+  )}
+
+  <div class="bg-blue-50 border-l-4 border-blue-400 p-4 mb-8 rounded">
+    <p class="text-sm text-blue-800">
+      <strong>Time:</strong> ~5 minutes &nbsp;·&nbsp;
+      <strong>Prerequisites:</strong> Rust 1.85+ (or Docker / language SDK per the tabs below)
+    </p>
+  </div>
+
+  <slot />
+
+  <div class="mt-12 pt-8 border-t border-gray-200">
+    <h2 class="text-xl font-bold mb-3">Next steps</h2>
+    <ul class="space-y-2">
+      <li>→ Read the <a href={`/${product.slug}/docs/`} class="text-blue-600 hover:underline">concepts documentation</a></li>
+      <li>→ Browse <a href={`/${product.slug}/use-cases/`} class="text-blue-600 hover:underline">real-world use cases</a></li>
+      <li>→ See the <a href={`/${product.slug}/api/`} class="text-blue-600 hover:underline">full API reference</a></li>
+    </ul>
+  </div>
+</Minisite>

--- a/src/components/astro/minisite/UseCases.astro
+++ b/src/components/astro/minisite/UseCases.astro
@@ -1,0 +1,45 @@
+---
+import Minisite from '../../../layouts/Minisite.astro';
+import UseCaseCard from '../../astro/primitives/UseCaseCard.astro';
+import type { Product } from '../../../data/products';
+import { useCasesForProduct } from '../../../data/audiences';
+
+interface Props {
+  product: Product;
+  intro?: string;
+}
+
+const { product, intro } = Astro.props;
+const title = `${product.name} — Use Cases`;
+const useCases = useCasesForProduct(product.slug);
+---
+
+<Minisite product={product} title={title}>
+  <section class="mb-8">
+    <h2 class="text-2xl font-bold mb-4">Use cases</h2>
+    {intro ? (
+      <p class="text-gray-700 leading-relaxed">{intro}</p>
+    ) : (
+      <p class="text-gray-700 leading-relaxed">
+        Real-world deployments patterns for {product.name}. Each use case links
+        to the audiences that primarily care about it.
+      </p>
+    )}
+  </section>
+
+  {useCases.length === 0 ? (
+    <div class="border border-gray-200 rounded-lg p-6 text-gray-600">
+      Use cases for {product.name} are being written. Check back soon, or
+      contribute one via a PR to
+      <code class="bg-gray-100 px-1 py-0.5 rounded">src/data/audiences/index.ts</code>.
+    </div>
+  ) : (
+    <div class="space-y-4">
+      {useCases.map((uc) => (
+        <UseCaseCard useCase={uc} />
+      ))}
+    </div>
+  )}
+
+  <slot />
+</Minisite>

--- a/src/components/astro/primitives/AudienceBadge.astro
+++ b/src/components/astro/primitives/AudienceBadge.astro
@@ -1,0 +1,32 @@
+---
+import { getAudience } from '../../../data/audiences';
+import type { Product } from '../../../data/products';
+
+interface Props {
+  slug: string;
+  product?: Product;
+}
+
+const { slug, product } = Astro.props;
+const audience = getAudience(slug);
+const label = audience?.name ?? slug;
+const href = audience ? `/audiences/${audience.slug}/` : null;
+const color = product?.accentColor ?? '#2563EB';
+---
+
+{href ? (
+  <a
+    href={href}
+    class="inline-flex items-center text-xs px-2 py-0.5 rounded-full no-underline hover:underline"
+    style={`background: ${color}20; color: ${color}; border: 1px solid ${color}40;`}
+  >
+    {label}
+  </a>
+) : (
+  <span
+    class="inline-flex items-center text-xs px-2 py-0.5 rounded-full"
+    style={`background: ${color}20; color: ${color}; border: 1px solid ${color}40;`}
+  >
+    {label}
+  </span>
+)}

--- a/src/components/astro/primitives/LanguageTabs.astro
+++ b/src/components/astro/primitives/LanguageTabs.astro
@@ -1,0 +1,56 @@
+---
+interface Tab {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  tabs?: Tab[];
+}
+
+const defaultTabs = [
+  { id: 'rust', label: 'Rust' },
+  { id: 'cli', label: 'CLI' },
+  { id: 'python', label: 'Python' },
+  { id: 'ruby', label: 'Ruby' },
+  { id: 'wasm', label: 'WASM' },
+  { id: 'go', label: 'Go' },
+];
+
+const { tabs = defaultTabs } = Astro.props;
+const tabIds = tabs.map((t) => `tab-${t.id}-${Math.random().toString(36).slice(2, 8)}`);
+---
+
+<div class="language-tabs" data-language-tabs>
+  <div class="border-b border-gray-200">
+    <nav class="flex flex-wrap gap-1" role="tablist">
+      {tabs.map((tab, i) => (
+        <button
+          type="button"
+          class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+            i === 0
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-gray-600 hover:text-gray-900'
+          }`}
+          role="tab"
+          aria-selected={i === 0 ? 'true' : 'false'}
+          data-tab-target={tabIds[i]}
+          onclick={`document.querySelectorAll('[data-language-tabs] [data-tab-target]').forEach(b => { b.classList.remove('border-blue-600', 'text-blue-600'); b.classList.add('border-transparent', 'text-gray-600'); b.setAttribute('aria-selected', 'false'); }); this.classList.remove('border-transparent', 'text-gray-600'); this.classList.add('border-blue-600', 'text-blue-600'); this.setAttribute('aria-selected', 'true'); document.querySelectorAll('[data-language-tabs] [data-tab-panel]').forEach(p => p.classList.add('hidden')); document.getElementById('${tabIds[i]}').classList.remove('hidden');`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  </div>
+
+  {tabs.map((tab, i) => (
+    <div
+      id={tabIds[i]}
+      class={`tab-content mt-4 ${i === 0 ? '' : 'hidden'}`}
+      role="tabpanel"
+      data-tab-panel
+    >
+      <slot name={tab.id}>{tab.label} content</slot>
+    </div>
+  ))}
+</div>

--- a/src/components/astro/primitives/Steps.astro
+++ b/src/components/astro/primitives/Steps.astro
@@ -1,0 +1,43 @@
+---
+interface Step {
+  title: string;
+  description?: string;
+}
+
+interface Props {
+  steps?: Step[];
+}
+
+const { steps = [] } = Astro.props;
+const hasSteps = steps.length > 0;
+const autoIds = hasSteps
+  ? steps.map((_, i) => `step-${i}-${Math.random().toString(36).slice(2, 6)}`)
+  : [];
+---
+
+{hasSteps ? (
+  <ol class="space-y-6">
+    {steps.map((step, i) => (
+      <li class="flex gap-4" id={autoIds[i]}>
+        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center font-bold">
+          {i + 1}
+        </div>
+        <div class="flex-1 pt-1">
+          <h3 class="font-bold">{step.title}</h3>
+          {step.description && (
+            <p class="text-gray-700 mt-1 leading-relaxed">{step.description}</p>
+          )}
+          {i === 0 && <slot name="step-1" />}
+          {i === 1 && <slot name="step-2" />}
+          {i === 2 && <slot name="step-3" />}
+          {i === 3 && <slot name="step-4" />}
+          {i === 4 && <slot name="step-5" />}
+        </div>
+      </li>
+    ))}
+  </ol>
+) : (
+  <div class="space-y-6">
+    <slot />
+  </div>
+)}

--- a/src/components/astro/primitives/UseCaseCard.astro
+++ b/src/components/astro/primitives/UseCaseCard.astro
@@ -1,0 +1,33 @@
+---
+import { getProduct } from '../../../data/products';
+import type { UseCase } from '../../../data/audiences';
+
+interface Props {
+  useCase: UseCase;
+}
+
+const { useCase } = Astro.props;
+const products = useCase.productSlugs
+  .map((slug) => getProduct(slug))
+  .filter(Boolean);
+---
+
+<div class="border border-gray-200 rounded-lg p-5 hover:shadow-md transition-all">
+  <h3 class="font-bold text-lg">{useCase.title}</h3>
+  <p class="text-sm text-gray-700 mt-2 leading-relaxed">{useCase.summary}</p>
+
+  {products.length > 0 && (
+    <div class="flex flex-wrap gap-1 mt-4">
+      <span class="text-xs text-gray-500 mr-1">Products:</span>
+      {products.map((p) => (
+        <a
+          href={`/${p!.slug}/`}
+          class="text-xs px-2 py-0.5 rounded-full hover:underline no-underline"
+          style={`background: ${p!.accentColor}20; color: ${p!.accentColor}`}
+        >
+          {p!.name}
+        </a>
+      ))}
+    </div>
+  )}
+</div>


### PR DESCRIPTION
## Summary

Adds the shared template layer for product minisite subpages:

- `src/components/astro/minisite/{Quickstart,Install,DocsIndex,UseCases,ApiReference,Examples}.astro` — wrappers around Minisite.astro with a `Product` prop and default chrome.
- `src/components/astro/primitives/{UseCaseCard,LanguageTabs,Steps,AudienceBadge}.astro` — building blocks the templates consume.

Per-product subpages (TODOs 23-28) will be thin wrappers that pass a `product` prop and slot in product-specific content.

## Why

Today `Minisite.astro` links to `/{product}/quickstart/`, `/{product}/docs/`, `/{product}/use-cases/`, `/{product}/api/` — none of which exist. Visitors get 404s. This commit ships the shared infrastructure so per-product content TODOs can fill in fast.

## Test plan

- [ ] `npm run build` passes
- [ ] Templates compile in isolation (no runtime test yet — they're consumed by TODOs 23-28)
- [ ] No "Mode 1/2/3" language

Closes TODO.restructure/22.
