### PR TITLE
docs(site): Ruby parse errors carry exact DER byte offsets

### DIFF
--- a/src/content/software/ruby.md
+++ b/src/content/software/ruby.md
@@ -98,6 +98,12 @@ rescue Confium::ParseError => e
 end
 
 begin
+  Confium::PKI::Certificate.from_der(truncated_der)
+rescue Confium::ParseError => e
+  e.offset   # => 20 — the exact byte where DER decoding ran out
+end
+
+begin
   Confium::TC::Cmp20.sign(shares, 3, message)
 rescue Confium::ThresholdError => e
   e.have_count  # => 2


### PR DESCRIPTION
## What

Documents the 0.6.1 parse-error behavior on the Ruby software page:
`Confium::ParseError#offset` now reports the exact byte where DER
decoding ran out (via confium-pki 0.5.6's `CertError::der_offset`).

One example block added to the typed-errors section. No code changes.
