### PR TITLE
feat(minisite): add subpages for transparency/pki/keyless/privacy/verify

### DIFF
--- a/src/pages/keyless/api.astro
+++ b/src/pages/keyless/api.astro
@@ -1,0 +1,45 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<ApiReference product={product} languages={['yaml', 'bash', 'python']}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Configure signing</h3>
+    <LanguageTabs tabs={[{id:'yaml',label:'GitHub Action'},{id:'bash',label:'CLI'},{id:'python',label:'Python'}]}>
+      <div slot="yaml" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# .github/workflows/release.yml
+on: { release: { types: [created] } }
+permissions: { id-token: write, contents: write }
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: confium/action@v1
+        with:
+          artifact: release.tar.gz`}</code></pre>
+      </div>
+      <div slot="bash" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# Local verify
+confium keyless verify \\
+    --artifact release.tar.gz \\
+    --signature sig.bin \\
+    --cert cert.pem`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.keyless import verify
+
+verify(
+    artifact="release.tar.gz",
+    signature="sig.bin",
+    certificate="cert.pem",
+)
+# → True (cert issued to GitHub repo via OIDC)`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/keyless/docs.astro
+++ b/src/pages/keyless/docs.astro
@@ -1,0 +1,37 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/keyless/concepts/oidc" class="text-blue-600 hover:underline">OIDC for code signing</a></li>
+        <li>→ <a href="/docs/keyless/concepts/short-lived-certs" class="text-blue-600 hover:underline">Short-lived certificates from threshold keys</a></li>
+        <li>→ <a href="/docs/keyless/concepts/anchoring" class="text-blue-600 hover:underline">Transparency log anchoring</a></li>
+        <li>→ <a href="/docs/keyless/concepts/root-of-trust" class="text-blue-600 hover:underline">Root of trust model</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/keyless/how-to/github-action" class="text-blue-600 hover:underline">Configure the GitHub Action</a></li>
+        <li>→ <a href="/docs/keyless/how-to/new-oidc-provider" class="text-blue-600 hover:underline">Add a new OIDC provider (Google/GitLab/Azure AD/Okta)</a></li>
+        <li>→ <a href="/docs/keyless/how-to/verify-in-ci" class="text-blue-600 hover:underline">Verify keyless signatures in CI</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://docs.rs/confium-keyless" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
+        <li>→ <a href="/specs/90-oidc-binding" class="text-blue-600 hover:underline">OIDC binding spec</a></li>
+        <li>→ <a href="/specs/91-keyless-flow" class="text-blue-600 hover:underline">Keyless signing flow spec</a></li>
+        <li>→ <a href="/specs/92-short-lived-cert" class="text-blue-600 hover:underline">Short-lived certificate spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/keyless/examples.astro
+++ b/src/pages/keyless/examples.astro
@@ -1,0 +1,27 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/keyless_github_action.yml" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">GitHub Action</h4>
+      <p class="text-sm text-gray-700 mt-2">Complete release workflow with keyless signing.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/keyless_gitlab_ci.yml" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">GitLab CI</h4>
+      <p class="text-sm text-gray-700 mt-2">Same flow for GitLab; uses GitLab OIDC.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/keyless_python_verify.py" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Python verifier</h4>
+      <p class="text-sm text-gray-700 mt-2">Drop into a release pipeline.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/keyless_browser_verify.html" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Browser verifier</h4>
+      <p class="text-sm text-gray-700 mt-2">Static HTML page using WASM.</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/keyless/index.astro
+++ b/src/pages/keyless/index.astro
@@ -1,0 +1,52 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is {product.name}?</h2>
+    <p class="text-gray-700 leading-relaxed">{product.description}</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Crates</h2>
+    <div class="flex flex-wrap gap-2">
+      {product.crates.map((c) => (
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+      ))}
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/keyless/install.astro
+++ b/src/pages/keyless/install.astro
@@ -1,0 +1,27 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">GitHub Action</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>uses: confium/action@v1</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">GitLab CI</h3>
+      <p class="text-sm text-gray-700">See <a href="/keyless/docs/gitlab" class="text-blue-600 hover:underline">GitLab CI integration</a>.</p>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">CLI (local verification)</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install --locked confium-cli</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Browser verifier</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>npm install @confium/confium-wasm</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/keyless/quickstart.astro
+++ b/src/pages/keyless/quickstart.astro
@@ -1,0 +1,61 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+const steps = [
+  { title: 'Add the GitHub Action', description: 'Drop confium/action into your release workflow.' },
+  { title: 'Push a tag', description: 'Trigger a release; the Action runs.' },
+  { title: 'Watch the Action produce a signature + cert', description: 'OIDC-issued short-lived cert anchored to the transparency log.' },
+  { title: 'Verify in CI', description: 'Use confium verify to check the artifact.' },
+  { title: 'Verify in browser', description: 'Use verify.confium.org or the WASM snippet.' },
+];
+---
+
+<Quickstart product={product} intro="Sign a GitHub release keylessly — no signing key to manage, no key rotation, OIDC only.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code># .github/workflows/release.yml
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: confium/action@v1
+        with:
+          artifact: release.tar.gz</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>git tag v1.0.0
+git push origin v1.0.0
+# Release is created automatically; the Action runs.</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code># Action output:
+# ✅ Signed release.tar.gz
+# Signature: https://confium.org/attestations/&lt;id&gt;/sig.bin
+# Certificate: https://confium.org/attestations/&lt;id&gt;/cert.pem
+# Transparency log: appended at seq 4823, root sha256:abc...</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium keyless verify \\
+    --artifact release.tar.gz \\
+    --signature sig.bin \\
+    --cert cert.pem
+# → valid; cert issued to GitHub repo yourname/yourrepo@v1.0.0</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code># Browser:
+open "https://verify.confium.org/?artifact=https://github.com/.../release.tar.gz"</code></pre>
+    </span>
+  </Steps>
+</Quickstart>

--- a/src/pages/keyless/use-cases.astro
+++ b/src/pages/keyless/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('keyless')!;
+---
+
+<UseCases product={product} intro="Keyless signing: no signing keys to manage. Common patterns:" />

--- a/src/pages/pki/api.astro
+++ b/src/pages/pki/api.astro
@@ -1,0 +1,57 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<ApiReference product={product}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Parse + verify a certificate</h3>
+    <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'},{id:'python',label:'Python'}]}>
+      <div slot="rust" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_pki::Certificate;
+
+let cert = Certificate::from_der(&der_bytes)?;
+println!("Subject: {}", cert.subject());
+println!("Not after: {}", cert.not_after());
+cert.verify_chain(&[root_cert])?;`}</code></pre>
+      </div>
+      <div slot="cli" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium pki parse-cert --in cert.der
+confium pki verify --cert cert.der --anchor root.der`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.pki import Certificate
+
+cert = Certificate.from_der(der_bytes)
+print("Subject:", cert.subject)
+cert.verify_chain([root_cert])`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Composite signature (PQ migration)</h3>
+    <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'}]}>
+      <div slot="rust" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_composite::{CompositeSignature, Component};
+
+let sig = CompositeSignature::sign_multi(
+    &[("ed25519", &ed_privkey), ("ml-dsa-65", &mldsa_privkey)],
+    b"message",
+)?;
+assert!(sig.verify(b"message")?);`}</code></pre>
+      </div>
+      <div slot="cli" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium pki composite-sign \\
+    --message "message" \\
+    --classical-key ed25519.key \\
+    --pq-key mldsa.key \\
+    --out sig.bin
+confium pki composite-verify --message "message" --signature sig.bin`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/pki/docs.astro
+++ b/src/pages/pki/docs.astro
@@ -1,0 +1,39 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/pki/concepts/threshold-ca" class="text-blue-600 hover:underline">Threshold CA lifecycle (issue, revoke, CRL)</a></li>
+        <li>→ <a href="/docs/pki/concepts/ocsp-crl" class="text-blue-600 hover:underline">OCSP / CRL from threshold keys</a></li>
+        <li>→ <a href="/docs/pki/concepts/acme" class="text-blue-600 hover:underline">ACME integration with threshold CA</a></li>
+        <li>→ <a href="/docs/pki/concepts/composite" class="text-blue-600 hover:underline">Composite signatures (PQ migration)</a></li>
+        <li>→ <a href="/docs/pki/concepts/attributes" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/pki/how-to/deploy-pkcs11-server" class="text-blue-600 hover:underline">Deploy PKCS#11 server as HSM replacement</a></li>
+        <li>→ <a href="/docs/pki/how-to/configure-openssl" class="text-blue-600 hover:underline">Configure OpenSSL 3.0 provider</a></li>
+        <li>→ <a href="/docs/pki/how-to/integrate-jce" class="text-blue-600 hover:underline">Integrate JCE into Java apps</a></li>
+        <li>→ <a href="/docs/pki/how-to/threshold-ca" class="text-blue-600 hover:underline">Stand up a threshold CA</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://docs.rs/confium-pki" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
+        <li>→ <a href="/specs/81-threshold-ca" class="text-blue-600 hover:underline">Threshold CA spec</a></li>
+        <li>→ <a href="/specs/82-composite-signatures" class="text-blue-600 hover:underline">Composite signatures spec</a></li>
+        <li>→ <a href="/specs/83-pkcs11-server" class="text-blue-600 hover:underline">PKCS#11 server spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/pki/examples.astro
+++ b/src/pages/pki/examples.astro
@@ -1,0 +1,27 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/pki_issue_cert.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Issue a cert from threshold keys</h4>
+      <p class="text-sm text-gray-700 mt-2">Combine threshold signing with X.509 issuance.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/pki_pkcs11_server.yaml" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">PKCS#11 server deployment</h4>
+      <p class="text-sm text-gray-700 mt-2">Drop-in replacement for an HSM-backed PKCS#11 module.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/pki_openssl_provider.conf" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">OpenSSL provider config</h4>
+      <p class="text-sm text-gray-700 mt-2">Use Confium from OpenSSL 3.0 without changing application code.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/pki_composite_sign.py" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Composite signing</h4>
+      <p class="text-sm text-gray-700 mt-2">Sign with classical + PQ keys; verify either component.</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/pki/index.astro
+++ b/src/pages/pki/index.astro
@@ -1,0 +1,52 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is {product.name}?</h2>
+    <p class="text-gray-700 leading-relaxed">{product.description}</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Crates</h2>
+    <div class="flex flex-wrap gap-2">
+      {product.crates.map((c) => (
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+      ))}
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/pki/install.astro
+++ b/src/pages/pki/install.astro
@@ -1,0 +1,42 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">Rust crate</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-pki
+# Full PKI product surface:
+cargo add confium-pki --features full</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">PKCS#11 server (HSM replacement)</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/pkcs11-server:latest
+docker run -p 2345:2345 -v ./shares:/etc/confium/shares:ro confium/pkcs11-server</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">OpenSSL 3.0 provider</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install confium-openssl-provider
+# Add to openssl.conf:
+# provider = confium
+# /usr/lib/ossl-modules/confium.so</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">JCE provider (Java)</h3>
+      <p class="text-sm text-gray-700 mb-3">Download the JAR; add to classpath:</p>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>&lt;dependency&gt;
+  &lt;groupId&gt;org.confium&lt;/groupId&gt;
+  &lt;artifactId&gt;confium-jce&lt;/artifactId&gt;
+  &lt;version&gt;0.3.0&lt;/version&gt;
+&lt;/dependency&gt;</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">TLS signer</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/tls-signer:latest</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/pki/quickstart.astro
+++ b/src/pages/pki/quickstart.astro
@@ -1,0 +1,50 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+const steps = [
+  { title: 'Install', description: 'cargo install --locked confium-cli' },
+  { title: 'Parse a cert', description: 'Inspect an existing X.509 certificate.' },
+  { title: 'Verify a cert chain', description: 'Verify a leaf cert against an anchor.' },
+  { title: 'Composite sign (PQ migration)', description: 'Sign a payload with classical + PQ keys.' },
+  { title: 'Verify composite', description: 'Verify the composite signature.' },
+];
+---
+
+<Quickstart product={product} intro="Parse, verify, and produce PQ-composite signatures — the three things every PKI integration needs.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install --locked confium-cli</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium pki parse-cert --in example.der
+# Subject: CN=example.com
+# Issuer: CN=Confium Test CA
+# Serial: 4A:3F:...
+# Not After: 2027-08-07T00:00:00Z</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium pki verify \\
+    --cert example.der \\
+    --anchor root.der
+# → valid</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium pki composite-sign \\
+    --message "hello" \\
+    --classical-key ed25519.key \\
+    --pq-key mldsa.key \\
+    --out composite-sig.bin</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium pki composite-verify \\
+    --message "hello" \\
+    --signature composite-sig.bin \\
+    --classical-pubkey ed25519.pub \\
+    --pq-pubkey mldsa.pub
+# → valid</code></pre>
+    </span>
+  </Steps>
+</Quickstart>

--- a/src/pages/pki/use-cases.astro
+++ b/src/pages/pki/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('pki')!;
+---
+
+<UseCases product={product} intro="PKI patterns enabled by threshold signing:" />

--- a/src/pages/privacy/api.astro
+++ b/src/pages/privacy/api.astro
@@ -1,0 +1,31 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<ApiReference product={product} languages={['rust', 'python']}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">PSI (ECDH-based)</h3>
+    <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'python',label:'Python'}]}>
+      <div slot="rust" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_privacy::psi::EcdhPsi;
+
+let server = EcdhPsi::new(["a@example.com".to_string()]);
+let req = server.request();
+let resp = server.respond(["a@example.com".as_bytes(), "b@example.com".as_bytes()]);
+let intersection = EcdhPsi::client_compute(&req, &resp);`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.privacy import EcdhPsi
+
+server = EcdhPsi(["a@example.com"])
+request = server.request()
+response = server.respond([b"a@example.com", b"b@example.com"])
+intersection = EcdhPsi.client_compute(request, response)`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/privacy/docs.astro
+++ b/src/pages/privacy/docs.astro
@@ -1,0 +1,41 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/privacy/concepts/psi" class="text-blue-600 hover:underline">Private Set Intersection (PSI)</a></li>
+        <li>→ <a href="/docs/privacy/concepts/pir" class="text-blue-600 hover:underline">Private Information Retrieval (PIR)</a></li>
+        <li>→ <a href="/docs/privacy/concepts/dp" class="text-blue-600 hover:underline">Differential Privacy (DP)</a></li>
+        <li>→ <a href="/docs/privacy/concepts/mpc" class="text-blue-600 hover:underline">Multi-party Computation (MPC / SPDZ)</a></li>
+        <li>→ <a href="/docs/privacy/concepts/ring-sigs" class="text-blue-600 hover:underline">Ring signatures</a></li>
+        <li>→ <a href="/docs/privacy/concepts/blind-sigs" class="text-blue-600 hover:underline">Blind signatures</a></li>
+        <li>→ <a href="/docs/privacy/concepts/vrf-vdf" class="text-blue-600 hover:underline">VRF + VDF</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/privacy/how-to/choose-primitive" class="text-blue-600 hover:underline">Choose the right primitive</a></li>
+        <li>→ <a href="/docs/privacy/how-to/two-party-psi" class="text-blue-600 hover:underline">Two-party PSI</a></li>
+        <li>→ <a href="/docs/privacy/how-to/mpc-cluster" class="text-blue-600 hover:underline">MPC cluster deployment</a></li>
+        <li>→ <a href="/docs/privacy/how-to/anonymous-credentials" class="text-blue-600 hover:underline">Issue anonymous credentials</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://docs.rs/confium-privacy" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
+        <li>→ <a href="/specs/31-psi" class="text-blue-600 hover:underline">PSI spec</a></li>
+        <li>→ <a href="/specs/32-mpc-spdz" class="text-blue-600 hover:underline">MPC spec</a></li>
+        <li>→ <a href="/specs/33-differential-privacy" class="text-blue-600 hover:underline">DP spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/privacy/examples.astro
+++ b/src/pages/privacy/examples.astro
@@ -1,0 +1,27 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/privacy_psi_two_party.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Two-party PSI</h4>
+      <p class="text-sm text-gray-700 mt-2">ECDH-PSI between two parties over a TCP transport.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/privacy_dp_aggregation.py" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">DP aggregation</h4>
+      <p class="text-sm text-gray-700 mt-2">Aggregate user telemetry with zCDP budget.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/privacy_ring_signature.rb" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Ring signatures</h4>
+      <p class="text-sm text-gray-700 mt-2">Sign as one-of-N via Ruby.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/privacy_vrf_randomness.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">VRF randomness</h4>
+      <p class="text-sm text-gray-700 mt-2">Verifiable randomness for leader election.</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -1,0 +1,52 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is {product.name}?</h2>
+    <p class="text-gray-700 leading-relaxed">{product.description}</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Crates</h2>
+    <div class="flex flex-wrap gap-2">
+      {product.crates.map((c) => (
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+      ))}
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/privacy/install.astro
+++ b/src/pages/privacy/install.astro
@@ -1,0 +1,23 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">Rust crate</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-privacy</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Python</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>pip install confium</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Ruby</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>gem install confium</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/privacy/quickstart.astro
+++ b/src/pages/privacy/quickstart.astro
@@ -1,0 +1,52 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+const steps = [
+  { title: 'Add the crate', description: 'cargo add confium-privacy' },
+  { title: 'Pick a primitive', description: 'PSI, PIR, DP, MPC, ring sigs, blind sigs, VRF, VDF.' },
+  { title: 'Run a 2-party PSI', description: 'Find the intersection of two sets without revealing them.' },
+  { title: 'Verify the result', description: 'Confirm only the intersection was revealed.' },
+  { title: 'Adapt', description: 'Swap primitives; same ergonomics.' },
+];
+---
+
+<Quickstart product={product} intro="Compute on shared data without revealing the inputs. PSI is the canonical starting point.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-privacy</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>use confium_privacy::psi::EcdhPsi;
+use confium_privity::pir::SealPir;
+use confium_privacy::dp::ZcdpBudget;
+// 15+ primitives available</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>let server = EcdhPsi::new(vec!["alice@ex.com".to_string()]);
+let request = server.request();
+
+let client_set: Vec&lt;String&gt; = vec!["alice@ex.com".into(), "carol@ex.com".into()];
+let response = server.respond(client_set.iter().map(|s| s.as_bytes()));
+
+let intersection = EcdhPsi::client_compute(&request, &response);
+// → {"alice@ex.com"}</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>// Server never learned client_set.
+// Client only learned the intersection, not the server set beyond that.
+assert_eq!(intersection, vec!["alice@ex.com"]);</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>// Same flow for ring sigs, VRFs, blind sigs, etc.
+use confium_privacy::ring_sig::RingSig;
+use confium_privacy::vrf::Ecvrf;
+
+let sig = RingSig::sign(&privkey, &[pubkey1, pubkey2, pubkey3], msg)?;
+// Verifier can confirm ONE of {pubkey1, pubkey2, pubkey3} signed,
+// but not which.</code></pre>
+    </span>
+  </Steps>
+</Quickstart>

--- a/src/pages/privacy/use-cases.astro
+++ b/src/pages/privacy/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('privacy')!;
+---
+
+<UseCases product={product} intro="Privacy-preserving patterns for applications:" />

--- a/src/pages/transparency/api.astro
+++ b/src/pages/transparency/api.astro
@@ -1,0 +1,40 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<ApiReference product={product}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Canonical flow: append → prove → verify</h3>
+    <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'},{id:'python',label:'Python'}]}>
+      <div slot="rust" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_transparency::MerkleTree;
+
+let mut tree = MerkleTree::new();
+let seq = tree.append(b"sha256:abc...")?;
+let root = tree.root();
+
+let proof = tree.inclusion_proof(seq)?;
+assert!(proof.verify(&root)?);`}</code></pre>
+      </div>
+      <div slot="cli" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium transparency append --artifact-hash sha256:abc...
+confium transparency prove --seq 0 --out proof.json
+confium transparency verify --proof proof.json --root &lt;(confium transparency root)`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.transparency import MerkleTree
+
+tree = MerkleTree()
+seq = tree.append(b"sha256:abc...")
+root = tree.root()
+
+proof = tree.inclusion_proof(seq)
+assert proof.verify(root)`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/transparency/docs.astro
+++ b/src/pages/transparency/docs.astro
@@ -1,0 +1,38 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/transparency/concepts/rfc-6962" class="text-blue-600 hover:underline">RFC 6962 inclusion & consistency proofs</a></li>
+        <li>→ <a href="/docs/transparency/concepts/witness-gossip" class="text-blue-600 hover:underline">Witness gossip & fork-resistance</a></li>
+        <li>→ <a href="/docs/transparency/concepts/ots-anchoring" class="text-blue-600 hover:underline">OTS anchoring to Bitcoin / public chains</a></li>
+        <li>→ <a href="/docs/transparency/concepts/ers" class="text-blue-600 hover:underline">Evidence Record Syntax (ERS) long-term archival</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/transparency/how-to/deploy-log-server" class="text-blue-600 hover:underline">Deploy a production log server</a></li>
+        <li>→ <a href="/docs/transparency/how-to/deploy-monitor" class="text-blue-600 hover:underline">Run a monitor (third-party auditing)</a></li>
+        <li>→ <a href="/docs/transparency/how-to/deploy-edge" class="text-blue-600 hover:underline">Deploy the Cloudflare Workers edge verifier</a></li>
+        <li>→ <a href="/docs/transparency/how-to/bitcoin-anchor" class="text-blue-600 hover:underline">Anchor tree heads to Bitcoin</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://docs.rs/confium-transparency" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
+        <li>→ <a href="/specs/42-transparency-log" class="text-blue-600 hover:underline">Transparency log spec</a></li>
+        <li>→ <a href="/specs/43-witness-gossip" class="text-blue-600 hover:underline">Witness gossip spec</a></li>
+        <li>→ <a href="/specs/45-ers-archival" class="text-blue-600 hover:underline">ERS archival spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/transparency/examples.astro
+++ b/src/pages/transparency/examples.astro
@@ -1,0 +1,27 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/transparency_local_log.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Local Merkle log</h4>
+      <p class="text-sm text-gray-700 mt-2">Append entries to an in-memory tree, generate proofs, verify.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/transparency_log_server.yaml" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Log server deployment</h4>
+      <p class="text-sm text-gray-700 mt-2">Docker Compose for production log server with persistent storage.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/transparency_cloudflare_worker.ts" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Cloudflare Worker verifier</h4>
+      <p class="text-sm text-gray-700 mt-2">Edge verification at 250+ POPs. Zero cold start.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/transparency_python_verify.py" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Python verifier</h4>
+      <p class="text-sm text-gray-700 mt-2">CLI tool: download a log root, verify an inclusion proof.</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/transparency/index.astro
+++ b/src/pages/transparency/index.astro
@@ -1,0 +1,52 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is {product.name}?</h2>
+    <p class="text-gray-700 leading-relaxed">{product.description}</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Crates</h2>
+    <div class="flex flex-wrap gap-2">
+      {product.crates.map((c) => (
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+      ))}
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/transparency/install.astro
+++ b/src/pages/transparency/install.astro
@@ -1,0 +1,30 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">Rust crate</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-transparency</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Docker (log server)</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/log-server:latest
+docker run -p 7878:7878 -v ./log.db:/data/log.db confium/log-server:latest</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Cloudflare Workers (edge verifier)</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>npm install @confium/log-edge
+wrangler deploy</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Python / Ruby</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>pip install confium
+gem install confium</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/transparency/quickstart.astro
+++ b/src/pages/transparency/quickstart.astro
@@ -1,0 +1,48 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+const steps = [
+  { title: 'Install', description: 'cargo install --locked confium-cli' },
+  { title: 'Start a local log', description: 'Run an RFC 6962 log server in the background.' },
+  { title: 'Append an entry', description: 'Add an artifact hash to the log.' },
+  { title: 'Prove inclusion', description: 'Generate an inclusion proof for a specific entry.' },
+  { title: 'Verify', description: 'Verify the proof against the tree head.' },
+];
+---
+
+<Quickstart product={product} intro="Stand up a local RFC 6962 transparency log, append an entry, and produce a verifiable inclusion proof — in 5 minutes.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo install --locked confium-cli
+confium --version</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium transparency serve \\
+    --data ./log.db \\
+    --port 7878 &
+# Log server is now running on localhost:7878</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium transparency append \\
+    --artifact-hash sha256:$(printf "hello" | sha256sum | cut -d' ' -f1) \\
+    --url http://localhost:7878
+# → appended at sequence 0</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium transparency prove \\
+    --seq 0 \\
+    --url http://localhost:7878 \\
+    --out ./proof.json
+# → inclusion proof written to ./proof.json</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>confium transparency verify \\
+    --proof ./proof.json \\
+    --root &lt;(confium transparency root --url http://localhost:7878)
+# → valid</code></pre>
+    </span>
+  </Steps>
+</Quickstart>

--- a/src/pages/transparency/use-cases.astro
+++ b/src/pages/transparency/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('transparency')!;
+---
+
+<UseCases product={product} intro="Tamper-evident audit trails on RFC 6962. Common deployment patterns:" />

--- a/src/pages/verify/api.astro
+++ b/src/pages/verify/api.astro
@@ -1,0 +1,39 @@
+---
+import ApiReference from '../../components/astro/minisite/ApiReference.astro';
+import LanguageTabs from '../../components/astro/primitives/LanguageTabs.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<ApiReference product={product} languages={['ts', 'python', 'ruby', 'bash']}>
+  <section class="mb-12">
+    <h3 class="text-xl font-bold mb-4">Verify a composite signature</h3>
+    <LanguageTabs tabs={[{id:'ts',label:'TypeScript'},{id:'python',label:'Python'},{id:'ruby',label:'Ruby'},{id:'bash',label:'HTTP'}]}>
+      <div slot="ts" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`import init, { CompositeSignature } from '@confium/confium-wasm';
+await init();
+
+const sig = new CompositeSignature(components);
+const ok = sig.verify(message);`}</code></pre>
+      </div>
+      <div slot="python" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium import CompositeSignature
+
+sig = CompositeSignature(components)
+assert sig.verify(message)`}</code></pre>
+      </div>
+      <div slot="ruby" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`require 'confium'
+
+sig = Confium::Composite::Signature.new(components)
+raise unless sig.verify(message)`}</code></pre>
+      </div>
+      <div slot="bash" class="mt-4">
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`curl -X POST http://verify-server:8080/v1/composite/verify \\
+    -H 'Content-Type: application/json' \\
+    -d '{"message":"...","signature":"..."}'`}</code></pre>
+      </div>
+    </LanguageTabs>
+  </section>
+</ApiReference>

--- a/src/pages/verify/docs.astro
+++ b/src/pages/verify/docs.astro
@@ -1,0 +1,38 @@
+---
+import DocsIndex from '../../components/astro/minisite/DocsIndex.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<DocsIndex product={product}>
+  <div class="space-y-8 mt-12">
+    <div>
+      <h3 class="font-bold text-lg mb-3">Concepts</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/verify/concepts/verifier-only" class="text-blue-600 hover:underline">Verifier-only design philosophy</a></li>
+        <li>→ <a href="/docs/verify/concepts/provenance" class="text-blue-600 hover:underline">Provenance & transparency-log anchoring</a></li>
+        <li>→ <a href="/docs/verify/concepts/batch-verify" class="text-blue-600 hover:underline">Batch verification + LRU cache</a></li>
+        <li>→ <a href="/docs/verify/concepts/bindings" class="text-blue-600 hover:underline">Language bindings parity model</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">How-to</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="/docs/verify/how-to/wasm-in-spa" class="text-blue-600 hover:underline">Embed WASM in a SPA</a></li>
+        <li>→ <a href="/docs/verify/how-to/ci-gate" class="text-blue-600 hover:underline">Add verify gate to CI</a></li>
+        <li>→ <a href="/docs/verify/how-to/server-deploy" class="text-blue-600 hover:underline">Deploy verify-server</a></li>
+        <li>→ <a href="/docs/verify/how-to/dashboard" class="text-blue-600 hover:underline">Real-time verify dashboard</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-3">Reference</h3>
+      <ul class="space-y-2 text-sm">
+        <li>→ <a href="https://www.npmjs.com/package/@confium/confium-wasm" class="text-blue-600 hover:underline" target="_blank">npm package</a></li>
+        <li>→ <a href="/bindings/parity" class="text-blue-600 hover:underline">Bindings parity matrix</a></li>
+        <li>→ <a href="/specs/61-wasm-verifier" class="text-blue-600 hover:underline">WASM verifier spec</a></li>
+        <li>→ <a href="/specs/62-http-verify" class="text-blue-600 hover:underline">HTTP verify spec</a></li>
+      </ul>
+    </div>
+  </div>
+</DocsIndex>

--- a/src/pages/verify/examples.astro
+++ b/src/pages/verify/examples.astro
@@ -1,0 +1,27 @@
+---
+import Examples from '../../components/astro/minisite/Examples.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<Examples product={product}>
+  <div class="grid md:grid-cols-2 gap-6">
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/verify_browser_wasm.html" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Browser WASM</h4>
+      <p class="text-sm text-gray-700 mt-2">Single HTML page; verifies a signature client-side.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/verify_node_endpoint.ts" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Node verify endpoint</h4>
+      <p class="text-sm text-gray-700 mt-2">Express handler wrapping @confium/confium-wasm.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/verify_python_ci.py" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">CI verification gate</h4>
+      <p class="text-sm text-gray-700 mt-2">Block deploys on verification failure.</p>
+    </a>
+    <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/verify_ruby_sinatra.rb" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
+      <h4 class="font-bold">Sinatra verify service</h4>
+      <p class="text-sm text-gray-700 mt-2">Single-file Ruby HTTP verifier.</p>
+    </a>
+  </div>
+</Examples>

--- a/src/pages/verify/index.astro
+++ b/src/pages/verify/index.astro
@@ -1,0 +1,52 @@
+---
+import Minisite from '../../layouts/Minisite.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<Minisite product={product}>
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">What is {product.name}?</h2>
+    <p class="text-gray-700 leading-relaxed">{product.description}</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Key Features</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      {product.features.map((f) => (
+        <div class="border border-gray-200 rounded-lg p-4">
+          <p class="font-medium">{f}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Quick Start</h2>
+    <div class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm">
+      <div class="text-gray-400"># Install</div>
+      <div>{product.install}</div>
+    </div>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-2xl font-bold mb-4">Who is this for?</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      {product.audience.map((a) => (
+        <div class="bg-gray-50 rounded-lg p-4">
+          <p class="font-medium">{a}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold mb-4">Crates</h2>
+    <div class="flex flex-wrap gap-2">
+      {product.crates.map((c) => (
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+      ))}
+    </div>
+  </section>
+</Minisite>

--- a/src/pages/verify/install.astro
+++ b/src/pages/verify/install.astro
@@ -1,0 +1,31 @@
+---
+import Install from '../../components/astro/minisite/Install.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<Install product={product}>
+  <div class="space-y-8">
+    <div>
+      <h3 class="font-bold text-lg mb-2">npm (browser / Node)</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>npm install @confium/confium-wasm</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">PyPI</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>pip install confium</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">RubyGems</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>gem install confium</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">Go</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>go get github.com/confium/confium-go</code></pre>
+    </div>
+    <div>
+      <h3 class="font-bold text-lg mb-2">HTTP service</h3>
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/verify-server:latest</code></pre>
+    </div>
+  </div>
+</Install>

--- a/src/pages/verify/quickstart.astro
+++ b/src/pages/verify/quickstart.astro
@@ -1,0 +1,47 @@
+---
+import Quickstart from '../../components/astro/minisite/Quickstart.astro';
+import Steps from '../../components/astro/primitives/Steps.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+const steps = [
+  { title: 'Install the WASM package', description: 'npm install @confium/confium-wasm' },
+  { title: 'Load the WASM module', description: 'Import + init in your page.' },
+  { title: 'Verify a composite signature', description: 'Browser-side, no server calls.' },
+  { title: 'Verify a transparency inclusion proof', description: 'Same module, different API.' },
+  { title: 'Optional: deploy verify-server', description: 'HTTP endpoint for non-WASM clients.' },
+];
+---
+
+<Quickstart product={product} intro="Verify threshold signatures, transparency proofs, and cert chains anywhere — browser, edge, server, CLI.">
+  <Steps steps={steps}>
+    <span slot="step-1" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>npm install @confium/confium-wasm</code></pre>
+    </span>
+    <span slot="step-2" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>// ESM
+import init, { CompositeSignature } from '@confium/confium-wasm';
+await init();  // one-time WASM bootstrap</code></pre>
+    </span>
+    <span slot="step-3" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>const sig = new CompositeSignature(components);
+const ok = sig.verify(message);
+console.log(ok ? '✅ valid' : '❌ invalid');</code></pre>
+    </span>
+    <span slot="step-4" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>import { verifyInclusionWithHead } from '@confium/confium-wasm';
+
+const ok = verifyInclusionWithHead(proofJson, headJson);
+console.log(ok ? '✅ in log' : '❌ not in log');</code></pre>
+    </span>
+    <span slot="step-5" class="block mt-2">
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>docker pull confium/verify-server:latest
+docker run -p 8080:8080 confium/verify-server
+
+# Verify via HTTP:
+curl -X POST http://localhost:8080/v1/composite/verify \\
+    -H 'Content-Type: application/json' \\
+    -d '{"message":"...","signature":"..."}'</code></pre>
+    </span>
+  </Steps>
+</Quickstart>

--- a/src/pages/verify/use-cases.astro
+++ b/src/pages/verify/use-cases.astro
@@ -1,0 +1,8 @@
+---
+import UseCases from '../../components/astro/minisite/UseCases.astro';
+import { getProduct } from '../../data/products';
+
+const product = getProduct('verify')!;
+---
+
+<UseCases product={product} intro="Verify-side patterns: browser, edge, server, CI:" />


### PR DESCRIPTION
## Summary

Closes TODO.restructure/24-28 — the remaining 5 product minisites.

Adds 6 subpages per product (quickstart, install, docs, use-cases, api, examples):
- `/transparency/{quickstart,install,docs,use-cases,api,examples}/`
- `/pki/{quickstart,install,docs,use-cases,api,examples}/`
- `/keyless/{quickstart,install,docs,use-cases,api,examples}/`
- `/privacy/{quickstart,install,docs,use-cases,api,examples}/`
- `/verify/{quickstart,install,docs,use-cases,api,examples}/`

All 6 products' minisite nav is now 404-free.

## Test plan

- [ ] `npm run build` passes
- [ ] Each subpage renders
- [ ] No "Mode 1/2/3" language
- [ ] Use-cases pull from audience data layer (TODO 21)
