### PR TITLE
feat(minisite/threshold): add 6 subpages (quickstart/install/docs/use-cases/api/examples)

### DIFF
--- a/src/pages/threshold/api.astro
+++ b/src/pages/threshold/api.astro
@@ -1,0 +1,76 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<ApiReference product={product}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Canonical flow: DKG → sign → verify</h3>
+    <LanguageTabs>
+      <div slot="rust" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`// Cargo.toml: confium-threshold = { version = "0.4", features = ["cmp20"] }
+use confium_threshold::cmp20;
+
+// 1. DKG (3 parties, threshold 2)
+let keygen = cmp20::keygen(threshold=2, parties=3)?;
+
+// 2. Sign with any 2 of 3 shares
+let sig = cmp20::sign(
+    &[keygen.shares[0].clone(), keygen.shares[1].clone()],
+    threshold=2,
+    message=b"hello",
+)?;
+
+// 3. Verify with the joint public key
+assert!(cmp20::verify(&sig, &keygen.public_key, b"hello")?);`}</code></pre>
+      </div>
+      <div slot="cli" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# DKG
+confium threshold dkg --parties 3 --threshold 2 --scheme cmp20 --out ./shares/
+
+# Sign with 2 of 3 shares
+confium threshold sign \\
+    --shares ./shares/party1.json ./shares/party2.json \\
+    --message "hello" \\
+    --out ./sig.der
+
+# Verify
+confium verify ecdsa-p256 \\
+    --message "hello" \\
+    --signature ./sig.der \\
+    --public-key ./shares/public.json`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# pip install confium
+from confium.tc import Cmp20
+
+# DKG
+kg = Cmp20.keygen(threshold=2, parties=3)
+
+# Sign with 2 shares
+sig = Cmp20.sign([kg.shares[0], kg.shares[1]], threshold=2, message=b"hello")
+
+# Verify
+assert Cmp20.verify(sig, kg.public_key, b"hello")`}</code></pre>
+      </div>
+      <div slot="ruby" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# gem install confium
+require 'confium'
+
+# DKG
+kg = Confium::TC::Cmp20.keygen(threshold: 2, parties: 3)
+
+# Sign with 2 shares
+sig = Confium::TC::Cmp20.sign([kg.shares[0], kg.shares[1]],
+                              threshold: 2,
+                              message: "hello")
+
+# Verify
+raise unless Confium::TC::Cmp20.verify(sig, kg.public_key, "hello")`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/threshold/docs.astro
+++ b/src/pages/threshold/docs.astro
@@ -1,0 +1,43 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/threshold/concepts/threshold-signing" class="text-blue-600 hover:underline">Threshold signing fundamentals (T-of-N)</a></li>
+        <li>→ <a href="/docs/threshold/concepts/dkg" class="text-blue-600 hover:underline">Distributed Key Generation (DKG)</a></li>
+        <li>→ <a href="/docs/threshold/concepts/mta" class="text-blue-600 hover:underline">Multiplicative-to-Additive (MtA) via Paillier</a></li>
+        <li>→ <a href="/docs/threshold/concepts/share-refresh" class="text-blue-600 hover:underline">Share refresh & proactive security (Herzberg)</a></li>
+        <li>→ <a href="/docs/threshold/concepts/reshare" class="text-blue-600 hover:underline">Reshare: changing T or N without re-keying</a></li>
+      </ul>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/threshold/how-to/deploy-signerd" class="text-blue-600 hover:underline">Deploy signerd in production</a></li>
+        <li>→ <a href="/docs/threshold/how-to/integrate-hsm" class="text-blue-600 hover:underline">Protect shares with an HSM (PKCS#11)</a></li>
+        <li>→ <a href="/docs/threshold/how-to/refresh" class="text-blue-600 hover:underline">Schedule Herzberg share refresh</a></li>
+        <li>→ <a href="/docs/threshold/how-to/monitor" class="text-blue-600 hover:underline">Monitor signing sessions (Prometheus)</a></li>
+        <li>→ <a href="/docs/threshold/how-to/policy" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+      </ul>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/confium-threshold)</a></li>
+        <li>→ <a href="/docs/threshold/reference/config" class="text-blue-600 hover:underline">signerd config reference</a></li>
+        <li>→ <a href="/docs/threshold/reference/cli" class="text-blue-600 hover:underline">confium threshold subcommands</a></li>
+        <li>→ <a href="/specs/22-threshold-session" class="text-blue-600 hover:underline">Threshold session spec</a></li>
+        <li>→ <a href="/specs/70-cmp20" class="text-blue-600 hover:underline">CMP20 spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/threshold/examples.astro
+++ b/src/pages/threshold/examples.astro
@@ -1,0 +1,35 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/threshold_local_dkg.rs"
+       class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Local 3-party DKG</h4>
+      <p class="text-sm text-gray-700 mt-2">Runnable Rust example. Spins up 3 in-process parties, runs DKG, signs, verifies. Best starting point.</p>
+      <p class="text-xs text-gray-500 mt-3">threshold_local_dkg.rs</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/threshold_signerd_deploy.yaml"
+       class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">signerd deployment</h4>
+      <p class="text-sm text-gray-700 mt-2">Docker Compose + signerd.toml for a 3-node production signing cluster.</p>
+      <p class="text-xs text-gray-500 mt-3">threshold_signerd_deploy.yaml</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/threshold_ruby_quickstart.rb"
+       class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Ruby quickstart</h4>
+      <p class="text-sm text-gray-700 mt-2">5-line Ruby script: DKG, sign, verify. Uses the gem.</p>
+      <p class="text-xs text-gray-500 mt-3">threshold_ruby_quickstart.rb</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/threshold_python_quickstart.py"
+       class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Python quickstart</h4>
+      <p class="text-sm text-gray-700 mt-2">Python equivalent: DKG, sign, verify via the confium package.</p>
+      <p class="text-xs text-gray-500 mt-3">threshold_python_quickstart.py</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/threshold/index.astro
+++ b/src/pages/threshold/index.astro
@@ -1,0 +1,82 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is Confium Threshold?</h2>
+    <p class="text-gray-700 leading-relaxed">
+      Confium Threshold is a production-grade threshold signing platform. It replaces
+      single-key HSMs with T-of-N distributed signing — no single party can sign alone,
+      and compromising any T-1 parties doesn't compromise the key.
+    </p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Supported Algorithms</h2>
+    <ul class="list-disc pl-6 space-y-1">
+      <li><strong>CMP20</strong> — 3-round threshold ECDSA over P-256 with real Paillier MtA</li>
+      <li><strong>GG18</strong> — 4-round threshold ECDSA over P-256</li>
+      <li><strong>FROST-P256</strong> — 2-round threshold ECDSA over P-256 (Shamir + Feldman VSS)</li>
+      <li><strong>FROST-Ed25519</strong> — 2-round threshold EdDSA over Ed25519</li>
+      <li><strong>MuSig</strong> — 2-round threshold Schnorr signatures</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+      <div class="text-gray-400 mt-2"># Generate threshold key (2-of-3 CMP20)</div>
+      <div>confium tc keygen --scheme cmp20 --threshold 2 --party-count 3</div>
+      <div class="text-gray-400 mt-2"># Sign a message</div>
+      <div>confium tc sign --scheme cmp20 --shares keyset.json --threshold 2 --message "hello"</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Architecture</h2>
+    <p class="text-gray-700 mb-4">
+      The coordinator orchestrates signing sessions across distributed signers.
+      Each signer holds a share of the private key. The coordinator collects
+      commitments, runs the MtA protocol, and aggregates partial signatures
+      into a standard ECDSA signature verifiable with the joint public key.
+    </p>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="border border-gray-200 rounded-lg p-4">
+        <h3 class="font-bold mb-2">Coordinator</h3>
+        <p class="text-sm text-gray-600">TCP server with multi-round protocol orchestration, policy enforcement, rate limiting, backpressure, and Prometheus metrics.</p>
+      </div>
+      <div class="border border-gray-200 rounded-lg p-4">
+        <h3 class="font-bold mb-2">Signer Daemon</h3>
+        <p class="text-sm text-gray-600">Standalone binary (<code>confium-signerd</code>) that connects to the coordinator, registers, and responds to signing requests.</p>
+      </div>
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/threshold/install.astro
+++ b/src/pages/threshold/install.astro
@@ -1,0 +1,62 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">Rust crate</h3>
+      <p class="text-sm text-gray-700 mb-3">For application embedding.</p>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-threshold</code></pre>
+      <p class="text-xs text-gray-500 mt-2">
+        Or pin specific schemes via features:
+        <code class="bg-gray-100 px-1 rounded">confium-threshold = { version = "0.4", features = ["cmp20", "frost-p256"] }</code>
+      </p>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-2">CLI</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install --locked confium-cli</code></pre>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-2">Docker (signerd)</h3>
+      <p class="text-sm text-gray-700 mb-3">For production signing service.</p>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/signerd:latest
+docker run -d \
+  -p 7000:7000 \
+  -v ./shares:/etc/confium/shares:ro \
+  -v ./signerd.toml:/etc/confium/signerd.toml:ro \
+  confium/signerd:latest</code></pre>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-2">Kubernetes operator</h3>
+      <p class="text-sm text-gray-700 mb-3">For declarative share management.</p>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>kubectl apply -f https://confium.org/operator.yaml
+kubectl apply -f - <<EOF
+apiVersion: confium.org/v1
+kind: ThresholdKey
+metadata:
+  name: my-key
+spec:
+  threshold: 2
+  parties: 3
+  scheme: cmp20
+EOF</code></pre>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-2">Ruby gem</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>gem install confium</code></pre>
+    </div>
+
+    <div>
+      <h3 class="font-bold text-lg mb-2">Python</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>pip install confium</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/threshold/quickstart.astro
+++ b/src/pages/threshold/quickstart.astro
@@ -1,0 +1,60 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+const steps = [
+  { title: 'Install Rust + cargo', description: 'Rust 1.85+ (edition 2024). Install via rustup.' },
+  { title: 'Install confium-cli', description: 'cargo install --locked confium-cli' },
+  { title: 'Run a 3-party DKG', description: 'Generate shares for a 2-of-3 threshold key.' },
+  { title: 'Sign a message', description: 'Combine 2 shares to produce an ECDSA signature.' },
+  { title: 'Verify', description: 'Confirm the signature with the public key.' },
+];
+---
+
+<Quickstart product={product} intro="Get a 2-of-3 threshold ECDSA signature in 5 minutes. No HSM, no K8s, just cargo and a terminal.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+rustc --version  # need 1.85+</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install --locked confium-cli
+confium --version</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium threshold dkg \
+  --parties 3 \
+  --threshold 2 \
+  --scheme cmp20 \
+  --out-dir ./shares/
+ls ./shares/
+# party1.json  party2.json  party3.json  public.json</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium threshold sign \
+  --shares ./shares/party1.json ./shares/party2.json \
+  --message "hello, threshold world" \
+  --out ./signature.der
+# Combined signature from 2 shares; party3 was offline.</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium verify ecdsa-p256 \
+  --message "hello, threshold world" \
+  --signature ./signature.der \
+  --public-key ./shares/public.json
+# → valid</code></pre>
+    </span>
+  </Steps>
+
+  <div class="mt-12 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+    <p class="text-sm text-gray-700">
+      <strong>What just happened:</strong> you ran a 3-party distributed key
+      generation (DKG), combined 2 of 3 shares to sign a message (the third
+      party was unnecessary), and verified the result against the joint public
+      key. That's the entire threshold-signing primitive.
+    </p>
+  </div>
+</Quickstart>

--- a/src/pages/threshold/use-cases.astro
+++ b/src/pages/threshold/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('threshold')!;
+---
+
+<UseCases product={product} intro="Threshold signatures replace single-key custody with T-of-N quorum signing. The use cases below are the patterns we see most often in production deployments." />


### PR DESCRIPTION
## Summary

Fills the threshold minisite depth so the Minisite nav no longer 404s.

Pages added:
- `/threshold/quickstart/` — 3-party DKG + sign + verify, ~5 min
- `/threshold/install/` — Rust/CLI/Docker/K8s/Ruby/Python tabs
- `/threshold/docs/` — index of concepts/how-to/reference
- `/threshold/use-cases/` — pulls from audience/use-case data layer
- `/threshold/api/` — Rust/CLI/Python/Ruby tabs for canonical flow
- `/threshold/examples/` — links to confium-examples crate

Also brings in the previously untracked `/threshold/index.astro` (overview page from prior session).

## Test plan

- [ ] `npm run build` passes
- [ ] Each subpage renders without 404
- [ ] No "Mode 1/2/3" language

Closes TODO.restructure/23.
