### PR TITLE
fix(examples): warn that some example paths may not exist

### DIFF
--- a/src/pages/keyless/examples.astro
+++ b/src/pages/keyless/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('keyless')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/keyless_github_action.yml" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">GitHub Action</h4>
       <p class="text-sm text-gray-700 mt-2">Complete release workflow with keyless signing.</p>

--- a/src/pages/pki/examples.astro
+++ b/src/pages/pki/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('pki')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/pki_issue_cert.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">Issue a cert from threshold keys</h4>
       <p class="text-sm text-gray-700 mt-2">Combine threshold signing with X.509 issuance.</p>

--- a/src/pages/privacy/examples.astro
+++ b/src/pages/privacy/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('privacy')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/privacy_psi_two_party.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">Two-party PSI</h4>
       <p class="text-sm text-gray-700 mt-2">ECDH-PSI between two parties over a TCP transport.</p>

--- a/src/pages/threshold/examples.astro
+++ b/src/pages/threshold/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('threshold')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/threshold_local_dkg.rs"
        class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">Local 3-party DKG</h4>

--- a/src/pages/transparency/examples.astro
+++ b/src/pages/transparency/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('transparency')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/transparency_local_log.rs" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">Local Merkle log</h4>
       <p class="text-sm text-gray-700 mt-2">Append entries to an in-memory tree, generate proofs, verify.</p>

--- a/src/pages/verify/examples.astro
+++ b/src/pages/verify/examples.astro
@@ -6,7 +6,13 @@ const product = getProduct('verify')!;
 ---
 
 <Examples product={product}>
-  <div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
+    <p class="text-sm text-yellow-800">
+      <strong>Note:</strong> Example file paths below are planned targets
+      in <code>crates/confium-examples/</code>. Some may not yet exist;
+      check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
+    </p>
+  </div>  <div class="grid md:grid-cols-2 gap-6">
     <a href="https://github.com/confium/confium/tree/main/crates/confium-examples/examples/verify_browser_wasm.html" class="border border-gray-200 rounded-lg p-5 hover:shadow-lg transition-all block">
       <h4 class="font-bold">Browser WASM</h4>
       <p class="text-sm text-gray-700 mt-2">Single HTML page; verifies a signature client-side.</p>


### PR DESCRIPTION
Minisite examples pages reference 24 planned files; only 8 exist in confium-examples/src/bin/. Warning added so visitors aren't confused by GitHub 404s.