### PR TITLE
fix(docs): replace broken /docs/{product}/concepts/* links

### DIFF
--- a/src/pages/keyless/docs.astro
+++ b/src/pages/keyless/docs.astro
@@ -10,18 +10,18 @@ const product = getProduct('keyless')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/keyless/concepts/oidc" class="text-blue-600 hover:underline">OIDC for code signing</a></li>
-        <li>→ <a href="/docs/keyless/concepts/short-lived-certs" class="text-blue-600 hover:underline">Short-lived certificates from threshold keys</a></li>
-        <li>→ <a href="/docs/keyless/concepts/anchoring" class="text-blue-600 hover:underline">Transparency log anchoring</a></li>
-        <li>→ <a href="/docs/keyless/concepts/root-of-trust" class="text-blue-600 hover:underline">Root of trust model</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">OIDC for code signing</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Short-lived certificates from threshold keys</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Transparency log anchoring</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Root of trust model</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/keyless/how-to/github-action" class="text-blue-600 hover:underline">Configure the GitHub Action</a></li>
-        <li>→ <a href="/docs/keyless/how-to/new-oidc-provider" class="text-blue-600 hover:underline">Add a new OIDC provider (Google/GitLab/Azure AD/Okta)</a></li>
-        <li>→ <a href="/docs/keyless/how-to/verify-in-ci" class="text-blue-600 hover:underline">Verify keyless signatures in CI</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Configure the GitHub Action</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Add a new OIDC provider (Google/GitLab/Azure AD/Okta)</a></li>
+        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Verify keyless signatures in CI</a></li>
       </ul>
     </div>
     <div>

--- a/src/pages/pki/docs.astro
+++ b/src/pages/pki/docs.astro
@@ -10,20 +10,20 @@ const product = getProduct('pki')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/pki/concepts/threshold-ca" class="text-blue-600 hover:underline">Threshold CA lifecycle (issue, revoke, CRL)</a></li>
-        <li>→ <a href="/docs/pki/concepts/ocsp-crl" class="text-blue-600 hover:underline">OCSP / CRL from threshold keys</a></li>
-        <li>→ <a href="/docs/pki/concepts/acme" class="text-blue-600 hover:underline">ACME integration with threshold CA</a></li>
-        <li>→ <a href="/docs/pki/concepts/composite" class="text-blue-600 hover:underline">Composite signatures (PQ migration)</a></li>
-        <li>→ <a href="/docs/pki/concepts/attributes" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Threshold CA lifecycle (issue, revoke, CRL)</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">OCSP / CRL from threshold keys</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">ACME integration with threshold CA</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Composite signatures (PQ migration)</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/pki/how-to/deploy-pkcs11-server" class="text-blue-600 hover:underline">Deploy PKCS#11 server as HSM replacement</a></li>
-        <li>→ <a href="/docs/pki/how-to/configure-openssl" class="text-blue-600 hover:underline">Configure OpenSSL 3.0 provider</a></li>
-        <li>→ <a href="/docs/pki/how-to/integrate-jce" class="text-blue-600 hover:underline">Integrate JCE into Java apps</a></li>
-        <li>→ <a href="/docs/pki/how-to/threshold-ca" class="text-blue-600 hover:underline">Stand up a threshold CA</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Deploy PKCS#11 server as HSM replacement</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Configure OpenSSL 3.0 provider</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Integrate JCE into Java apps</a></li>
+        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Stand up a threshold CA</a></li>
       </ul>
     </div>
     <div>

--- a/src/pages/privacy/docs.astro
+++ b/src/pages/privacy/docs.astro
@@ -10,22 +10,22 @@ const product = getProduct('privacy')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/privacy/concepts/psi" class="text-blue-600 hover:underline">Private Set Intersection (PSI)</a></li>
-        <li>→ <a href="/docs/privacy/concepts/pir" class="text-blue-600 hover:underline">Private Information Retrieval (PIR)</a></li>
-        <li>→ <a href="/docs/privacy/concepts/dp" class="text-blue-600 hover:underline">Differential Privacy (DP)</a></li>
-        <li>→ <a href="/docs/privacy/concepts/mpc" class="text-blue-600 hover:underline">Multi-party Computation (MPC / SPDZ)</a></li>
-        <li>→ <a href="/docs/privacy/concepts/ring-sigs" class="text-blue-600 hover:underline">Ring signatures</a></li>
-        <li>→ <a href="/docs/privacy/concepts/blind-sigs" class="text-blue-600 hover:underline">Blind signatures</a></li>
-        <li>→ <a href="/docs/privacy/concepts/vrf-vdf" class="text-blue-600 hover:underline">VRF + VDF</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Private Set Intersection (PSI)</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Private Information Retrieval (PIR)</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Differential Privacy (DP)</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Multi-party Computation (MPC / SPDZ)</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Ring signatures</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Blind signatures</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">VRF + VDF</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/privacy/how-to/choose-primitive" class="text-blue-600 hover:underline">Choose the right primitive</a></li>
-        <li>→ <a href="/docs/privacy/how-to/two-party-psi" class="text-blue-600 hover:underline">Two-party PSI</a></li>
-        <li>→ <a href="/docs/privacy/how-to/mpc-cluster" class="text-blue-600 hover:underline">MPC cluster deployment</a></li>
-        <li>→ <a href="/docs/privacy/how-to/anonymous-credentials" class="text-blue-600 hover:underline">Issue anonymous credentials</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Choose the right primitive</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Two-party PSI</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">MPC cluster deployment</a></li>
+        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Issue anonymous credentials</a></li>
       </ul>
     </div>
     <div>

--- a/src/pages/threshold/docs.astro
+++ b/src/pages/threshold/docs.astro
@@ -10,22 +10,22 @@ const product = getProduct('threshold')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/threshold/concepts/threshold-signing" class="text-blue-600 hover:underline">Threshold signing fundamentals (T-of-N)</a></li>
-        <li>→ <a href="/docs/threshold/concepts/dkg" class="text-blue-600 hover:underline">Distributed Key Generation (DKG)</a></li>
-        <li>→ <a href="/docs/threshold/concepts/mta" class="text-blue-600 hover:underline">Multiplicative-to-Additive (MtA) via Paillier</a></li>
-        <li>→ <a href="/docs/threshold/concepts/share-refresh" class="text-blue-600 hover:underline">Share refresh & proactive security (Herzberg)</a></li>
-        <li>→ <a href="/docs/threshold/concepts/reshare" class="text-blue-600 hover:underline">Reshare: changing T or N without re-keying</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Threshold signing fundamentals (T-of-N)</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Distributed Key Generation (DKG)</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Multiplicative-to-Additive (MtA) via Paillier</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Share refresh & proactive security (Herzberg)</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Reshare: changing T or N without re-keying</a></li>
       </ul>
     </div>
 
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/threshold/how-to/deploy-signerd" class="text-blue-600 hover:underline">Deploy signerd in production</a></li>
-        <li>→ <a href="/docs/threshold/how-to/integrate-hsm" class="text-blue-600 hover:underline">Protect shares with an HSM (PKCS#11)</a></li>
-        <li>→ <a href="/docs/threshold/how-to/refresh" class="text-blue-600 hover:underline">Schedule Herzberg share refresh</a></li>
-        <li>→ <a href="/docs/threshold/how-to/monitor" class="text-blue-600 hover:underline">Monitor signing sessions (Prometheus)</a></li>
-        <li>→ <a href="/docs/threshold/how-to/policy" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Deploy signerd in production</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Protect shares with an HSM (PKCS#11)</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Schedule Herzberg share refresh</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Monitor signing sessions (Prometheus)</a></li>
+        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
       </ul>
     </div>
 
@@ -33,8 +33,8 @@ const product = getProduct('threshold')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/confium-threshold)</a></li>
-        <li>→ <a href="/docs/threshold/reference/config" class="text-blue-600 hover:underline">signerd config reference</a></li>
-        <li>→ <a href="/docs/threshold/reference/cli" class="text-blue-600 hover:underline">confium threshold subcommands</a></li>
+        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">signerd config reference</a></li>
+        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">confium threshold subcommands</a></li>
         <li>→ <a href="/specs/22-threshold-session" class="text-blue-600 hover:underline">Threshold session spec</a></li>
         <li>→ <a href="/specs/70-cmp20" class="text-blue-600 hover:underline">CMP20 spec</a></li>
       </ul>

--- a/src/pages/transparency/docs.astro
+++ b/src/pages/transparency/docs.astro
@@ -10,19 +10,19 @@ const product = getProduct('transparency')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/transparency/concepts/rfc-6962" class="text-blue-600 hover:underline">RFC 6962 inclusion & consistency proofs</a></li>
-        <li>→ <a href="/docs/transparency/concepts/witness-gossip" class="text-blue-600 hover:underline">Witness gossip & fork-resistance</a></li>
-        <li>→ <a href="/docs/transparency/concepts/ots-anchoring" class="text-blue-600 hover:underline">OTS anchoring to Bitcoin / public chains</a></li>
-        <li>→ <a href="/docs/transparency/concepts/ers" class="text-blue-600 hover:underline">Evidence Record Syntax (ERS) long-term archival</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">RFC 6962 inclusion & consistency proofs</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Witness gossip & fork-resistance</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">OTS anchoring to Bitcoin / public chains</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Evidence Record Syntax (ERS) long-term archival</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/transparency/how-to/deploy-log-server" class="text-blue-600 hover:underline">Deploy a production log server</a></li>
-        <li>→ <a href="/docs/transparency/how-to/deploy-monitor" class="text-blue-600 hover:underline">Run a monitor (third-party auditing)</a></li>
-        <li>→ <a href="/docs/transparency/how-to/deploy-edge" class="text-blue-600 hover:underline">Deploy the Cloudflare Workers edge verifier</a></li>
-        <li>→ <a href="/docs/transparency/how-to/bitcoin-anchor" class="text-blue-600 hover:underline">Anchor tree heads to Bitcoin</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Deploy a production log server</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Run a monitor (third-party auditing)</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Deploy the Cloudflare Workers edge verifier</a></li>
+        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Anchor tree heads to Bitcoin</a></li>
       </ul>
     </div>
     <div>

--- a/src/pages/verify/docs.astro
+++ b/src/pages/verify/docs.astro
@@ -10,19 +10,19 @@ const product = getProduct('verify')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/verify/concepts/verifier-only" class="text-blue-600 hover:underline">Verifier-only design philosophy</a></li>
-        <li>→ <a href="/docs/verify/concepts/provenance" class="text-blue-600 hover:underline">Provenance & transparency-log anchoring</a></li>
-        <li>→ <a href="/docs/verify/concepts/batch-verify" class="text-blue-600 hover:underline">Batch verification + LRU cache</a></li>
-        <li>→ <a href="/docs/verify/concepts/bindings" class="text-blue-600 hover:underline">Language bindings parity model</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Verifier-only design philosophy</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Provenance & transparency-log anchoring</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Batch verification + LRU cache</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Language bindings parity model</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/docs/verify/how-to/wasm-in-spa" class="text-blue-600 hover:underline">Embed WASM in a SPA</a></li>
-        <li>→ <a href="/docs/verify/how-to/ci-gate" class="text-blue-600 hover:underline">Add verify gate to CI</a></li>
-        <li>→ <a href="/docs/verify/how-to/server-deploy" class="text-blue-600 hover:underline">Deploy verify-server</a></li>
-        <li>→ <a href="/docs/verify/how-to/dashboard" class="text-blue-600 hover:underline">Real-time verify dashboard</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Embed WASM in a SPA</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Add verify gate to CI</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Deploy verify-server</a></li>
+        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Real-time verify dashboard</a></li>
       </ul>
     </div>
     <div>


### PR DESCRIPTION
30+ broken links across 6 product docs pages. Replaced with valid product overview / docs.rs links.