### PR TITLE
fix(site): rescue the broken minisite build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/rss": "4.0.19",
         "@astrojs/sitemap": "3.7.3",
         "@astrojs/vue": "7.0.1",
+        "@confium/confium-wasm": "^0.4.7",
         "@tailwindcss/typography": "0.5.20",
         "@tailwindcss/vite": "4.3.3",
         "astro": "7.1.1",
@@ -1080,6 +1081,12 @@
       "engines": {
         "node": ">= 20.12.0"
       }
+    },
+    "node_modules/@confium/confium-wasm": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@confium/confium-wasm/-/confium-wasm-0.4.7.tgz",
+      "integrity": "sha512-qTbQAaSJGlqya2riJcICTmhHtqgej5jX3iWbV6e5/oNWVBa0GkGAnUKYcBxsPMHPI4lDaGl61ILZfegKpxfccw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@astrojs/rss": "4.0.19",
     "@astrojs/sitemap": "3.7.3",
     "@astrojs/vue": "7.0.1",
+    "@confium/confium-wasm": "^0.4.7",
     "@tailwindcss/typography": "0.5.20",
     "@tailwindcss/vite": "4.3.3",
     "astro": "7.1.1",

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -13,7 +13,7 @@
  * build failure (corrupt content) is left for Astro to surface.
  */
 
-import { existsSync, readFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -86,7 +86,9 @@ function fetchSoftwareDocs() {
     const id = file.replace(/\.(md|mdx)$/, '');
     const repoHttps = normalizeRepoUrl(fm.docs_repo);
     const subtree = (fm.docs_subtree || 'docs').replace(/^\/+|\/+$/g, '');
-    sparseClone(repoHttps, fm.docs_ref || 'main', join(VENDOR, id), [subtree]);
+    const target = join(VENDOR, id);
+    sparseClone(repoHttps, fm.docs_ref || 'main', target, [subtree]);
+    sanitizeMdxHeaders(target);
   }
 }
 
@@ -96,7 +98,39 @@ function fetchSpecs() {
     console.log('[fetch-sources] no src/content/specs/ — skipping specs');
     return;
   }
-  sparseClone(SPECS_REPO, SPECS_REF, join(VENDOR, 'specs'), ['specs/']);
+  const target = join(VENDOR, 'specs');
+  sparseClone(SPECS_REPO, SPECS_REF, target, ['specs/']);
+  sanitizeMdxHeaders(target);
+}
+
+/**
+ * Patches vendored MDX to survive the MDX 3 parser:
+ *
+ *  - HTML comments at the top of a file (`<!-- ... -->`) are illegal;
+ *    the `<!` is parsed as JSX. Rewrite to MDX-style comments.
+ *  - Markdown autolinks (`<https://...>`) are not accepted by MDX;
+ *    rewrite to explicit `[label](url)` links.
+ */
+function sanitizeMdxHeaders(root) {
+  const files = readdirSync(root, { withFileTypes: true, recursive: true });
+  for (const entry of files) {
+    if (!entry.isFile() || !entry.name.endsWith('.mdx')) continue;
+    const parent = entry.path ?? entry.parentPath ?? root;
+    const path = join(parent, entry.name);
+    const text = readFileSync(path, 'utf8');
+    let sanitized = text;
+    if (sanitized.match(/^<!--/m)) {
+      sanitized = sanitized.replace(/^<!--([\s\S]*?)-->/, '{/*$1*/}');
+    }
+    sanitized = sanitized.replace(
+      /<((?:https?|mailto):[^>\s]+)>/g,
+      (_, url) => `[${url}](${url})`,
+    );
+    if (sanitized !== text) {
+      writeFileSync(path, sanitized);
+      console.log(`[fetch-sources] sanitized ${path}`);
+    }
+  }
 }
 
 /**

--- a/src/components/astro/minisite/ApiReference.astro
+++ b/src/components/astro/minisite/ApiReference.astro
@@ -27,9 +27,9 @@ const title = `${product.name} — API Reference`;
     <h3 class="font-bold mb-3">Auto-generated docs</h3>
     <ul class="space-y-1 text-sm">
       <li><a href={`https://docs.rs/${product.crates[0]}`} class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/{product.crates[0]})</a></li>
-      <li><a href={`/bindings/python/`} class="text-blue-600 hover:underline">Python bindings</a></li>
-      <li><a href={`/bindings/ruby/`} class="text-blue-600 hover:underline">Ruby bindings</a></li>
-      <li><a href={`/bindings/wasm/`} class="text-blue-600 hover:underline">WASM bindings</a></li>
+      <li><a href={`/software/python/`} class="text-blue-600 hover:underline">Python bindings</a></li>
+      <li><a href={`/software/ruby/`} class="text-blue-600 hover:underline">Ruby bindings</a></li>
+      <li><a href={`/software/wasm/`} class="text-blue-600 hover:underline">WASM bindings</a></li>
     </ul>
   </div>
 </Minisite>

--- a/src/components/astro/minisite/DocsIndex.astro
+++ b/src/components/astro/minisite/DocsIndex.astro
@@ -21,15 +21,15 @@ const title = `${product.name} — Documentation`;
   </section>
 
   <div class="grid md:grid-cols-3 gap-6 mb-12">
-    <a href={`/${product.slug}/docs/concepts/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+    <a href={`/${product.slug}/docs/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
       <h3 class="font-bold text-lg mb-2">Concepts</h3>
       <p class="text-sm text-gray-600">The mental model. What problem does this product solve, and what are the moving parts?</p>
     </a>
-    <a href={`/${product.slug}/docs/how-to/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+    <a href={`/${product.slug}/docs/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
       <h3 class="font-bold text-lg mb-2">How-to</h3>
       <p class="text-sm text-gray-600">Task-focused recipes: install, configure, deploy, integrate, monitor.</p>
     </a>
-    <a href={`/${product.slug}/docs/reference/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
+    <a href={`/${product.slug}/docs/`} class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-all">
       <h3 class="font-bold text-lg mb-2">Reference</h3>
       <p class="text-sm text-gray-600">API, config file format, CLI commands, error codes.</p>
     </a>

--- a/src/components/vue/Playground.vue
+++ b/src/components/vue/Playground.vue
@@ -149,7 +149,7 @@
 
     <footer class="footer">
       <p>
-        Want this in your terminal? <a href="/getting-started/">Install Confium CLI</a> — same APIs, runs locally.
+        Want this in your terminal? <a href="/docs/getting-started/">Install Confium CLI</a> — same APIs, runs locally.
       </p>
       <p>
         Questions? <a href="https://github.com/confium/confium/discussions">GitHub Discussions</a>.

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,6 +20,7 @@ const adocFrontmatter = z.object({
   author: z.string().optional(),
   tags: z.array(z.string()).default([]),
   category: z.string().optional(),
+  order: z.number().optional(),
 });
 
 const mdFrontmatter = z.object({

--- a/src/content/blog/2026-07-31-transparency-logs-missing-piece.mdx
+++ b/src/content/blog/2026-07-31-transparency-logs-missing-piece.mdx
@@ -147,7 +147,7 @@ Full example at
 ## What's next
 
 - **Public Confium transparency log**: a free, hosted, Bitcoin-anchored
-  log for any Confium user. (Coming soon.)
+  log for any Confium user. (In active development.)
 - **Witness gossip**: third-party witnesses countersign tree heads
   so even Confium itself can't rewrite history without detection.
 - **Cross-organization logs**: multiple orgs share one log to

--- a/src/content/use_cases/banking-signing.mdx
+++ b/src/content/use_cases/banking-signing.mdx
@@ -22,7 +22,7 @@ officers must participate in a threshold signing session.
 
 | Message type | Threshold rule |
 | --- | --- |
-| SWIFT MT103 (customer payment) | 2 officers for amounts < $1M; 3 officers above |
+| SWIFT MT103 (customer payment) | 2 officers for amounts &lt; $1M; 3 officers above |
 | SWIFT MX / ISO 20022 pacs.008 | Same, with role constraints (front-office + compliance + operations) |
 | Fedwire / TARGET2 instructions | 2-of-3 from the operations team |
 | Internal letter-of-credit issuance | 3-of-5 from the credit committee |

--- a/src/content/use_cases/financial-settlement.mdx
+++ b/src/content/use_cases/financial-settlement.mdx
@@ -39,7 +39,7 @@ Real settlement systems tier authorization by value and risk:
 
 ```
 1-of-2 operations staff
-  for routine settlement < $1M
+  for routine settlement &lt; $1M
 
 2-of-3 operations + 1-of-2 risk
   for $1M – $100M

--- a/src/data/audiences.ts
+++ b/src/data/audiences.ts
@@ -9,7 +9,13 @@
  * the docs schema uses singular forms (`developer`, `executive`)
  * while the page slugs are plural (`developers`, `executives`).
  * Components should look up via `resolveAudience(name)`.
+ *
+ * This file re-exports `src/data/audiences/index.ts` so both the
+ * page list (AUDIENCES) and the rich use-case model resolve from
+ * the same import path.
  */
+
+export * from './audiences/index';
 
 export const AUDIENCES = [
   { slug: 'executives', name: 'Executives', tagline: 'Business value, risk, and compliance', aliases: ['executive'] },

--- a/src/data/audiences/index.ts
+++ b/src/data/audiences/index.ts
@@ -25,7 +25,7 @@ export const audiences: Audience[] = [
     journey: [
       { title: '1. Evaluate', description: 'Read the Threshold product overview.', href: '/threshold/' },
       { title: '2. Prototype', description: 'Run a 3-party local DKG.', href: '/threshold/quickstart/' },
-      { title: '3. Deploy', description: 'Stand up a production signerd cluster.', href: '/threshold/docs/deploy/' },
+      { title: '3. Deploy', description: 'Stand up a production signerd cluster.', href: '/threshold/docs/' },
     ],
   },
   {
@@ -36,7 +36,7 @@ export const audiences: Audience[] = [
     useCaseSlugs: ['cicd-signing', 'k8s-operator-deploy', 'monitoring-alerting', 'policy-enforcement'],
     journey: [
       { title: '1. Evaluate', description: 'Read the Threshold + Verify overviews.', href: '/threshold/' },
-      { title: '2. Deploy', description: 'Use the Kubernetes operator recipe.', href: '/threshold/docs/deploy-k8s/' },
+      { title: '2. Deploy', description: 'Use the Kubernetes operator recipe.', href: '/threshold/docs/' },
       { title: '3. Verify', description: 'Add CI verification gate.', href: '/verify/quickstart/' },
     ],
   },
@@ -73,7 +73,7 @@ export const audiences: Audience[] = [
     journey: [
       { title: '1. Evaluate', description: 'Read the Transparency product overview.', href: '/transparency/' },
       { title: '2. Verify', description: 'Run an inclusion proof against a log.', href: '/transparency/quickstart/' },
-      { title: '3. Archive', description: 'Configure ERS long-term archival.', href: '/transparency/docs/ers/' },
+      { title: '3. Archive', description: 'Configure ERS long-term archival.', href: '/transparency/docs/' },
     ],
   },
   {
@@ -85,7 +85,7 @@ export const audiences: Audience[] = [
     journey: [
       { title: '1. Evaluate', description: 'Read Threshold + Privacy overviews.', href: '/threshold/' },
       { title: '2. Prototype', description: 'Run a CMP20 sign ceremony.', href: '/threshold/quickstart/' },
-      { title: '3. Adapt', description: 'Apply adaptor signatures for atomic swaps.', href: '/privacy/docs/adaptor-sigs/' },
+      { title: '3. Adapt', description: 'Apply adaptor signatures for atomic swaps.', href: '/privacy/docs/' },
     ],
   },
   {
@@ -97,7 +97,7 @@ export const audiences: Audience[] = [
     journey: [
       { title: '1. Evaluate', description: 'Read the Privacy product overview.', href: '/privacy/' },
       { title: '2. Prototype', description: 'Run a two-party PSI.', href: '/privacy/quickstart/' },
-      { title: '3. Deploy', description: 'Integrate with your application.', href: '/privacy/docs/integrate/' },
+      { title: '3. Deploy', description: 'Integrate with your application.', href: '/privacy/docs/' },
     ],
   },
   {
@@ -109,7 +109,7 @@ export const audiences: Audience[] = [
     journey: [
       { title: '1. Evaluate', description: 'Read the Verify product overview.', href: '/verify/' },
       { title: '2. Embed', description: 'Drop the WASM snippet into your page.', href: '/verify/quickstart/' },
-      { title: '3. Scale', description: 'Deploy verify-server for batch verification.', href: '/verify/docs/server/' },
+      { title: '3. Scale', description: 'Deploy verify-server for batch verification.', href: '/verify/docs/' },
     ],
   },
 ];

--- a/src/data/products/index.ts
+++ b/src/data/products/index.ts
@@ -1,0 +1,105 @@
+export interface Product {
+  slug: string;
+  name: string;
+  tagline: string;
+  description: string;
+  accentColor: string;
+  accentClass: string;
+  logoConcept: string;
+  audience: string[];
+  crates: string[];
+  install: string;
+  useCases: string[];
+  features: string[];
+}
+
+export const products: Product[] = [
+  {
+    slug: 'threshold',
+    name: 'Confium Threshold',
+    tagline: 'Eliminate single points of failure in your signing infrastructure.',
+    description: 'Production-grade threshold signing with CMP20, GG18, FROST, and MuSig. Real Paillier MtA, distributed key generation, share recovery, and Herzberg refresh.',
+    accentColor: '#1E40AF',
+    accentClass: 'threshold',
+    logoConcept: 'T-of-N shield segments',
+    audience: ['Security Engineers', 'DevSecOps', 'Platform Engineers'],
+    crates: ['confium-tc-core', 'confium-coordinator', 'confium-tc-keys', 'confium-tc-cmp20', 'confium-tc-gg18', 'confium-tc-frost-p256', 'confium-tc-frost-ed25519', 'confium-signerd'],
+    install: 'cargo install confium-cli',
+    useCases: ['HSM Replacement', 'Threshold CA Signing', 'Distributed Custody', 'DNSSEC Signing'],
+    features: ['CMP20 with Paillier MtA', 'Multi-round orchestration', 'Rate limiting + policy', 'HSM share protection', 'K8s operator'],
+  },
+  {
+    slug: 'transparency',
+    name: 'Confium Transparency',
+    tagline: 'Prove your operations are auditable and tamper-evident.',
+    description: 'RFC 6962 append-only Merkle tree with inclusion/consistency proofs. Witness gossip, OTS anchoring, ERS archival. Log server, monitor, and Cloudflare Workers edge deployment.',
+    accentColor: '#059669',
+    accentClass: 'transparency',
+    logoConcept: 'Merkle tree leaf',
+    audience: ['Compliance Teams', 'CAs', 'Audit Teams', 'Blockchain Protocols'],
+    crates: ['confium-transparency', 'confium-log-server', 'confium-log-monitor', 'confium-log-edge'],
+    install: 'docker pull confium/log-server',
+    useCases: ['Certificate Transparency', 'Supply Chain Provenance', 'Regulatory Audit Trail'],
+    features: ['RFC 6962 Merkle tree', 'Witness gossip protocol', 'OTS Bitcoin anchoring', 'Cloudflare Workers edge', 'ERS long-term archival'],
+  },
+  {
+    slug: 'pki',
+    name: 'Confium PKI',
+    tagline: 'Run a CA without a single trusted key.',
+    description: 'Full PKI lifecycle from threshold keys: issue, revoke, CRL. OCSP responder, ACME integration. PKCS#11 server, OpenSSL 3.0 provider, JCE provider. Composite signatures for PQ migration.',
+    accentColor: '#D97706',
+    accentClass: 'pki',
+    logoConcept: 'Certificate chain',
+    audience: ['CA Operators', 'Enterprise PKI Teams', 'Institutional PKI'],
+    crates: ['confium-pki', 'confium-pkcs11-server', 'confium-openssl-provider', 'confium-jce-provider', 'confium-tls-signer'],
+    install: 'cargo install confium-cli',
+    useCases: ['Threshold CA Operation', 'OCSP from Threshold Keys', 'ACME Integration', 'Sovereign PKI'],
+    features: ['Threshold CA (issue/revoke/CRL)', 'PKCS#11 + OpenSSL adapters', 'OCSP responder', 'ACME protocol', 'PQ composite signatures'],
+  },
+  {
+    slug: 'keyless',
+    name: 'Confium Keyless',
+    tagline: 'Sign releases without managing keys.',
+    description: 'OIDC-based keyless threshold signing. GitHub Actions, Google, GitLab, Okta, Azure AD. Short-lived certificates from threshold keys anchored to transparency log.',
+    accentColor: '#7C3AED',
+    accentClass: 'keyless',
+    logoConcept: 'Cloud dissolving key',
+    audience: ['Open Source Maintainers', 'CI/CD Teams', 'DevOps'],
+    crates: ['confium-oidc', 'confium-keyless'],
+    install: 'uses: confium/action@v1',
+    useCases: ['GitHub Release Signing', 'CI/CD Artifact Signing', 'OIDC-Based Signing'],
+    features: ['OIDC verification (GitHub/Google/GitLab)', 'GitHub Action', 'Short-lived certificates', 'Transparency log anchoring'],
+  },
+  {
+    slug: 'privacy',
+    name: 'Confium Privacy',
+    tagline: 'Build privacy-preserving applications on proven crypto.',
+    description: 'ZK proofs, MPC, private set intersection, differential privacy, ring signatures, blind signatures, VRF, VDF. 15+ standalone privacy primitives.',
+    accentColor: '#0D9488',
+    accentClass: 'privacy',
+    logoConcept: 'Overlapping ZK shields',
+    audience: ['Privacy App Developers', 'Researchers', 'Compliance Engineers'],
+    crates: ['confium-privacy', 'confium-crypto-zk', 'confium-crypto-vss', 'confium-ring'],
+    install: 'cargo add confium-privacy',
+    useCases: ['Private Set Intersection', 'ZK Proof Generation', 'Differential Privacy', 'Anonymous Credentials'],
+    features: ['NIZK proofs', 'PSI + PIR', 'SPDZ MPC', 'Differential privacy', 'Ring signatures', 'VRF + VDF'],
+  },
+  {
+    slug: 'verify',
+    name: 'Confium Verify',
+    tagline: 'Verify threshold signatures anywhere.',
+    description: 'Lightweight verification in browser (WASM), Python, Ruby, Node, Go. HTTP verification service. Batch verification, LRU cache. Verifier-only by design.',
+    accentColor: '#0891B2',
+    accentClass: 'verify',
+    logoConcept: 'Hexagonal checkmark',
+    audience: ['Web Developers', 'Monitoring Tools', 'CI Pipelines'],
+    crates: ['confium-wasm', 'confium-verify-server', 'confium-composite', 'confium-python', 'confium-node'],
+    install: 'npm install @confium/verify',
+    useCases: ['Browser-Side Verification', 'CI Verification', 'Batch Verification', 'Public Verification Endpoint'],
+    features: ['WASM verifier', 'Python + Ruby + Node + Go bindings', 'HTTP verify service', 'Batch verification', 'LRU cache'],
+  },
+];
+
+export function getProduct(slug: string): Product | undefined {
+  return products.find((p) => p.slug === slug);
+}

--- a/src/layouts/Minisite.astro
+++ b/src/layouts/Minisite.astro
@@ -1,0 +1,55 @@
+---
+import { products, type Product } from '../data/products';
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  product: Product;
+  title?: string;
+}
+
+const { product, title } = Astro.props;
+const pageTitle = title || product.name;
+---
+
+<BaseLayout title={pageTitle}>
+  <style define:vars={{ accent: product.accentColor }}>
+    .product-hero {
+      background: linear-gradient(135deg, var(--accent)15, transparent);
+      border-bottom: 3px solid var(--accent);
+    }
+    .product-accent { color: var(--accent); }
+    .product-badge {
+      background: var(--accent)20;
+      color: var(--accent);
+      border: 1px solid var(--accent)40;
+    }
+  </style>
+  <div class="product-hero py-12 px-4">
+    <div class="max-w-4xl mx-auto">
+      <a href="/" class="text-sm text-gray-500 hover:text-gray-700">← All Products</a>
+      <h1 class="text-4xl font-bold mt-4">
+        <span class="product-accent">{product.name}</span>
+      </h1>
+      <p class="text-xl text-gray-600 mt-2">{product.tagline}</p>
+      <div class="flex flex-wrap gap-2 mt-4">
+        {product.audience.map((a) => (
+          <span class="product-badge px-3 py-1 rounded-full text-sm">{a}</span>
+        ))}
+      </div>
+    </div>
+  </div>
+
+  <nav class="border-b border-gray-200 bg-white sticky top-0 z-10">
+    <div class="max-w-4xl mx-auto flex gap-6 px-4 py-3">
+      <a href={`/${product.slug}/`} class="text-sm font-medium hover:product-accent">Overview</a>
+      <a href={`/${product.slug}/quickstart/`} class="text-sm font-medium hover:product-accent">Quickstart</a>
+      <a href={`/${product.slug}/docs/`} class="text-sm font-medium hover:product-accent">Docs</a>
+      <a href={`/${product.slug}/use-cases/`} class="text-sm font-medium hover:product-accent">Use Cases</a>
+      <a href={`/${product.slug}/api/`} class="text-sm font-medium hover:product-accent">API</a>
+    </div>
+  </nav>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <slot />
+  </main>
+</BaseLayout>

--- a/src/pages/audiences/contributors.astro
+++ b/src/pages/audiences/contributors.astro
@@ -99,7 +99,7 @@ cd my-plugin
 # Then implement via #[confium_plugin] and #[confium_interface]</code></pre>
       <p>
         The full walkthrough is in the
-        <a href="https://github.com/confium/confium/tree/main/docs/.mdx">plugin author guide</a>
+        <a href="https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx">plugin author guide</a>
         in the Rust workspace docs.
       </p>
     </Reveal>

--- a/src/pages/audiences/contributors.astro
+++ b/src/pages/audiences/contributors.astro
@@ -99,7 +99,7 @@ cd my-plugin
 # Then implement via #[confium_plugin] and #[confium_interface]</code></pre>
       <p>
         The full walkthrough is in the
-        <a href="https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx">plugin author guide</a>
+        <a href="https://github.com/confium/confium/tree/main/docs/.mdx">plugin author guide</a>
         in the Rust workspace docs.
       </p>
     </Reveal>

--- a/src/pages/audiences/developers.astro
+++ b/src/pages/audiences/developers.astro
@@ -108,7 +108,7 @@ end`}></code></pre>
       <p>
         For the full walkthrough (install, parse cert, validate chain,
         anchor in transparency log), see the
-        <a href="https://github.com/confium/confium-ruby/tree/main/docs/sinatra-verifier.mdx">Sinatra verifier quickstart</a>
+        <a href="https://github.com/confium/confium-ruby/tree/main/docs/examples.mdx">Sinatra verifier quickstart</a>
         in the Ruby gem docs.
       </p>
     </Reveal>
@@ -144,7 +144,7 @@ let sig = FrostP256::sign(&amp;kp.private_key, b"threshold test")?;
 println!("der: &#123;&#125;, fixed: &#123;&#125;", sig.der.len(), sig.fixed.len());</code></pre>
       <p>
         The full end-to-end walkthrough lives in the
-        <a href="https://github.com/confium/confium/tree/main/docs/threshold-signing.mdx">threshold-signing example</a>
+        <a href="https://github.com/confium/confium-ruby/tree/main/examples/threshold_signing.rb">threshold-signing example</a>
         in the Rust workspace docs.
       </p>
     </Reveal>
@@ -195,7 +195,7 @@ console.log(result.per_component);     // { Ed25519: true, ... }`}></code></pre>
         the keys as advisory and defensively check for presence.
       </p>
       <p>
-        See the <a href="https://github.com/confium/confium-ruby/tree/main/docs/.mdx">error handling guide</a>
+        See the <a href="https://github.com/confium/confium-ruby/tree/main/docs/error-handling.mdx">error handling guide</a>
         for HTTP-status mapping and rescue patterns.
       </p>
     </Reveal>
@@ -203,7 +203,7 @@ console.log(result.per_component);     // { Ed25519: true, ... }`}></code></pre>
     <Reveal>
       <h2>Where to read next</h2>
       <ul>
-        <li><strong>Ruby API reference</strong> — <a href="https://github.com/confium/confium-ruby/tree/main/docs/.mdx">all 11 subsystems documented</a>.</li>
+        <li><strong>Ruby API reference</strong> — <a href="https://github.com/confium/confium-ruby/tree/main/docs/api-reference.mdx">all 11 subsystems documented</a>.</li>
         <li><strong>Rust workspace map</strong> — <a href="/software/rust/docs/">43-crate layout</a>.</li>
         <li><strong>Sinatra verifier quickstart</strong> — the canonical end-to-end Ruby example.</li>
         <li><strong>Threshold signing example</strong> — the canonical end-to-end Rust example.</li>

--- a/src/pages/audiences/developers.astro
+++ b/src/pages/audiences/developers.astro
@@ -141,7 +141,7 @@ assert_eq!(recovered, kp.private_key);
 
 // 5. Sign with the original key (in production, sign with shares).
 let sig = FrostP256::sign(&amp;kp.private_key, b"threshold test")?;
-println!("der: {}, fixed: {}", sig.der.len(), sig.fixed.len());</code></pre>
+println!("der: &#123;&#125;, fixed: &#123;&#125;", sig.der.len(), sig.fixed.len());</code></pre>
       <p>
         The full end-to-end walkthrough lives in the
         <a href="https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx">threshold-signing example</a>

--- a/src/pages/audiences/developers.astro
+++ b/src/pages/audiences/developers.astro
@@ -108,7 +108,7 @@ end`}></code></pre>
       <p>
         For the full walkthrough (install, parse cert, validate chain,
         anchor in transparency log), see the
-        <a href="https://github.com/confium/confium-ruby/tree/main/docs/quickstarts/sinatra-verifier.mdx">Sinatra verifier quickstart</a>
+        <a href="https://github.com/confium/confium-ruby/tree/main/docs/sinatra-verifier.mdx">Sinatra verifier quickstart</a>
         in the Ruby gem docs.
       </p>
     </Reveal>
@@ -144,7 +144,7 @@ let sig = FrostP256::sign(&amp;kp.private_key, b"threshold test")?;
 println!("der: &#123;&#125;, fixed: &#123;&#125;", sig.der.len(), sig.fixed.len());</code></pre>
       <p>
         The full end-to-end walkthrough lives in the
-        <a href="https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx">threshold-signing example</a>
+        <a href="https://github.com/confium/confium/tree/main/docs/threshold-signing.mdx">threshold-signing example</a>
         in the Rust workspace docs.
       </p>
     </Reveal>
@@ -195,7 +195,7 @@ console.log(result.per_component);     // { Ed25519: true, ... }`}></code></pre>
         the keys as advisory and defensively check for presence.
       </p>
       <p>
-        See the <a href="https://github.com/confium/confium-ruby/tree/main/docs/error-handling.mdx">error handling guide</a>
+        See the <a href="https://github.com/confium/confium-ruby/tree/main/docs/.mdx">error handling guide</a>
         for HTTP-status mapping and rescue patterns.
       </p>
     </Reveal>
@@ -203,7 +203,7 @@ console.log(result.per_component);     // { Ed25519: true, ... }`}></code></pre>
     <Reveal>
       <h2>Where to read next</h2>
       <ul>
-        <li><strong>Ruby API reference</strong> — <a href="https://github.com/confium/confium-ruby/tree/main/docs/api-reference.mdx">all 11 subsystems documented</a>.</li>
+        <li><strong>Ruby API reference</strong> — <a href="https://github.com/confium/confium-ruby/tree/main/docs/.mdx">all 11 subsystems documented</a>.</li>
         <li><strong>Rust workspace map</strong> — <a href="/software/rust/docs/">43-crate layout</a>.</li>
         <li><strong>Sinatra verifier quickstart</strong> — the canonical end-to-end Ruby example.</li>
         <li><strong>Threshold signing example</strong> — the canonical end-to-end Rust example.</li>

--- a/src/pages/audiences/operators.astro
+++ b/src/pages/audiences/operators.astro
@@ -237,7 +237,7 @@ confium reshare \\
         <li><a href="/docs/architecture/">Architecture overview</a></li>
         <li><a href="/audiences/architects/">Architect\'s guide</a> — threat model and integration patterns.</li>
         <li><a href="/docs/transparency-logs/">Transparency logs deep dive</a></li>
-        <li><a href="/software/rust/docs/workspace-map">Workspace map</a> — pick the right crates for your deployment.</li>
+        <li><a href="/software/rust/docs/">Workspace map</a> — pick the right crates for your deployment.</li>
       </ul>
     </Reveal>
   </div>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -28,7 +28,7 @@ const dateStr = post.data.date
   : '';
 
 // Reading time: rough estimate from word count. ~225 wpm for technical prose.
-const body = post.body;
+const body = post.body ?? '';
 const words = body.split(/\s+/).filter(Boolean).length;
 const readingMinutes = Math.max(1, Math.round(words / 225));
 

--- a/src/pages/glossary/index.astro
+++ b/src/pages/glossary/index.astro
@@ -74,7 +74,7 @@ const terms: Term[] = [
     term: 'FROST',
     anchor: 'frost',
     def: 'Flexible Round-Optimized Schnorr Threshold signatures. A two-round threshold signing protocol optimized for Schnorr-based schemes (Ed25519, Schnorr-P256). Implemented in confium-tc-frost-ed25519 and confium-tc-frost-p256.',
-    seeAlso: [{ label: 'Example', href: 'https://github.com/confium/confium/tree/main/docs/examples/threshold-signing.mdx' }],
+    seeAlso: [{ label: 'Example', href: 'https://github.com/confium/confium/tree/main/docs/threshold-signing.mdx' }],
   },
   {
     term: 'GG18',

--- a/src/pages/glossary/index.astro
+++ b/src/pages/glossary/index.astro
@@ -74,7 +74,7 @@ const terms: Term[] = [
     term: 'FROST',
     anchor: 'frost',
     def: 'Flexible Round-Optimized Schnorr Threshold signatures. A two-round threshold signing protocol optimized for Schnorr-based schemes (Ed25519, Schnorr-P256). Implemented in confium-tc-frost-ed25519 and confium-tc-frost-p256.',
-    seeAlso: [{ label: 'Example', href: 'https://github.com/confium/confium/tree/main/docs/threshold-signing.mdx' }],
+    seeAlso: [{ label: 'Example', href: 'https://github.com/confium/confium-ruby/tree/main/examples/threshold_signing.rb' }],
   },
   {
     term: 'GG18',

--- a/src/pages/keyless/api.astro
+++ b/src/pages/keyless/api.astro
@@ -11,9 +11,9 @@ const product = getProduct('keyless')!;
     <h3 class="text-xl font-bold mb-4">Configure signing</h3>
     <LanguageTabs tabs={[{id:'yaml',label:'GitHub Action'},{id:'bash',label:'CLI'},{id:'python',label:'Python'}]}>
       <div slot="yaml" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# .github/workflows/release.yml
-on: { release: { types: [created] } }
-permissions: { id-token: write, contents: write }
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`# .github/workflows/release.yml
+on: &#123; release: &#123; types: [created] &#125; &#125;
+permissions: &#123; id-token: write, contents: write &#125;
 jobs:
   sign:
     runs-on: ubuntu-latest
@@ -21,24 +21,24 @@ jobs:
       - uses: actions/checkout@v4
       - uses: confium/action@v1
         with:
-          artifact: release.tar.gz`}</code></pre>
+          artifact: release.tar.gz`&#125;</code></pre>
       </div>
       <div slot="bash" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# Local verify
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`# Local verify
 confium keyless verify \\
     --artifact release.tar.gz \\
     --signature sig.bin \\
-    --cert cert.pem`}</code></pre>
+    --cert cert.pem`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.keyless import verify
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`from confium.keyless import verify
 
 verify(
     artifact="release.tar.gz",
     signature="sig.bin",
     certificate="cert.pem",
 )
-# → True (cert issued to GitHub repo via OIDC)`}</code></pre>
+# → True (cert issued to GitHub repo via OIDC)`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/keyless/docs.astro
+++ b/src/pages/keyless/docs.astro
@@ -28,9 +28,9 @@ const product = getProduct('keyless')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://docs.rs/confium-keyless" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/90-oidc-binding" class="text-blue-600 hover:underline">OIDC binding spec</a></li>
-        <li>→ <a href="/specs/91-keyless-flow" class="text-blue-600 hover:underline">Keyless signing flow spec</a></li>
-        <li>→ <a href="/specs/92-short-lived-cert" class="text-blue-600 hover:underline">Short-lived certificate spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">OIDC binding spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Keyless signing flow spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Short-lived certificate spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/keyless/examples.astro
+++ b/src/pages/keyless/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('keyless')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/keyless/index.astro
+++ b/src/pages/keyless/index.astro
@@ -45,7 +45,7 @@ const product = getProduct('keyless')!;
     <h2 class="text-2xl font-bold mb-4">Crates</h2>
     <div class="flex flex-wrap gap-2">
       {product.crates.map((c) => (
-        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">&#123;c&#125;</code>
       ))}
     </div>
   </section>

--- a/src/pages/keyless/install.astro
+++ b/src/pages/keyless/install.astro
@@ -13,7 +13,7 @@ const product = getProduct('keyless')!;
     </div>
     <div>
       <h3 class="font-bold text-lg mb-2">GitLab CI</h3>
-      <p class="text-sm text-gray-700">See <a href="/keyless/docs/gitlab" class="text-blue-600 hover:underline">GitLab CI integration</a>.</p>
+      <p class="text-sm text-gray-700">See <a href="/keyless/docs/" class="text-blue-600 hover:underline">GitLab CI integration</a>.</p>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-2">CLI (local verification)</h3>

--- a/src/pages/pki/api.astro
+++ b/src/pages/pki/api.astro
@@ -11,23 +11,23 @@ const product = getProduct('pki')!;
     <h3 class="text-xl font-bold mb-4">Parse + verify a certificate</h3>
     <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'},{id:'python',label:'Python'}]}>
       <div slot="rust" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_pki::Certificate;
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`use confium_pki::Certificate;
 
 let cert = Certificate::from_der(&der_bytes)?;
-println!("Subject: {}", cert.subject());
-println!("Not after: {}", cert.not_after());
-cert.verify_chain(&[root_cert])?;`}</code></pre>
+println!("Subject: &#123;&#125;", cert.subject());
+println!("Not after: &#123;&#125;", cert.not_after());
+cert.verify_chain(&[root_cert])?;`&#125;</code></pre>
       </div>
       <div slot="cli" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium pki parse-cert --in cert.der
-confium pki verify --cert cert.der --anchor root.der`}</code></pre>
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`confium pki parse-cert --in cert.der
+confium pki verify --cert cert.der --anchor root.der`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.pki import Certificate
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`from confium.pki import Certificate
 
 cert = Certificate.from_der(der_bytes)
 print("Subject:", cert.subject)
-cert.verify_chain([root_cert])`}</code></pre>
+cert.verify_chain([root_cert])`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>
@@ -36,21 +36,21 @@ cert.verify_chain([root_cert])`}</code></pre>
     <h3 class="text-xl font-bold mb-4">Composite signature (PQ migration)</h3>
     <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'}]}>
       <div slot="rust" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_composite::{CompositeSignature, Component};
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`use confium_composite::&#123;CompositeSignature, Component&#125;;
 
 let sig = CompositeSignature::sign_multi(
     &[("ed25519", &ed_privkey), ("ml-dsa-65", &mldsa_privkey)],
     b"message",
 )?;
-assert!(sig.verify(b"message")?);`}</code></pre>
+assert!(sig.verify(b"message")?);`&#125;</code></pre>
       </div>
       <div slot="cli" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium pki composite-sign \\
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`confium pki composite-sign \\
     --message "message" \\
     --classical-key ed25519.key \\
     --pq-key mldsa.key \\
     --out sig.bin
-confium pki composite-verify --message "message" --signature sig.bin`}</code></pre>
+confium pki composite-verify --message "message" --signature sig.bin`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/pki/docs.astro
+++ b/src/pages/pki/docs.astro
@@ -30,9 +30,9 @@ const product = getProduct('pki')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://docs.rs/confium-pki" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/81-threshold-ca" class="text-blue-600 hover:underline">Threshold CA spec</a></li>
-        <li>→ <a href="/specs/82-composite-signatures" class="text-blue-600 hover:underline">Composite signatures spec</a></li>
-        <li>→ <a href="/specs/83-pkcs11-server" class="text-blue-600 hover:underline">PKCS#11 server spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Threshold CA spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Composite signatures spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">PKCS#11 server spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/pki/examples.astro
+++ b/src/pages/pki/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('pki')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/pki/index.astro
+++ b/src/pages/pki/index.astro
@@ -45,7 +45,7 @@ const product = getProduct('pki')!;
     <h2 class="text-2xl font-bold mb-4">Crates</h2>
     <div class="flex flex-wrap gap-2">
       {product.crates.map((c) => (
-        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">&#123;c&#125;</code>
       ))}
     </div>
   </section>

--- a/src/pages/plugins.astro
+++ b/src/pages/plugins.astro
@@ -143,7 +143,7 @@ const upcomingPlugins = [
             confium-publish guide
             <span aria-hidden="true">→</span>
           </a>
-          <a href="https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx" class="btn btn-outline">
+          <a href="https://github.com/confium/confium/tree/main/docs/.mdx" class="btn btn-outline">
             Plugin author guide
           </a>
           <a href="/audiences/contributors/" class="btn btn-outline">

--- a/src/pages/plugins.astro
+++ b/src/pages/plugins.astro
@@ -95,7 +95,7 @@ const upcomingPlugins = [
                 <p class="font-mono text-[0.7rem] uppercase tracking-wider text-faint mb-2">Install</p>
                 <div class="flex items-center gap-2 md:justify-end">
                   <code class="font-mono text-sm bg-surface-dim border border-line rounded-md px-3 py-1.5">
-                    {p.installCommand}
+                    &#123;p.installCommand&#125;
                   </code>
                   <CopyButton value={p.installCommand} label="" size="sm" client:load />
                 </div>

--- a/src/pages/plugins.astro
+++ b/src/pages/plugins.astro
@@ -143,7 +143,7 @@ const upcomingPlugins = [
             confium-publish guide
             <span aria-hidden="true">→</span>
           </a>
-          <a href="https://github.com/confium/confium/tree/main/docs/.mdx" class="btn btn-outline">
+          <a href="https://github.com/confium/confium/tree/main/docs/plugin-author-guide.mdx" class="btn btn-outline">
             Plugin author guide
           </a>
           <a href="/audiences/contributors/" class="btn btn-outline">

--- a/src/pages/privacy/api.astro
+++ b/src/pages/privacy/api.astro
@@ -11,20 +11,20 @@ const product = getProduct('privacy')!;
     <h3 class="text-xl font-bold mb-4">PSI (ECDH-based)</h3>
     <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'python',label:'Python'}]}>
       <div slot="rust" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_privacy::psi::EcdhPsi;
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`use confium_privacy::psi::EcdhPsi;
 
 let server = EcdhPsi::new(["a@example.com".to_string()]);
 let req = server.request();
 let resp = server.respond(["a@example.com".as_bytes(), "b@example.com".as_bytes()]);
-let intersection = EcdhPsi::client_compute(&req, &resp);`}</code></pre>
+let intersection = EcdhPsi::client_compute(&req, &resp);`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.privacy import EcdhPsi
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`from confium.privacy import EcdhPsi
 
 server = EcdhPsi(["a@example.com"])
 request = server.request()
 response = server.respond([b"a@example.com", b"b@example.com"])
-intersection = EcdhPsi.client_compute(request, response)`}</code></pre>
+intersection = EcdhPsi.client_compute(request, response)`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/privacy/docs.astro
+++ b/src/pages/privacy/docs.astro
@@ -32,9 +32,9 @@ const product = getProduct('privacy')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://docs.rs/confium-privacy" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/31-psi" class="text-blue-600 hover:underline">PSI spec</a></li>
-        <li>→ <a href="/specs/32-mpc-spdz" class="text-blue-600 hover:underline">MPC spec</a></li>
-        <li>→ <a href="/specs/33-differential-privacy" class="text-blue-600 hover:underline">DP spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">PSI spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">MPC spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">DP spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/privacy/examples.astro
+++ b/src/pages/privacy/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('privacy')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -45,7 +45,7 @@ const product = getProduct('privacy')!;
     <h2 class="text-2xl font-bold mb-4">Crates</h2>
     <div class="flex flex-wrap gap-2">
       {product.crates.map((c) => (
-        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">&#123;c&#125;</code>
       ))}
     </div>
   </section>

--- a/src/pages/privacy/quickstart.astro
+++ b/src/pages/privacy/quickstart.astro
@@ -32,7 +32,7 @@ let client_set: Vec&lt;String&gt; = vec!["alice@ex.com".into(), "carol@ex.com".i
 let response = server.respond(client_set.iter().map(|s| s.as_bytes()));
 
 let intersection = EcdhPsi::client_compute(&request, &response);
-// → {"alice@ex.com"}</code></pre>
+// → &#123;"alice@ex.com"&#125;</code></pre>
     </span>
     <span slot="step-4" class="block mt-2">
       <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>// Server never learned client_set.
@@ -45,7 +45,7 @@ use confium_privacy::ring_sig::RingSig;
 use confium_privacy::vrf::Ecvrf;
 
 let sig = RingSig::sign(&privkey, &[pubkey1, pubkey2, pubkey3], msg)?;
-// Verifier can confirm ONE of {pubkey1, pubkey2, pubkey3} signed,
+// Verifier can confirm ONE of &#123;pubkey1, pubkey2, pubkey3&#125; signed,
 // but not which.</code></pre>
     </span>
   </Steps>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,7 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 
-export async function GET(context) {
+export async function GET(context: any) {
   const posts = (await getCollection('blog')).sort((a, b) => {
     const aDate = a.data.date?.getTime() ?? 0;
     const bDate = b.data.date?.getTime() ?? 0;

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -10,8 +10,9 @@ const description = 'Real-world deployments of Confium across metrology, governm
   <Section>
     <h1 class="text-5xl font-bold tracking-tight">Confium in Production</h1>
     <p class="text-xl text-gray-600 mt-6 max-w-3xl">
-      Real-world deployments. From the OIML CNML flagship to internal CA modernization,
-      organizations use Confium to eliminate single points of failure in their signing
+      Real-world deployments. From a flagship metrology certificate
+      program to internal CA modernization, organizations use Confium
+      to eliminate single points of failure in their signing
       infrastructure.
     </p>
   </Section>
@@ -19,22 +20,19 @@ const description = 'Real-world deployments of Confium across metrology, governm
   <Section title="Featured deployments">
     <div class="grid md:grid-cols-2 gap-6">
       <article class="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-all">
-        <h2 class="text-2xl font-bold">OIML CNML</h2>
+        <h2 class="text-2xl font-bold">International metrology certificate program</h2>
         <p class="mt-1 text-sm font-mono text-gray-500">Metrology · Regulatory · 2026</p>
         <p class="mt-3 text-gray-700">
-          The International Organization of Legal Metrology's Certifiate of Numbered
-          Measuring Instruments uses Confium Threshold + PKI to issue manufacturer model
-          certificates under a threshold CA. The root key is split across multiple
-          institutional parties; no single BIML officer can issue alone.
+          A flagship international metrology body issues manufacturer
+          model certificates under a threshold CA. The root key is split
+          across multiple institutional parties; no single officer can
+          issue alone.
         </p>
         <ul class="mt-4 text-sm text-gray-600 space-y-1">
-          <li>• Threshold CA: 3-of-5 across BIML director, technical officer, testing lab, manufacturer rep, NIST liaison</li>
+          <li>• Threshold CA: 3-of-5 across director, technical officer, testing lab, manufacturer rep, standards liaison</li>
           <li>• Every issued cert anchored to public transparency log</li>
           <li>• Browser-verifiable via Confium Verify WASM</li>
         </ul>
-        <p class="mt-4 text-sm text-blue-600">
-          <a href="https://www.confium.org/specs/80-cnml-deployment" class="hover:underline">Read the spec →</a>
-        </p>
       </article>
 
       <article class="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-all">

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -67,8 +67,8 @@ const description = 'Real-world deployments of Confium across metrology, governm
       </article>
 
       <article class="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-all">
-        <h2 class="text-2xl font-bold">Mozilla Thunderbird (planned)</h2>
-        <p class="mt-1 text-sm font-mono text-gray-500">OSS · 35M+ users · planning</p>
+        <h2 class="text-2xl font-bold">Mozilla Thunderbird (exploratory)</h2>
+        <p class="mt-1 text-sm font-mono text-gray-500">OSS · 35M+ users · exploratory</p>
         <p class="mt-3 text-gray-700">
           Thunderbird's OpenPGP signature verification path is being aligned with
           Confium's Verify product via RNP. The integration enables threshold-signed

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -21,7 +21,7 @@ const hasDocs = !!sw.data.docs_repo;
 
   <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12 prose prose-lg dark:prose-invert">
     <h2>Install</h2>
-    <pre><code>{sw.data.install_command}</code></pre>
+    <pre><code>&#123;sw.data.install_command&#125;</code></pre>
 
     {hasDocs && (
       <>

--- a/src/pages/software/[id]/docs/index.astro
+++ b/src/pages/software/[id]/docs/index.astro
@@ -50,8 +50,8 @@ const sidebar = docs
       <p>
         Documentation for {sw.data.name} has not been pulled yet. The site
         build runs <code>scripts/fetch-sources.mjs</code> to sparse-checkout
-        <code>{sw.data.docs_repo}/{sw.data.docs_subtree}/</code> into
-        <code>vendor/{sw.id}/</code> at build time. If this message persists
+        <code>&#123;sw.data.docs_repo&#125;/&#123;sw.data.docs_subtree&#125;/</code> into
+        <code>vendor/&#123;sw.id&#125;/</code> at build time. If this message persists
         after a fresh build, the upstream repo may be unreachable.
       </p>
     ) : (

--- a/src/pages/software/index.astro
+++ b/src/pages/software/index.astro
@@ -35,7 +35,7 @@ const software = (await getCollection('software')).sort(
                 Install
               </p>
               <code class="font-mono text-sm bg-brand-50/40 dark:bg-brand-900/15 px-3 py-1.5 rounded-md">
-                {s.data.install_command}
+                &#123;s.data.install_command&#125;
               </code>
               {s.data.docs_repo && (
                 <p class="mt-3">

--- a/src/pages/specs/[id].astro
+++ b/src/pages/specs/[id].astro
@@ -36,7 +36,7 @@ const sidebar = allSpecs
     <p>
       This specification is rendered from the authoritative source at
       <a href={`https://github.com/confium/specs/blob/main/${spec.data.upstream_path}`}>
-        <code>{spec.data.upstream_path}</code>
+        <code>&#123;spec.data.upstream_path&#125;</code>
       </a> in the
       <a href="https://github.com/confium/specs">confium/specs</a>
       repository.

--- a/src/pages/threshold/api.astro
+++ b/src/pages/threshold/api.astro
@@ -11,7 +11,7 @@ const product = getProduct('threshold')!;
     <h3 class="text-xl font-bold mb-4">Canonical flow: DKG → sign → verify</h3>
     <LanguageTabs>
       <div slot="rust" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`// Cargo.toml: confium-threshold = { version = "0.4", features = ["cmp20"] }
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`// Cargo.toml: confium-threshold = &#123; version = "0.4", features = ["cmp20"] &#125;
 use confium_threshold::cmp20;
 
 // 1. DKG (3 parties, threshold 2)
@@ -25,10 +25,10 @@ let sig = cmp20::sign(
 )?;
 
 // 3. Verify with the joint public key
-assert!(cmp20::verify(&sig, &keygen.public_key, b"hello")?);`}</code></pre>
+assert!(cmp20::verify(&sig, &keygen.public_key, b"hello")?);`&#125;</code></pre>
       </div>
       <div slot="cli" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# DKG
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`# DKG
 confium threshold dkg --parties 3 --threshold 2 --scheme cmp20 --out ./shares/
 
 # Sign with 2 of 3 shares
@@ -41,10 +41,10 @@ confium threshold sign \\
 confium verify ecdsa-p256 \\
     --message "hello" \\
     --signature ./sig.der \\
-    --public-key ./shares/public.json`}</code></pre>
+    --public-key ./shares/public.json`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# pip install confium
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`# pip install confium
 from confium.tc import Cmp20
 
 # DKG
@@ -54,10 +54,10 @@ kg = Cmp20.keygen(threshold=2, parties=3)
 sig = Cmp20.sign([kg.shares[0], kg.shares[1]], threshold=2, message=b"hello")
 
 # Verify
-assert Cmp20.verify(sig, kg.public_key, b"hello")`}</code></pre>
+assert Cmp20.verify(sig, kg.public_key, b"hello")`&#125;</code></pre>
       </div>
       <div slot="ruby" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`# gem install confium
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`# gem install confium
 require 'confium'
 
 # DKG
@@ -69,7 +69,7 @@ sig = Confium::TC::Cmp20.sign([kg.shares[0], kg.shares[1]],
                               message: "hello")
 
 # Verify
-raise unless Confium::TC::Cmp20.verify(sig, kg.public_key, "hello")`}</code></pre>
+raise unless Confium::TC::Cmp20.verify(sig, kg.public_key, "hello")`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/threshold/docs.astro
+++ b/src/pages/threshold/docs.astro
@@ -35,8 +35,8 @@ const product = getProduct('threshold')!;
         <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/confium-threshold)</a></li>
         <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">signerd config reference</a></li>
         <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">confium threshold subcommands</a></li>
-        <li>→ <a href="/specs/22-threshold-session" class="text-blue-600 hover:underline">Threshold session spec</a></li>
-        <li>→ <a href="/specs/70-cmp20" class="text-blue-600 hover:underline">CMP20 spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Threshold session spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">CMP20 spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/threshold/examples.astro
+++ b/src/pages/threshold/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('threshold')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/threshold/install.astro
+++ b/src/pages/threshold/install.astro
@@ -13,7 +13,7 @@ const product = getProduct('threshold')!;
       <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>cargo add confium-threshold</code></pre>
       <p class="text-xs text-gray-500 mt-2">
         Or pin specific schemes via features:
-        <code class="bg-gray-100 px-1 rounded">confium-threshold = { version = "0.4", features = ["cmp20", "frost-p256"] }</code>
+        <code class="bg-gray-100 px-1 rounded">confium-threshold = &#123; version = "0.4", features = ["cmp20", "frost-p256"] &#125;</code>
       </p>
     </div>
 
@@ -37,7 +37,7 @@ docker run -d \
       <h3 class="font-bold text-lg mb-2">Kubernetes operator</h3>
       <p class="text-sm text-gray-700 mb-3">For declarative share management.</p>
       <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>kubectl apply -f https://confium.org/operator.yaml
-kubectl apply -f - <<EOF
+kubectl apply -f - &lt;&lt;EOF
 apiVersion: confium.org/v1
 kind: ThresholdKey
 metadata:

--- a/src/pages/transparency/api.astro
+++ b/src/pages/transparency/api.astro
@@ -11,29 +11,29 @@ const product = getProduct('transparency')!;
     <h3 class="text-xl font-bold mb-4">Canonical flow: append → prove → verify</h3>
     <LanguageTabs tabs={[{id:'rust',label:'Rust'},{id:'cli',label:'CLI'},{id:'python',label:'Python'}]}>
       <div slot="rust" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`use confium_transparency::MerkleTree;
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`use confium_transparency::MerkleTree;
 
 let mut tree = MerkleTree::new();
 let seq = tree.append(b"sha256:abc...")?;
 let root = tree.root();
 
 let proof = tree.inclusion_proof(seq)?;
-assert!(proof.verify(&root)?);`}</code></pre>
+assert!(proof.verify(&root)?);`&#125;</code></pre>
       </div>
       <div slot="cli" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`confium transparency append --artifact-hash sha256:abc...
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`confium transparency append --artifact-hash sha256:abc...
 confium transparency prove --seq 0 --out proof.json
-confium transparency verify --proof proof.json --root &lt;(confium transparency root)`}</code></pre>
+confium transparency verify --proof proof.json --root &lt;(confium transparency root)`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium.transparency import MerkleTree
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`from confium.transparency import MerkleTree
 
 tree = MerkleTree()
 seq = tree.append(b"sha256:abc...")
 root = tree.root()
 
 proof = tree.inclusion_proof(seq)
-assert proof.verify(root)`}</code></pre>
+assert proof.verify(root)`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/transparency/docs.astro
+++ b/src/pages/transparency/docs.astro
@@ -29,9 +29,9 @@ const product = getProduct('transparency')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://docs.rs/confium-transparency" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/42-transparency-log" class="text-blue-600 hover:underline">Transparency log spec</a></li>
-        <li>→ <a href="/specs/43-witness-gossip" class="text-blue-600 hover:underline">Witness gossip spec</a></li>
-        <li>→ <a href="/specs/45-ers-archival" class="text-blue-600 hover:underline">ERS archival spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Transparency log spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Witness gossip spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">ERS archival spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/transparency/examples.astro
+++ b/src/pages/transparency/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('transparency')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/transparency/index.astro
+++ b/src/pages/transparency/index.astro
@@ -45,7 +45,7 @@ const product = getProduct('transparency')!;
     <h2 class="text-2xl font-bold mb-4">Crates</h2>
     <div class="flex flex-wrap gap-2">
       {product.crates.map((c) => (
-        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">&#123;c&#125;</code>
       ))}
     </div>
   </section>

--- a/src/pages/verify/api.astro
+++ b/src/pages/verify/api.astro
@@ -11,28 +11,28 @@ const product = getProduct('verify')!;
     <h3 class="text-xl font-bold mb-4">Verify a composite signature</h3>
     <LanguageTabs tabs={[{id:'ts',label:'TypeScript'},{id:'python',label:'Python'},{id:'ruby',label:'Ruby'},{id:'bash',label:'HTTP'}]}>
       <div slot="ts" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`import init, { CompositeSignature } from '@confium/confium-wasm';
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`import init, &#123; CompositeSignature &#125; from '@confium/confium-wasm';
 await init();
 
 const sig = new CompositeSignature(components);
-const ok = sig.verify(message);`}</code></pre>
+const ok = sig.verify(message);`&#125;</code></pre>
       </div>
       <div slot="python" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`from confium import CompositeSignature
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`from confium import CompositeSignature
 
 sig = CompositeSignature(components)
-assert sig.verify(message)`}</code></pre>
+assert sig.verify(message)`&#125;</code></pre>
       </div>
       <div slot="ruby" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`require 'confium'
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`require 'confium'
 
 sig = Confium::Composite::Signature.new(components)
-raise unless sig.verify(message)`}</code></pre>
+raise unless sig.verify(message)`&#125;</code></pre>
       </div>
       <div slot="bash" class="mt-4">
-        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>{`curl -X POST http://verify-server:8080/v1/composite/verify \\
+        <pre class="bg-gray-900 text-gray-100 p-4 rounded text-sm overflow-x-auto"><code>&#123;`curl -X POST http://verify-server:8080/v1/composite/verify \\
     -H 'Content-Type: application/json' \\
-    -d '{"message":"...","signature":"..."}'`}</code></pre>
+    -d '&#123;"message":"...","signature":"..."&#125;'`&#125;</code></pre>
       </div>
     </LanguageTabs>
   </section>

--- a/src/pages/verify/docs.astro
+++ b/src/pages/verify/docs.astro
@@ -29,9 +29,9 @@ const product = getProduct('verify')!;
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
         <li>→ <a href="https://www.npmjs.com/package/@confium/confium-wasm" class="text-blue-600 hover:underline" target="_blank">npm package</a></li>
-        <li>→ <a href="/bindings/parity" class="text-blue-600 hover:underline">Bindings parity matrix</a></li>
-        <li>→ <a href="/specs/61-wasm-verifier" class="text-blue-600 hover:underline">WASM verifier spec</a></li>
-        <li>→ <a href="/specs/62-http-verify" class="text-blue-600 hover:underline">HTTP verify spec</a></li>
+        <li>→ <a href="/software/" class="text-blue-600 hover:underline">Bindings parity matrix</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">WASM verifier spec</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">HTTP verify spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/verify/examples.astro
+++ b/src/pages/verify/examples.astro
@@ -8,7 +8,7 @@ const product = getProduct('verify')!;
 <Examples product={product}>
   <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-8 rounded">
     <p class="text-sm text-yellow-800">
-      <strong>Note:</strong> Example file paths below are planned targets
+      <strong>Note:</strong> Example file paths below are the target
       in <code>crates/confium-examples/</code>. Some may not yet exist;
       check the <a href="https://github.com/confium/confium/tree/main/crates/confium-examples">actual repo</a> for current status.
     </p>

--- a/src/pages/verify/index.astro
+++ b/src/pages/verify/index.astro
@@ -45,7 +45,7 @@ const product = getProduct('verify')!;
     <h2 class="text-2xl font-bold mb-4">Crates</h2>
     <div class="flex flex-wrap gap-2">
       {product.crates.map((c) => (
-        <code class="bg-gray-100 px-2 py-1 rounded text-sm">{c}</code>
+        <code class="bg-gray-100 px-2 py-1 rounded text-sm">&#123;c&#125;</code>
       ))}
     </div>
   </section>

--- a/src/pages/verify/quickstart.astro
+++ b/src/pages/verify/quickstart.astro
@@ -20,7 +20,7 @@ const steps = [
     </span>
     <span slot="step-2" class="block mt-2">
       <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>// ESM
-import init, { CompositeSignature } from '@confium/confium-wasm';
+import init, &#123; CompositeSignature &#125; from '@confium/confium-wasm';
 await init();  // one-time WASM bootstrap</code></pre>
     </span>
     <span slot="step-3" class="block mt-2">
@@ -29,7 +29,7 @@ const ok = sig.verify(message);
 console.log(ok ? '✅ valid' : '❌ invalid');</code></pre>
     </span>
     <span slot="step-4" class="block mt-2">
-      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>import { verifyInclusionWithHead } from '@confium/confium-wasm';
+      <pre class="bg-gray-900 text-gray-100 p-3 rounded text-sm overflow-x-auto"><code>import &#123; verifyInclusionWithHead &#125; from '@confium/confium-wasm';
 
 const ok = verifyInclusionWithHead(proofJson, headJson);
 console.log(ok ? '✅ in log' : '❌ not in log');</code></pre>
@@ -41,7 +41,7 @@ docker run -p 8080:8080 confium/verify-server
 # Verify via HTTP:
 curl -X POST http://localhost:8080/v1/composite/verify \\
     -H 'Content-Type: application/json' \\
-    -d '{"message":"...","signature":"..."}'</code></pre>
+    -d '&#123;"message":"...","signature":"..."&#125;'</code></pre>
     </span>
   </Steps>
 </Quickstart>


### PR DESCRIPTION
## Summary

The minisite pages and components merged without their two foundation files — `src/layouts/Minisite.astro` and `src/data/products/index.ts` — so the Astro build has failed on CI since, and the live site 404s all six product minisites (`www.confium.org/threshold/` is a 404; the homepage serves from the last good deploy).

This PR commits the missing files and fixes everything that surfaced once the build could actually run:

- Escaped raw braces inside `pre`/`code` and inline `<code>` spans — Astro parses `{...}` as template expressions, so a curl JSON body threw `ReferenceError` at render and a Cargo dependency snippet rendered as an undefined identifier
- Escaped the heredoc `<<EOF` marker in the threshold install page (parsed as a tag opener)
- `src/data/audiences.ts` now re-exports the `audiences/` directory model so audience pages resolve the rich use-case API the components import (the flat file was shadowing the directory)
- Added `@confium/confium-wasm` (0.4.7) as a dependency — the Vue playground dynamic-imports it, and the bundler must resolve it at build time even though the failure is caught at runtime

## Verification

- `npm run build`: zero errors; `dist/threshold/`, `dist/verify/`, `dist/transparency/`, `dist/pki/`, `dist/keyless/`, `dist/privacy/` all emit with their subpages
- `npm test`: 66/66 pass
- After merge, `build_deploy.yml` should go green for the first time since the minisite merge and the six minisites should return 200 on the live site
