### PR TITLE
docs(site): deep audit sweep — render what we can actually do now

### DIFF
--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -13,7 +13,8 @@
  * build failure (corrupt content) is left for Astro to surface.
  */
 
-import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync, rmSync, statSync } from 'node:fs';
+import { relative, resolve as resolvePath } from 'node:path';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -85,6 +86,7 @@ function fetchSoftwareDocs() {
     console.log('[fetch-sources] no src/content/software/ — skipping');
     return;
   }
+  const vendored = [];
   for (const file of readdirSync(softwareDir)) {
     if (!file.endsWith('.md') && !file.endsWith('.mdx')) continue;
     const fm = loadFrontmatter(join(softwareDir, file));
@@ -98,7 +100,13 @@ function fetchSoftwareDocs() {
       const file = join(target, subtree, blocked);
       if (existsSync(file)) rmSync(file);
     }
-    sanitizeMdxHeaders(target);
+    vendored.push({ target, subtree, id, repo: repoHttps, ref: fm.docs_ref || 'main' });
+  }
+  // Second pass: link rewriting needs every vendor present — the
+  // per-language docs cross-link into the full tree under `rust`.
+  for (const v of vendored) {
+    rewriteDocLinks(v.target, v.subtree, v.id, v.repo, v.ref);
+    sanitizeMdxHeaders(v.target);
   }
 }
 
@@ -121,6 +129,110 @@ function fetchSpecs() {
  *  - Markdown autolinks (`<https://...>`) are not accepted by MDX;
  *    rewrite to explicit `[label](url)` links.
  */
+/**
+ * Rewrite repo-relative `.md`/`.mdx` links in vendored docs into
+ * absolute site URLs (`/software/{id}/docs/...`). Upstream docs are
+ * written for GitHub browsing; on the nested site the same relative
+ * links would resolve against the rendered page's URL and 404.
+ * Only links whose target exists inside the vendored subtree are
+ * rewritten; anything else (anchors, images, external) is kept.
+ */
+function rewriteDocLinks(root, subtree, id, repoHttps, ref) {
+  // Cone-mode sparse checkout of a nested subtree (docs/bindings)
+  // also pulls the files directly under docs/; walk the whole docs
+  // root so those top-level files get rewritten too.
+  const docsRoot = join(root, subtree.split('/')[0]);
+  const files = readdirSync(docsRoot, { withFileTypes: true, recursive: true });
+  for (const entry of files) {
+    if (!entry.isFile() || (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx'))) continue;
+    const parent = entry.path ?? entry.parentPath ?? docsRoot;
+    const path = join(parent, entry.name);
+    const text = readFileSync(path, 'utf8');
+    const re = /\]\(([^)#\s]+?)(#[^)\s]*)?\)/g;
+    let changed = false;
+    const out = text.replace(re, (m, target, anchor) => {
+      // Upstream docs sometimes assume the site's /docs/ IA; map
+      // those into this vendor's own docs tree.
+      if (target.startsWith('/docs/')) {
+        const t = target.slice('/docs/'.length)
+          .replace(/\.(md|mdx)$/, '')
+          .split('/')
+          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
+          .join('/');
+        const cands = [join(docsRoot, `${t}.mdx`), join(docsRoot, `${t}.md`),
+                       join(docsRoot, t, 'index.mdx')];
+        for (const c of cands) {
+          if (existsSync(c)) {
+            changed = true;
+            return `](/software/${id}/docs/${t}${anchor ?? ''})`;
+          }
+        }
+        return m;
+      }
+      // Only rewrite relative, potentially-doc links: skip URLs,
+      // images, mailto, and site-absolute links.
+      if (/^(https?:|mailto:|\/|\.png|\.jpe?g|\.svg|\.gif)/i.test(target)) return m;
+      let resolved = resolvePath(dirname(path), target);
+      // Extensionless sibling links: try the .mdx/.md/index forms.
+      if (!/\.(md|mdx)$/.test(resolved)) {
+        for (const cand of [`${resolved}.mdx`, `${resolved}.md`,
+                            join(resolved, 'index.mdx'), join(resolved, 'index.md')]) {
+          if (existsSync(cand)) { resolved = cand; break; }
+        }
+      }
+      if (!/\.(md|mdx)$/.test(resolved)) {
+        // Escapes the docs root (e.g. ../CONTRIBUTING.md): link to
+        // the upstream repository.
+        if (!resolved.startsWith(resolvePath(root) + '/')) return m;
+        const inRepoRoot = relative(join(VENDOR, id), resolved);
+        return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
+      }
+      if (!resolved.startsWith(resolvePath(docsRoot) + '/')) {
+        if (!resolved.startsWith(resolvePath(root) + '/')) return m;
+        const inRepoRoot = relative(join(VENDOR, id), resolved);
+        return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
+      }
+      if (existsSync(resolved)) {
+        // Mirror Astro's github-slugger (dots and other
+        // non-word chars are stripped per segment).
+        const rel = relative(resolvePath(docsRoot), resolved)
+          .replace(/\.(md|mdx)$/, '')
+          .replace(/\/index$/, '')
+          .split('/')
+          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
+          .join('/');
+        changed = true;
+        return `](/software/${id}/docs/${rel}${anchor ?? ''})`;
+      }
+      // The per-language vendors pull only the bindings subtree plus
+      // the top level of docs/; links into the rest of the confium
+      // docs resolve against the full tree vendored under `rust`,
+      // mapped by position within the docs root.
+      const rustDocs = join(VENDOR, 'rust', 'docs');
+      const alt = resolvePath(rustDocs, relative(resolvePath(docsRoot), resolved));
+      if (existsSync(rustDocs) && alt.startsWith(resolvePath(rustDocs) + '/') && existsSync(alt)) {
+        const rel = relative(resolvePath(rustDocs), alt)
+          .replace(/\.(md|mdx)$/, '')
+          .replace(/\/index$/, '')
+          .split('/')
+          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
+          .join('/');
+        changed = true;
+        return `](/software/rust/docs/${rel}${anchor ?? ''})`;
+      }
+      // Target exists nowhere in the vendored trees: send readers to
+      // the upstream repository instead of a dead link.
+      const inRepo = relative(join(VENDOR, id), resolved);
+      changed = true;
+      return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepo}${anchor ?? ''})`;
+    });
+    if (changed) {
+      writeFileSync(path, out);
+      console.log(`[fetch-sources] rewrote links in ${relative(ROOT, path)}`);
+    }
+  }
+}
+
 function sanitizeMdxHeaders(root) {
   const files = readdirSync(root, { withFileTypes: true, recursive: true });
   for (const entry of files) {
@@ -136,6 +248,9 @@ function sanitizeMdxHeaders(root) {
       /<((?:https?|mailto):[^>\s]+)>/g,
       (_, url) => `[${url}](${url})`,
     );
+    // Escape {braces} in prose so upstream template placeholders
+    // render literally instead of failing as JSX expressions.
+    sanitized = sanitized.replace(/(^|[^`{])\{([a-zA-Z][a-zA-Z0-9_-]*)\}/g, '$1\\{$2\\}');
     if (sanitized !== text) {
       writeFileSync(path, sanitized);
       console.log(`[fetch-sources] sanitized ${path}`);

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -13,7 +13,7 @@
  * build failure (corrupt content) is left for Astro to surface.
  */
 
-import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
@@ -23,6 +23,12 @@ const ROOT = join(__dirname, '..');
 const VENDOR = join(ROOT, 'vendor');
 
 const SPECS_REPO = 'https://github.com/confium/specs.git';
+
+// Vendored doc files the public site must not render. cnml-profile
+// documents the institutional certificate format the site's
+// neutrality policy keeps off www.confium.org (the OIML quality
+// gate enforces it); the page stays in the upstream repo.
+const BLOCKED_DOCS = ['cnml-profile.mdx'];
 const SPECS_REF = process.env.CONFIUM_SPECS_REF || 'main';
 
 /**
@@ -88,6 +94,10 @@ function fetchSoftwareDocs() {
     const subtree = (fm.docs_subtree || 'docs').replace(/^\/+|\/+$/g, '');
     const target = join(VENDOR, id);
     sparseClone(repoHttps, fm.docs_ref || 'main', target, [subtree]);
+    for (const blocked of BLOCKED_DOCS) {
+      const file = join(target, subtree, blocked);
+      if (existsSync(file)) rmSync(file);
+    }
     sanitizeMdxHeaders(target);
   }
 }

--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -26,7 +26,7 @@ source carries inline rustdoc.
 | `confium-net` | Network transport abstraction for multi-party protocols. |
 | `confium-net-tcp` / `confium-net-quic` / `confium-net-ws` | TCP, QUIC, and WebSocket transports. |
 | `confium-store` | Compartmentalized key and secret persistence. |
-| `confium-store-pkcs11` / `confium-store-tpm` / `confium-store-cloud` / `confium-store-openpgp-card` | PKCS#11, TPM 2.0, cloud KMS, and OpenPGP-card (YubiKey, Nitrokey) backends. |
+| `confium-store-pkcs11` / `confium-store-tpm` / `confium-store-cloud` / `confium-store-openpgp-card` | PKCS#11, TPM 2.0, cloud KMS, and OpenPGP-card (YubiKey, Nitrokey) backends. `confium-store-cloud` builds real clients for AWS KMS, Cloud KMS, and Key Vault, lists KMS key IDs (`ListKeys`), and signs remotely via each provider's Sign API — the sign-with-handle contract (`cfm_keystore_sign`). |
 | `confium-sandbox-wasm` / `confium-sandbox-process` | WASM and out-of-process sandboxes for isolating plugin execution. |
 | `confium-deployment` | Deployment manifest schema and actor identity. |
 

--- a/src/content/software/ruby.md
+++ b/src/content/software/ruby.md
@@ -25,7 +25,7 @@ Ruby itself.
 | **XMLDSig** | Canonicalize XML (RFC 3076 + Exclusive C14N) prior to signature. |
 | **Attributes DSL** | `Confium::Attributes.parse`, `Signer`, `Predicate#satisfied_by?` — threshold policy over signer attributes. |
 | **Identity + Config** | `Confium::Identity::Actor`, `Confium::Config::Manifest` (deployment manifest TOML validation). |
-| **Threshold signing** | `Confium::TC::SigningSession` (the state machine + CMP20/GG18 combine), `Coordinator` (in-process), `NetworkCoordinator` + `SignerClient` (multi-host over TCP), `FrostP256` (Shamir + ECDSA), `ElGamalP256`, `ShareFile` persistence. |
+| **Threshold signing** | `Confium::TC::Session` (per-party FROST-ed25519 DKG + signing rounds), `SigningSession` (the state machine + CMP20/GG18 combine), `Coordinator` (in-process), `NetworkCoordinator` + `SignerClient` (multi-host over TCP), `FrostP256` (Shamir + ECDSA), `ElGamalP256`, `ShareFile` persistence. |
 | **Audit sinks** | `Confium::Audit` — every signing/verification op fires a record; `FileSink`, `MemorySink`, `StderrSink`, `OtlpSink` (OTLP/HTTP JSON). |
 | **Long-term archival** | `Confium::ERS::EvidenceRecord` — RFC 4998 evidence records with renewal. |
 | **Typed errors** | `Confium::ParseError`, `VerificationError`, `ThresholdError`, `CryptoError`, `IndexError`, `PolicyViolationError`, ... — every documented failure path, each with a structured `details` Hash. |
@@ -123,6 +123,30 @@ encryption), install `ruby-rnp` alongside — the two coexist without
 symbol conflict. See
 [Confium and RNP](/concepts/confium-and-rnp/) for the
 sibling-project relationship.
+
+## Per-party threshold sessions
+
+Each signer process runs its own session — the share never leaves
+the process:
+
+```ruby
+# 3-party DKG — every party derives the same group public key.
+dkg = %w[p0 p1 p2].each_index.map do |i|
+  Confium::TC::Session.new("FROST-ed25519-dkg",
+                           parties: %w[p0 p1 p2],
+                           threshold: 2, this_party_idx: i)
+end
+# ... broadcast each round's outgoing messages to every party ...
+
+blob = dkg[0].result   # length-prefixed group pubkey || this share
+
+# 2-of-3 signing — every signing party emits the SAME 64-byte
+# RFC-8032 signature, verifiable under the group public key.
+sess = Confium::TC::Session.new("FROST-ed25519",
+                                parties: %w[p0 p1 p2],
+                                threshold: 2, this_party_idx: 0,
+                                local_share: blob, message: "payload")
+```
 
 ## See also
 

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageHero from '../../components/astro/PageHero.astro';
 
@@ -10,6 +10,7 @@ export async function getStaticPaths() {
 
 const { sw } = Astro.props;
 const hasDocs = !!sw.data.docs_repo;
+const { Content } = await render(sw);
 ---
 
 <BaseLayout title={sw.data.name} description={sw.data.description}>
@@ -20,8 +21,7 @@ const hasDocs = !!sw.data.docs_repo;
   />
 
   <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12 prose prose-lg dark:prose-invert">
-    <h2>Install</h2>
-    <pre><code>&#123;sw.data.install_command&#125;</code></pre>
+    <Content />
 
     {hasDocs && (
       <>

--- a/src/pages/software/[id]/docs/[...slug].astro
+++ b/src/pages/software/[id]/docs/[...slug].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
       const slug = doc.id
         .split(`${vendorId}/docs/`)[1]
         ?.replace(/\.(md|mdx)$/, '') || '';
-      if (!slug || slug.includes('/')) continue;
+      if (!slug || slug === 'index') continue;
       paths.push({
         params: { id: sw.id, slug },
         props: { sw, doc },

--- a/src/pages/software/[id]/docs/[...slug].astro
+++ b/src/pages/software/[id]/docs/[...slug].astro
@@ -10,10 +10,10 @@ export async function getStaticPaths() {
   for (const sw of software) {
     if (!sw.data.docs_repo) continue;
     const vendorId = sw.id;
-    const docs = allDocs.filter((d) => d.id.includes(`/${vendorId}/docs/`));
+    const docs = allDocs.filter((d) => d.id.startsWith(`${vendorId}/docs/`));
     for (const doc of docs) {
       const slug = doc.id
-        .split(`/${vendorId}/docs/`)[1]
+        .split(`${vendorId}/docs/`)[1]
         ?.replace(/\.(md|mdx)$/, '') || '';
       if (!slug || slug.includes('/')) continue;
       paths.push({
@@ -30,11 +30,11 @@ const { Content, headings } = await render(doc);
 
 const allDocs = await getCollection('softwareDocs');
 const vendorId = sw.id;
-const siblingDocs = allDocs.filter((d) => d.id.includes(`/${vendorId}/docs/`));
+const siblingDocs = allDocs.filter((d) => d.id.startsWith(`${vendorId}/docs/`));
 const sidebar = siblingDocs
   .sort((a, b) => a.id.localeCompare(b.id))
   .map((d) => {
-    const slug = d.id.split(`/${vendorId}/docs/`)[1]?.replace(/\.(md|mdx)$/, '') || '';
+    const slug = d.id.split(`${vendorId}/docs/`)[1]?.replace(/\.(md|mdx)$/, '') || '';
     return {
       label: d.data.title ?? slug,
       href: `/software/${sw.id}/docs/${slug}/`,

--- a/src/pages/threshold/index.astro
+++ b/src/pages/threshold/index.astro
@@ -32,7 +32,7 @@ const product = getProduct('threshold')!;
       <li><strong>CMP20</strong> — 3-round threshold ECDSA over P-256 with real Paillier MtA</li>
       <li><strong>GG18</strong> — 4-round threshold ECDSA over P-256</li>
       <li><strong>FROST-P256</strong> — 2-round threshold ECDSA over P-256 (Shamir + Feldman VSS)</li>
-      <li><strong>FROST-Ed25519</strong> — 2-round threshold EdDSA over Ed25519</li>
+      <li><strong>FROST-Ed25519</strong> — 2-round threshold EdDSA over Ed25519, drivable per-party (one session per signer process; the share never leaves)</li>
       <li><strong>MuSig</strong> — 2-round threshold Schnorr signatures</li>
     </ul>
   </section>


### PR DESCRIPTION
## What

Deep audit of the site against gem 0.6.3 and confium 0.5.9. Four
findings, all fixed:

### 1. The vendored docs router never matched a single page (pre-existing)

Astro glob ids are relative without a leading slash
(`ruby/docs/api-reference`); the route filter required
`/ruby/docs/`. Every per-repo docs page was unrouted — only the
landing pages existed. Filter fixed: the full Ruby/Rust/Go/Python/
Node docs trees now render (63 software pages, up from ~9).

### 2. The /software/{id} page rendered only frontmatter (pre-existing)

The carefully maintained per-language bodies (Ruby's coverage
table, examples, typed-errors section) never displayed. The
template now renders the body.

### 3. Content gaps vs 0.6.3 / 0.5.9

- Ruby page + threshold minisite + components page now describe the
  per-party FROST-ed25519 sessions (`Confium::TC::Session`), the
  Keystore remote-signing binding, and the real cloud-KMS
  capabilities behind the sign-with-handle contract.
- Upstream docs updated in lockstep (merged):
  confium-ruby#88/#89 (TC::Session reference, gate word),
  confium#285/#286/#287/#288 (sign-with-handle architecture,
  gate words, FAQ link).

### 4. Site-neutrality gate

`cnml-profile.mdx` (the institutional certificate profile) is
blocked from the vendored Ruby docs — it stays in the upstream repo
per the OIML gate policy.

## Verification

Build green; 66/66 tests; **OIML 0 hits; forbidden-language 0
hits** (these gates see the vendored trees for the first time and
pass); 63 software pages render.
