### PR TITLE
docs(site): minisite Docs pages link real destinations

### DIFF
--- a/src/pages/keyless/docs.astro
+++ b/src/pages/keyless/docs.astro
@@ -10,27 +10,28 @@ const product = getProduct('keyless')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">OIDC for code signing</a></li>
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Short-lived certificates from threshold keys</a></li>
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Transparency log anchoring</a></li>
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Root of trust model</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">Keyless in the layer map</a></li>
+        <li>→ <a href="/concepts/threshold-crypto-101/" class="text-blue-600 hover:underline">Why threshold behind keyless</a></li>
+        <li>→ <a href="/use-cases/keyless-ci-signing/" class="text-blue-600 hover:underline">Use case: keyless CI signing</a></li>
+        <li>→ <a href="/use-cases/keyless-threshold-code-signing/" class="text-blue-600 hover:underline">Use case: keyless threshold code signing</a></li>
+        <li>→ <a href="/use-cases/git-signing/" class="text-blue-600 hover:underline">Use case: Git commit signing</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Configure the GitHub Action</a></li>
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Add a new OIDC provider (Google/GitLab/Azure AD/Okta)</a></li>
-        <li>→ <a href="/keyless/" class="text-blue-600 hover:underline">Verify keyless signatures in CI</a></li>
+        <li>→ <a href="/keyless/quickstart/" class="text-blue-600 hover:underline">Quickstart: sign a release from CI</a></li>
+        <li>→ <a href="/use-cases/nodejs-release-pipeline/" class="text-blue-600 hover:underline">Node.js release pipeline</a></li>
+        <li>→ <a href="/use-cases/sbom-signing/" class="text-blue-600 hover:underline">SBOM signing</a></li>
+        <li>→ <a href="/docs/log-confium-org/" class="text-blue-600 hover:underline">Anchoring ceremonies to the public log</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://docs.rs/confium-keyless" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">OIDC binding spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Keyless signing flow spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Short-lived certificate spec</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="https://docs.rs/confium-keyless" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-keyless</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Keyless signing spec</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/pki/docs.astro
+++ b/src/pages/pki/docs.astro
@@ -10,29 +10,31 @@ const product = getProduct('pki')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Threshold CA lifecycle (issue, revoke, CRL)</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">OCSP / CRL from threshold keys</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">ACME integration with threshold CA</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Composite signatures (PQ migration)</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+        <li>→ <a href="/concepts/tls-analogy/" class="text-blue-600 hover:underline">Confium vs CAs and WebPKI</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">PKI in the layer map</a></li>
+        <li>→ <a href="/concepts/composite-signatures/" class="text-blue-600 hover:underline">Composite signatures for PQC migration</a></li>
+        <li>→ <a href="/use-cases/sovereign-pki/" class="text-blue-600 hover:underline">Use case: sovereign institutional PKI</a></li>
+        <li>→ <a href="/use-cases/web-tls/" class="text-blue-600 hover:underline">Use case: TLS certificate issuance</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Deploy PKCS#11 server as HSM replacement</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Configure OpenSSL 3.0 provider</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Integrate JCE into Java apps</a></li>
-        <li>→ <a href="/pki/" class="text-blue-600 hover:underline">Stand up a threshold CA</a></li>
+        <li>→ <a href="/pki/quickstart/" class="text-blue-600 hover:underline">Quickstart: threshold certificate issuance</a></li>
+        <li>→ <a href="/docs/adapters/pkcs11/" class="text-blue-600 hover:underline">PKCS#11 server adapter</a></li>
+        <li>→ <a href="/docs/adapters/openssl/" class="text-blue-600 hover:underline">OpenSSL 3.0 provider</a></li>
+        <li>→ <a href="/docs/adapters/jce/" class="text-blue-600 hover:underline">JCE provider (Java)</a></li>
+        <li>→ <a href="/docs/adapters/tls/" class="text-blue-600 hover:underline">TLS 1.3 signer</a></li>
+        <li>→ <a href="/docs/pq-migration/" class="text-blue-600 hover:underline">Post-quantum migration guide</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://docs.rs/confium-pki" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Threshold CA spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Composite signatures spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">PKCS#11 server spec</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="https://docs.rs/confium-pki" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-pki</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">PKI and adapter specs</a></li>
+        <li>→ <a href="/docs/components/" class="text-blue-600 hover:underline">Crate inventory</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/privacy/docs.astro
+++ b/src/pages/privacy/docs.astro
@@ -10,31 +10,27 @@ const product = getProduct('privacy')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Private Set Intersection (PSI)</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Private Information Retrieval (PIR)</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Differential Privacy (DP)</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Multi-party Computation (MPC / SPDZ)</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Ring signatures</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Blind signatures</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">VRF + VDF</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">Privacy foundations in the layer map</a></li>
+        <li>→ <a href="/use-cases/confidential-computing/" class="text-blue-600 hover:underline">Use case: confidential computing</a></li>
+        <li>→ <a href="/use-cases/healthcare-records/" class="text-blue-600 hover:underline">Use case: healthcare records</a></li>
+        <li>→ <a href="/use-cases/government-identity/" class="text-blue-600 hover:underline">Use case: government identity</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Choose the right primitive</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Two-party PSI</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">MPC cluster deployment</a></li>
-        <li>→ <a href="/privacy/" class="text-blue-600 hover:underline">Issue anonymous credentials</a></li>
+        <li>→ <a href="/privacy/quickstart/" class="text-blue-600 hover:underline">Quickstart: first PSI run</a></li>
+        <li>→ <a href="/use-cases/banking-signing/" class="text-blue-600 hover:underline">Use case: banking signing</a></li>
+        <li>→ <a href="/use-cases/financial-settlement/" class="text-blue-600 hover:underline">Use case: financial settlement</a></li>
+        <li>→ <a href="/docs/benchmarks/" class="text-blue-600 hover:underline">Benchmarks</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://docs.rs/confium-privacy" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">PSI spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">MPC spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">DP spec</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="https://docs.rs/confium-privacy" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-privacy</a></li>
+        <li>→ <a href="/docs/components/" class="text-blue-600 hover:underline">Crate inventory</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/threshold/docs.astro
+++ b/src/pages/threshold/docs.astro
@@ -10,33 +10,31 @@ const product = getProduct('threshold')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Threshold signing fundamentals (T-of-N)</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Distributed Key Generation (DKG)</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Multiplicative-to-Additive (MtA) via Paillier</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Share refresh & proactive security (Herzberg)</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Reshare: changing T or N without re-keying</a></li>
+        <li>→ <a href="/concepts/threshold-crypto-101/" class="text-blue-600 hover:underline">Threshold signing fundamentals (T-of-N)</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">Threshold signing, end to end (architecture)</a></li>
+        <li>→ <a href="/concepts/attribute-based-threshold/" class="text-blue-600 hover:underline">Attribute-based quorum selection</a></li>
+        <li>→ <a href="/use-cases/distributed-custody/" class="text-blue-600 hover:underline">Use case: distributed custody</a></li>
+        <li>→ <a href="/use-cases/root-ca-key-ceremony/" class="text-blue-600 hover:underline">Use case: root-CA key ceremony</a></li>
       </ul>
     </div>
-
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Deploy signerd in production</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Protect shares with an HSM (PKCS#11)</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Schedule Herzberg share refresh</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Monitor signing sessions (Prometheus)</a></li>
-        <li>→ <a href="/threshold/" class="text-blue-600 hover:underline">Attribute-based signing policies</a></li>
+        <li>→ <a href="/threshold/quickstart/" class="text-blue-600 hover:underline">Quickstart: first threshold signature</a></li>
+        <li>→ <a href="/docs/deployment/" class="text-blue-600 hover:underline">Deploy signerd and the coordinator</a></li>
+        <li>→ <a href="/docs/adapters/pkcs11/" class="text-blue-600 hover:underline">Protect shares with an HSM (PKCS#11)</a></li>
+        <li>→ <a href="/use-cases/kubernetes-deployment/" class="text-blue-600 hover:underline">Run ceremonies on Kubernetes</a></li>
+        <li>→ <a href="/docs/benchmarks/" class="text-blue-600 hover:underline">Benchmark suite</a></li>
       </ul>
     </div>
-
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline" target="_blank">Rust API (docs.rs/confium-threshold)</a></li>
-        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">signerd config reference</a></li>
-        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline">confium threshold subcommands</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Threshold session spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">CMP20 spec</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="/software/ruby/" class="text-blue-600 hover:underline">Ruby: SigningSession + coordinators</a></li>
+        <li>→ <a href="https://docs.rs/confium-threshold" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-threshold</a></li>
+        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Threshold session and scheme specs</a></li>
+        <li>→ <a href="/docs/components/" class="text-blue-600 hover:underline">Crate inventory</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/transparency/docs.astro
+++ b/src/pages/transparency/docs.astro
@@ -10,28 +10,30 @@ const product = getProduct('transparency')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">RFC 6962 inclusion & consistency proofs</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Witness gossip & fork-resistance</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">OTS anchoring to Bitcoin / public chains</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Evidence Record Syntax (ERS) long-term archival</a></li>
+        <li>→ <a href="/concepts/transparency-logs/" class="text-blue-600 hover:underline">Transparency logs explained</a></li>
+        <li>→ <a href="/docs/transparency-logs/" class="text-blue-600 hover:underline">Inclusion, consistency proofs, witnesses, OTS</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">The log stack: server, edge, monitor</a></li>
+        <li>→ <a href="/use-cases/timestamping/" class="text-blue-600 hover:underline">Use case: RFC 3161 timestamping</a></li>
+        <li>→ <a href="/use-cases/long-term-archival/" class="text-blue-600 hover:underline">Use case: long-term archival (ERS)</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Deploy a production log server</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Run a monitor (third-party auditing)</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Deploy the Cloudflare Workers edge verifier</a></li>
-        <li>→ <a href="/transparency/" class="text-blue-600 hover:underline">Anchor tree heads to Bitcoin</a></li>
+        <li>→ <a href="/transparency/quickstart/" class="text-blue-600 hover:underline">Quickstart: first Merkle proof</a></li>
+        <li>→ <a href="/docs/log-confium-org/" class="text-blue-600 hover:underline">The public log at log.confium.org</a></li>
+        <li>→ <a href="/use-cases/operate-transparency-log/" class="text-blue-600 hover:underline">Operate your own log</a></li>
+        <li>→ <a href="/use-cases/blockchain-anchoring/" class="text-blue-600 hover:underline">Anchor heads via OpenTimestamps</a></li>
+        <li>→ <a href="/software/node/" class="text-blue-600 hover:underline">Verify proofs from Node.js</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://docs.rs/confium-transparency" class="text-blue-600 hover:underline" target="_blank">Rust API</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="https://docs.rs/confium-transparency" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-transparency</a></li>
         <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Transparency log spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">Witness gossip spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">ERS archival spec</a></li>
+        <li>→ <a href="/glossary/" class="text-blue-600 hover:underline">Glossary</a></li>
       </ul>
     </div>
   </div>

--- a/src/pages/verify/docs.astro
+++ b/src/pages/verify/docs.astro
@@ -10,28 +10,28 @@ const product = getProduct('verify')!;
     <div>
       <h3 class="font-bold text-lg mb-3">Concepts</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Verifier-only design philosophy</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Provenance & transparency-log anchoring</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Batch verification + LRU cache</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Language bindings parity model</a></li>
+        <li>→ <a href="/docs/architecture/" class="text-blue-600 hover:underline">The verification pipeline (architecture)</a></li>
+        <li>→ <a href="/concepts/composite-signatures/" class="text-blue-600 hover:underline">Verifying composite signatures</a></li>
+        <li>→ <a href="/concepts/transparency-logs/" class="text-blue-600 hover:underline">Verifying log proofs</a></li>
+        <li>→ <a href="/use-cases/polyglot-verification/" class="text-blue-600 hover:underline">Use case: polyglot verification</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">How-to</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Embed WASM in a SPA</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Add verify gate to CI</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Deploy verify-server</a></li>
-        <li>→ <a href="/verify/" class="text-blue-600 hover:underline">Real-time verify dashboard</a></li>
+        <li>→ <a href="/verify/quickstart/" class="text-blue-600 hover:underline">Quickstart: verify in the browser</a></li>
+        <li>→ <a href="/use-cases/public-verification-endpoint/" class="text-blue-600 hover:underline">Run a public verification endpoint</a></li>
+        <li>→ <a href="/software/" class="text-blue-600 hover:underline">Verify from every language</a></li>
+        <li>→ <a href="/docs/log-confium-org/" class="text-blue-600 hover:underline">Check proofs against the public log</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-bold text-lg mb-3">Reference</h3>
       <ul class="space-y-2 text-sm">
-        <li>→ <a href="https://www.npmjs.com/package/@confium/confium-wasm" class="text-blue-600 hover:underline" target="_blank">npm package</a></li>
-        <li>→ <a href="/software/" class="text-blue-600 hover:underline">Bindings parity matrix</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">WASM verifier spec</a></li>
-        <li>→ <a href="/specs/" class="text-blue-600 hover:underline">HTTP verify spec</a></li>
+        <li>→ <a href="/docs/wasm-api/" class="text-blue-600 hover:underline">WASM verifier API</a></li>
+        <li>→ <a href="/docs/rust-api/" class="text-blue-600 hover:underline">Rust API</a></li>
+        <li>→ <a href="https://docs.rs/confium-verify" class="text-blue-600 hover:underline" target="_blank">docs.rs/confium-verify</a></li>
+        <li>→ <a href="/software/ruby/" class="text-blue-600 hover:underline">Ruby verifier surface</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## What

Follow-up to #87: every product minisite's **Docs** page was a
placeholder — 7–11 links per page all pointing back at the product's
own index (e.g. "Deploy signerd in production" → `/threshold/`).

Each of the six pages now links the real destination the item names:

- **Concepts** → the relevant concept pages and use cases
- **How-to** → quickstarts, deployment/adapters docs, the public-log
  page, operation use cases
- **Reference** → Rust API, WASM API, the product's docs.rs facade,
  specs, crate inventory, language surfaces

## Verification

- Build green; 66/66 vitest; OIML + forbidden-language gates 0 hits.
- All 49 distinct internal links across the six pages verified to
  resolve against the built `dist/`.
