### PR TITLE
refactor(specs): extract the converter into a tested module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Fetch specs corpus (golden converter tests)
+      run: node scripts/fetch-sources.mjs specs
+
     - name: Run Vitest
       run: npm test
       env:

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -1,16 +1,23 @@
 /**
  * Sparse-checkout vendor sources for per-repo docs and specs.
  *
- * Reads `src/content/software/*.md` for `docs_repo`, `docs_ref`,
- * `docs_subtree`, and clones each into `vendor/<id>/` using a sparse
- * checkout limited to `README*` and `/<docs_subtree>/`.
+ * Software docs: reads `src/content/software/*.md` for `docs_repo`,
+ * `docs_ref`, `docs_subtree`, clones each into `vendor/<id>/` with a
+ * sparse checkout, then rewrites repo-relative links into site URLs.
  *
- * Reads `src/content/specs/*.md` and clones the specs repo into
- * `vendor/specs/` with a sparse checkout of the `specs/` directory.
+ * Specs: clones the specs repo into `vendor/specs/`, converts every
+ * `specs/*.adoc` to a sibling `.md` (pure conversion lives in
+ * scripts/lib/specs-converter.mjs), and copies embeddable diagrams
+ * into `public/specs/images/`. What may render is decided by
+ * scripts/lib/neutrality.mjs.
  *
  * Failures degrade gracefully: a missing repo or unreachable ref
  * logs a warning and the site builds without those docs. A real
  * build failure (corrupt content) is left for Astro to surface.
+ *
+ * Set CONFIUM_REFRESH_SOURCES=1 to fast-forward existing vendor
+ * clones instead of silently reusing them (the default keeps
+ * offline-friendly reuse; CI always fetches fresh).
  */
 
 import { existsSync, readFileSync, mkdirSync, readdirSync, writeFileSync, rmSync, statSync, cpSync } from 'node:fs';
@@ -19,23 +26,17 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 
+import { convertSpec, serializeSpec } from './lib/specs-converter.mjs';
+import { BLOCKED_DOCS, isBlockedSpec, isNeutralitySvg } from './lib/neutrality.mjs';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const VENDOR = join(ROOT, 'vendor');
 
 const SPECS_REPO = 'https://github.com/confium/specs.git';
-
-// Vendored doc files the public site must not render. cnml-profile
-// documents the institutional certificate format the site's
-// neutrality policy keeps off www.confium.org (the OIML quality
-// gate enforces it); the page stays in the upstream repo.
-const BLOCKED_DOCS = ['cnml-profile.mdx'];
-// Spec sources kept out of the central site for the same reason:
-// the institutional CNML deployment spec stays in the specs repo.
-const BLOCKED_SPECS = ['80-cnml-deployment.adoc'];
 const SPECS_REF = process.env.CONFIUM_SPECS_REF || 'main';
-const SPECS_RAW_BASE =
-  'https://raw.githubusercontent.com/confium/specs/main';
+
+const REFRESH = process.env.CONFIUM_REFRESH_SOURCES === '1';
 
 /**
  * @param {string} repo
@@ -44,11 +45,23 @@ const SPECS_RAW_BASE =
  * @param {string[]} sparsePaths
  */
 function sparseClone(repo, ref, targetDir, sparsePaths) {
+  mkdirSync(VENDOR, { recursive: true });
   if (existsSync(targetDir)) {
-    console.log(`[fetch-sources] reusing ${targetDir}`);
+    if (!REFRESH) {
+      console.log(`[fetch-sources] reusing ${targetDir}`);
+      return;
+    }
+    console.log(`[fetch-sources] refreshing ${targetDir} to ${ref}`);
+    try {
+      execSync(`git fetch --quiet origin ${ref}`, { cwd: targetDir });
+      execSync('git checkout --quiet FETCH_HEAD', { cwd: targetDir });
+    } catch (err) {
+      console.warn(
+        `[fetch-sources] WARNING: refresh failed for ${targetDir} — ${err.message}`,
+      );
+    }
     return;
   }
-  mkdirSync(VENDOR, { recursive: true });
   console.log(`[fetch-sources] cloning ${repo}@${ref} → ${targetDir}`);
   try {
     execSync(
@@ -129,34 +142,60 @@ function fetchSpecs() {
 }
 
 /**
- * The specs repo is AsciiDoc; the site renders Markdown. Emit one
- * `.md` per vendored `.adoc` (the AsciiDoc sources stay untouched in
- * the vendor tree) with generated frontmatter, then the `specDocs`
- * content collection picks them up. Not a general converter — the
- * specs corpus is the contract.
+ * The fs-backed resolve adapter for the specs converter: it answers
+ * existence/policy questions so the converter itself stays pure.
+ *
+ * @param {string} target - vendor/specs
+ * @param {string[]} skippedImages - diagrams the neutrality policy keeps off-site
+ */
+function specsResolve(target, skippedImages) {
+  const specsDir = join(target, 'specs');
+  const imagesDir = join(target, 'images');
+  return {
+    specHref(leaf) {
+      return existsSync(join(specsDir, `${leaf}.adoc`)) ? `/specs/${leaf}/` : null;
+    },
+    specStatus(leaf) {
+      if (isBlockedSpec(`${leaf}.adoc`)) return 'blocked';
+      return existsSync(join(specsDir, `${leaf}.adoc`)) ? 'page' : 'missing';
+    },
+    imageHref(file) {
+      if (skippedImages.includes(file)) return null;
+      return existsSync(join(imagesDir, file)) ? `/specs/images/${file}` : null;
+    },
+    blobUrl(path) {
+      return `https://github.com/confium/specs/blob/${SPECS_REF}/${path}`;
+    },
+  };
+}
+
+/**
+ * Emit one `.md` per vendored `.adoc`; the AsciiDoc sources stay
+ * untouched in the vendor tree. The `specDocs` content collection
+ * picks up the generated `.md` files.
  */
 function convertSpecs(target, skippedImages) {
   const specsDir = join(target, 'specs');
   if (!existsSync(specsDir)) return;
+  const resolve = specsResolve(target, skippedImages);
   for (const entry of readdirSync(specsDir, { withFileTypes: true })) {
     if (!entry.isFile() || !entry.name.endsWith('.adoc')) continue;
-    if (BLOCKED_SPECS.includes(entry.name)) {
+    if (isBlockedSpec(entry.name)) {
       console.log(`[fetch-sources] skipping blocked spec ${entry.name}`);
       continue;
     }
     const text = readFileSync(join(specsDir, entry.name), 'utf8');
-    const { frontmatter, body } = adocToMarkdown(text, entry.name, specsDir, skippedImages);
-    const out = `---\n${frontmatter}\n---\n\n${body}`;
-    writeFileSync(join(specsDir, entry.name.replace(/\.adoc$/, '.md')), out);
+    const converted = convertSpec(text, entry.name, resolve);
+    writeFileSync(join(specsDir, entry.name.replace(/\.adoc$/, '.md')), serializeSpec(converted));
   }
+  console.log(`[fetch-sources] converted specs to markdown`);
 }
 
 /**
  * Spec diagrams live at the specs repo root; serve them from the
  * site itself rather than hotlinking raw.githubusercontent.com.
- * Diagrams whose text trips the OIML neutrality gate stay on
- * GitHub — they are returned as the skipped set so the converter
- * can link out instead of embedding.
+ * Returns the files the neutrality policy kept off-site so the
+ * converter can link out instead of embedding.
  */
 function copySpecImages(target) {
   const src = join(target, 'images');
@@ -167,7 +206,7 @@ function copySpecImages(target) {
   for (const f of readdirSync(src)) {
     const s = join(src, f);
     if (!statSync(s).isFile()) continue;
-    if (/oiml/i.test(readFileSync(s, 'utf8'))) {
+    if (isNeutralitySvg(readFileSync(s, 'utf8'))) {
       skipped.push(f);
       continue;
     }
@@ -178,203 +217,6 @@ function copySpecImages(target) {
     console.log(`[fetch-sources] kept off-site (neutrality): ${skipped.join(', ')}`);
   }
   return skipped;
-}
-
-function specCategory(id, product) {
-  if (product) return product;
-  if (id === 'PRODUCTS') return 'index';
-  const n = parseInt(id, 10);
-  if (!Number.isNaN(n)) {
-    if (n <= 9) return 'architecture';
-    if (n <= 19) return 'modes';
-  }
-  return 'security';
-}
-
-function extractDescription(body) {
-  const prose = body
-    .split('\n')
-    .map((l) => l.trim())
-    .find(
-      (l) =>
-        l &&
-        !/^[#>|!`={]/.test(l) &&
-        !l.startsWith('['),
-    );
-  if (!prose) return '';
-  const flat = prose.replace(/\s+/g, ' ');
-  const cut = flat.search(/[.!?](\s|$)/);
-  return (cut === -1 ? flat : flat.slice(0, cut + 1)).slice(0, 240);
-}
-
-function yamlQuote(value) {
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-}
-
-function emitTable(rows) {
-  const cells = rows
-    .filter((r) => r.trim() !== '')
-    .map((r) =>
-      r
-        .replace(/^\|/, '')
-        .split('|')
-        .map((c) => c.trim()),
-    );
-  if (!cells.length) return [];
-  const width = Math.max(...cells.map((c) => c.length));
-  const norm = cells.map((c) => {
-    while (c.length < width) c.push('');
-    return c;
-  });
-  const md = [`| ${norm[0].join(' | ')} |`, `|${' --- |'.repeat(width)}`];
-  for (const r of norm.slice(1)) md.push(`| ${r.join(' | ')} |`);
-  return md;
-}
-
-/**
- * Rewrite `link:` and `image::` macros inline. Relative spec links
- * become site URLs (GitHub blob for specs that do not exist as
- * pages, e.g. unwritten drafts or blocked files); `../images/x.svg`
- * points at the copied `/specs/images/x.svg`.
- */
-function specInline(text, specsDir, skippedImages) {
-  text = text.replace(
-    /link:\+\+(.+?)\+\+\[([^\]]*)\]/g,
-    (_, url, label) => `[${label || url}](${url})`,
-  );
-  text = text.replace(
-    /link:((?:https?:|mailto:)[^\s[]+)\[([^\]]*)\]/g,
-    (_, url, label) => `[${label || url}](${url})`,
-  );
-  text = text.replace(
-    /link:([\w./-]+?\.adoc)\[([^\]]*)\]/g,
-    (_m, target, label) => {
-      const leaf = target.replace(/\.adoc$/, '').split('/').pop();
-      const label2 = label || leaf;
-      // Resolve against the AsciiDoc source, not the generated .md —
-      // conversion order must not decide where a link points.
-      if (BLOCKED_SPECS.includes(`${leaf}.adoc`)) {
-        return `[${label2}](https://github.com/confium/specs/blob/main/specs/${target})`;
-      }
-      if (existsSync(join(specsDir, `${leaf}.adoc`))) {
-        return `[${label2}](/specs/${leaf}/)`;
-      }
-      // Unwritten spec: keep the cross-reference as plain text rather
-      // than linking to a GitHub page that does not exist either.
-      return label2;
-    },
-  );
-  // Bare AsciiDoc URL macro: `https://host/path[label]`.
-  text = text.replace(
-    /(^|[\s(])((?:https?:\/\/)[^\s[]+)\[([^\]\n]{1,80})\]/g,
-    (_m, pre, url, label) => `${pre}[${label}](${url})`,
-  );
-  text = text.replace(/image::([\w./-]+\.\w+)\[([^\]]*)\]/g, (_m, path, alt) => {
-    const file = path.split('/').pop();
-    if (skippedImages.includes(file)) {
-      return `[${alt || 'View diagram'} (SVG)](https://github.com/confium/specs/blob/main/images/${file})`;
-    }
-    const rel = path.replace(/^(\.\.\/)+/, '');
-    return `![${alt}](${rel.startsWith('images/') ? `/specs/${rel}` : `${SPECS_RAW_BASE}/${rel}`})`;
-  });
-  return text;
-}
-
-/**
- * @param {string} text
- * @param {string} adocName
- * @param {string} specsDir
- * @param {string[]} skippedImages
- * @returns {{ frontmatter: string, body: string }}
- */
-function adocToMarkdown(text, adocName, specsDir, skippedImages) {
-  const lines = text.split('\n');
-  const attrs = {};
-  let title = adocName.replace(/\.adoc$/, '');
-  let i = 0;
-  if (lines[0] && /^= /.test(lines[0])) {
-    title = lines[0].replace(/^= +/, '').trim();
-    i = 1;
-  }
-  for (; i < lines.length; i++) {
-    const line = lines[i];
-    if (line === '') break;
-    const attr = line.match(/^:([\w-]+):\s*(.*)$/);
-    if (attr) {
-      attrs[attr[1]] = attr[2].trim();
-      continue;
-    }
-    if (/ <[^>]+>$/.test(line)) continue; // author line
-  }
-  const out = [];
-  let inFence = false;
-  let inListing = false;
-  let pendingLang = null;
-  let table = null;
-  for (; i < lines.length; i++) {
-    let line = lines[i];
-    if (line.startsWith('```')) {
-      out.push(line);
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) {
-      out.push(line);
-      continue;
-    }
-    if (line === '----') {
-      if (inListing) {
-        out.push('```');
-        inListing = false;
-      } else {
-        out.push('```' + (pendingLang ?? ''));
-        inListing = true;
-      }
-      pendingLang = null;
-      continue;
-    }
-    if (inListing) {
-      out.push(line);
-      continue;
-    }
-    const src = line.match(/^\[source(?:,\s*([\w+.-]+))?\]\s*$/);
-    if (src) {
-      pendingLang = src[1] ?? '';
-      continue;
-    }
-    if (line.trim() === '|===') {
-      if (table) {
-        out.push(...emitTable(table));
-        table = null;
-      } else {
-        table = [];
-      }
-      continue;
-    }
-    if (table) {
-      if (/^\[(cols|frame|grid)/i.test(line.trim())) continue;
-      table.push(line);
-      continue;
-    }
-    line = specInline(line, specsDir, skippedImages);
-    line = line.replace(/^(={1,6}) +(.+?)(?:\s*=*)$/, (_m, eq, txt) => '#'.repeat(eq.length) + ' ' + txt);
-    out.push(line);
-  }
-  if (table) out.push(...emitTable(table));
-
-  const id = adocName.replace(/\.adoc$/, '');
-  const description = extractDescription(out.join('\n'));
-  const fm = [
-    `title: ${yamlQuote(title)}`,
-    description ? `description: ${yamlQuote(description)}` : null,
-    `upstream_path: ${yamlQuote(`specs/${adocName}`)}`,
-    `category: ${specCategory(id, attrs.product)}`,
-    /^\d/.test(id) ? `spec_id: ${parseInt(id, 10)}` : null,
-    attrs.status ? `status: ${yamlQuote(attrs.status)}` : null,
-    attrs.implementation ? `implementation: ${yamlQuote(attrs.implementation)}` : null,
-    attrs.product ? `product: ${yamlQuote(attrs.product)}` : null,
-  ].filter(Boolean);
-  return { frontmatter: fm.join('\n'), body: out.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n' };
 }
 
 /**
@@ -533,6 +375,10 @@ function normalizeRepoUrl(repo) {
 }
 
 console.log('[fetch-sources] starting');
-fetchSoftwareDocs();
-fetchSpecs();
+// Optional scope arg ("software" or "specs") so CI can pull just the
+// corpus the golden converter tests need without cloning every
+// software-docs repo.
+const scope = process.argv[2];
+if (!scope || scope === 'software') fetchSoftwareDocs();
+if (!scope || scope === 'specs') fetchSpecs();
 console.log('[fetch-sources] done');

--- a/scripts/lib/neutrality.mjs
+++ b/scripts/lib/neutrality.mjs
@@ -1,0 +1,37 @@
+/**
+ * The site's neutrality policy, in one place: institutional-identity
+ * content stays off www.confium.org. The CI quality gate enforces the
+ * OIML half on dist/; this module keeps the fetch pipeline from ever
+ * vendoring the rest of it into the build.
+ */
+
+// Software-docs files the public site must not render. cnml-profile
+// documents the institutional certificate format; the page stays in
+// the upstream repo.
+export const BLOCKED_DOCS = ['cnml-profile.mdx'];
+
+// Spec sources kept off the central site: the institutional CNML
+// deployment spec stays in the specs repo (github.com/confium/specs),
+// linked but never rendered here.
+export const BLOCKED_SPECS = ['80-cnml-deployment.adoc'];
+
+/** @param {string} name — vendored docs file name */
+export function isBlockedDoc(name) {
+  return BLOCKED_DOCS.includes(name);
+}
+
+/** @param {string} name — spec .adoc/.md file name */
+export function isBlockedSpec(name) {
+  return BLOCKED_SPECS.includes(name);
+}
+
+/**
+ * Diagrams whose text carries the institutional label: the CI gate
+ * greps every dist file (SVG included) for OIML, so these stay on
+ * GitHub and are linked, not embedded.
+ *
+ * @param {string} svgText
+ */
+export function isNeutralitySvg(svgText) {
+  return /oiml/i.test(svgText);
+}

--- a/scripts/lib/specs-converter.mjs
+++ b/scripts/lib/specs-converter.mjs
@@ -1,0 +1,227 @@
+/**
+ * AsciiDoc → Markdown conversion for the specs corpus. Pure: every
+ * environment decision (which specs exist, which diagrams may be
+ * embedded, where upstream blobs live) arrives through `resolve`, so
+ * the module is testable with an in-memory adapter and has no fs/git
+ * dependencies.
+ *
+ * Not a general AsciiDoc converter — the confium/specs corpus is the
+ * contract: `= / ==` headings, `:attr:` headers, author lines,
+ * `|===` tables, `[source]` + `----` listings, ``` fences,
+ * `link:` / bare-URL macros, `image::` macros, and inline emphasis.
+ *
+ * resolve adapter:
+ *   specHref(leaf)  -> site href for a spec that becomes a page, else null
+ *   specStatus(leaf)-> 'page' | 'blocked' | 'missing'
+ *   imageHref(file) -> servable href for an embeddable diagram, else null
+ *   blobUrl(path)   -> canonical GitHub URL for content that stays upstream
+ */
+
+/** @param {string} id @param {string | undefined} product */
+function specCategory(id, product) {
+  if (product) return product;
+  if (id === 'PRODUCTS') return 'index';
+  const n = parseInt(id, 10);
+  if (!Number.isNaN(n)) {
+    if (n <= 9) return 'architecture';
+    if (n <= 19) return 'modes';
+  }
+  return 'security';
+}
+
+function extractDescription(body) {
+  const prose = body
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l && !/^[#>|!`={]/.test(l) && !l.startsWith('['));
+  if (!prose) return '';
+  const flat = prose.replace(/\s+/g, ' ');
+  const cut = flat.search(/[.!?](\s|$)/);
+  return (cut === -1 ? flat : flat.slice(0, cut + 1)).slice(0, 240);
+}
+
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function emitTable(rows) {
+  const cells = rows
+    .filter((r) => r.trim() !== '')
+    .map((r) =>
+      r
+        .replace(/^\|/, '')
+        .split('|')
+        .map((c) => c.trim()),
+    );
+  if (!cells.length) return [];
+  const width = Math.max(...cells.map((c) => c.length));
+  const norm = cells.map((c) => {
+    while (c.length < width) c.push('');
+    return c;
+  });
+  const md = [`| ${norm[0].join(' | ')} |`, `|${' --- |'.repeat(width)}`];
+  for (const r of norm.slice(1)) md.push(`| ${r.join(' | ')} |`);
+  return md;
+}
+
+/**
+ * @param {string} text
+ * @param {(leaf: string) => string | null} specHref
+ * @param {(leaf: string) => 'page' | 'blocked' | 'missing'} specStatus
+ * @param {(file: string) => string | null} imageHref
+ * @param {(path: string) => string} blobUrl
+ */
+function specInline(text, specHref, specStatus, imageHref, blobUrl) {
+  text = text.replace(
+    /link:\+\+(.+?)\+\+\[([^\]]*)\]/g,
+    (_, url, label) => `[${label || url}](${url})`,
+  );
+  text = text.replace(
+    /link:((?:https?:|mailto:)[^\s[]+)\[([^\]]*)\]/g,
+    (_, url, label) => `[${label || url}](${url})`,
+  );
+  text = text.replace(/link:([\w./-]+?\.adoc)\[([^\]]*)\]/g, (_m, target, label) => {
+    const leaf = target.replace(/\.adoc$/, '').split('/').pop();
+    const label2 = label || leaf;
+    const status = specStatus(leaf);
+    if (status === 'page' && specHref(leaf)) {
+      return `[${label2}](${specHref(leaf)})`;
+    }
+    if (status === 'blocked') {
+      return `[${label2}](${blobUrl(`specs/${target}`)})`;
+    }
+    // Unwritten spec: keep the cross-reference as plain text rather
+    // than linking to a GitHub page that does not exist either.
+    return label2;
+  });
+  // Bare AsciiDoc URL macro: `https://host/path[label]`.
+  text = text.replace(
+    /(^|[\s(])((?:https?:\/\/)[^\s[]+)\[([^\]\n]{1,80})\]/g,
+    (_m, pre, url, label) => `${pre}[${label}](${url})`,
+  );
+  text = text.replace(/image::([\w./-]+\.\w+)\[([^\]]*)\]/g, (_m, path, alt) => {
+    const file = path.split('/').pop();
+    const href = imageHref(file);
+    if (href) return `![${alt}](${href})`;
+    return `[${alt || 'View diagram'} (SVG)](${blobUrl(`images/${file}`)})`;
+  });
+  return text;
+}
+
+/**
+ * @param {string} text - AsciiDoc source
+ * @param {string} adocName - file name, e.g. "22-threshold-session.adoc"
+ * @param {{
+ *   specHref: (leaf: string) => string | null,
+ *   specStatus: (leaf: string) => 'page' | 'blocked' | 'missing',
+ *   imageHref: (file: string) => string | null,
+ *   blobUrl: (path: string) => string,
+ * }} resolve
+ * @returns {{ id: string, frontmatter: Record<string, string | number>, body: string }}
+ */
+export function convertSpec(text, adocName, resolve) {
+  const lines = text.split('\n');
+  const attrs = {};
+  let title = adocName.replace(/\.adoc$/, '');
+  let i = 0;
+  if (lines[0] && /^= /.test(lines[0])) {
+    title = lines[0].replace(/^= +/, '').trim();
+    i = 1;
+  }
+  for (; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') break;
+    const attr = line.match(/^:([\w-]+):\s*(.*)$/);
+    if (attr) {
+      attrs[attr[1]] = attr[2].trim();
+      continue;
+    }
+    if (/ <[^>]+>$/.test(line)) continue; // author line
+  }
+  const out = [];
+  let inFence = false;
+  let inListing = false;
+  let pendingLang = null;
+  let table = null;
+  for (; i < lines.length; i++) {
+    let line = lines[i];
+    if (line.startsWith('```')) {
+      out.push(line);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    if (line === '----') {
+      if (inListing) {
+        out.push('```');
+        inListing = false;
+      } else {
+        out.push('```' + (pendingLang ?? ''));
+        inListing = true;
+      }
+      pendingLang = null;
+      continue;
+    }
+    if (inListing) {
+      out.push(line);
+      continue;
+    }
+    const src = line.match(/^\[source(?:,\s*([\w+.-]+))?\]\s*$/);
+    if (src) {
+      pendingLang = src[1] ?? '';
+      continue;
+    }
+    if (line.trim() === '|===') {
+      if (table) {
+        out.push(...emitTable(table));
+        table = null;
+      } else {
+        table = [];
+      }
+      continue;
+    }
+    if (table) {
+      if (/^\[(cols|frame|grid)/i.test(line.trim())) continue;
+      table.push(line);
+      continue;
+    }
+    line = specInline(line, resolve.specHref, resolve.specStatus, resolve.imageHref, resolve.blobUrl);
+    line = line.replace(
+      /^(={1,6}) +(.+?)(?:\s*=*)$/,
+      (_m, eq, txt) => '#'.repeat(eq.length) + ' ' + txt,
+    );
+    out.push(line);
+  }
+  if (table) out.push(...emitTable(table));
+
+  const id = adocName.replace(/\.adoc$/, '');
+  /** @type {Record<string, string | number>} */
+  const frontmatter = {
+    title,
+    upstream_path: `specs/${adocName}`,
+    category: specCategory(id, attrs.product),
+  };
+  const description = extractDescription(out.join('\n'));
+  if (description) frontmatter.description = description;
+  if (/^\d/.test(id)) frontmatter.spec_id = parseInt(id, 10);
+  if (attrs.status) frontmatter.status = attrs.status;
+  if (attrs.implementation) frontmatter.implementation = attrs.implementation;
+  if (attrs.product) frontmatter.product = attrs.product;
+
+  return {
+    id,
+    frontmatter,
+    body: out.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n',
+  };
+}
+
+/** Serialize a convertSpec result the way the vendor tree expects. */
+export function serializeSpec(converted) {
+  const fm = Object.entries(converted.frontmatter).map(([k, v]) =>
+    typeof v === 'number' ? `${k}: ${v}` : `${k}: ${yamlQuote(String(v))}`,
+  );
+  return `---\n${fm.join('\n')}\n---\n\n${converted.body}`;
+}

--- a/scripts/lib/specs-converter.test.mjs
+++ b/scripts/lib/specs-converter.test.mjs
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { convertSpec, serializeSpec } from './specs-converter.mjs';
+import { isBlockedSpec, isNeutralitySvg, isBlockedDoc } from './neutrality.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VENDOR_SPECS = join(__dirname, '..', '..', 'vendor', 'specs', 'specs');
+
+/**
+ * In-memory resolve adapter: two specs exist, one is blocked, one is
+ * unwritten; one diagram embeds, one is kept off-site.
+ */
+function testResolve() {
+  return {
+    specHref: (leaf) =>
+      ['22-threshold-session', '91-keyless-flow'].includes(leaf) ? `/specs/${leaf}/` : null,
+    specStatus: (leaf) => {
+      if (leaf === '80-cnml-deployment') return 'blocked';
+      return ['22-threshold-session', '91-keyless-flow'].includes(leaf) ? 'page' : 'missing';
+    },
+    imageHref: (file) => (file === 'async-session-lifecycle.svg' ? `/specs/images/${file}` : null),
+    blobUrl: (path) => `https://github.com/confium/specs/blob/main/${path}`,
+  };
+}
+
+function convert(text, name = '22-threshold-session.adoc') {
+  return convertSpec(text, name, testResolve());
+}
+
+describe('neutrality policy', () => {
+  it('blocks the institutional deployment spec and doc', () => {
+    expect(isBlockedSpec('80-cnml-deployment.adoc')).toBe(true);
+    expect(isBlockedSpec('22-threshold-session.adoc')).toBe(false);
+    expect(isBlockedDoc('cnml-profile.mdx')).toBe(true);
+    expect(isBlockedDoc('index.mdx')).toBe(false);
+  });
+
+  it('flags diagrams carrying the institutional label', () => {
+    expect(isNeutralitySvg('<svg><text>OIML CNML 5-tier hierarchy</text></svg>')).toBe(true);
+    expect(isNeutralitySvg('<svg><text>Transparency log</text></svg>')).toBe(false);
+  });
+});
+
+describe('header and frontmatter', () => {
+  it('takes the title from the = heading and drops author/attribute lines', () => {
+    const { frontmatter, body } = convert(
+      ['= Specification 22 — Threshold session', ':product: threshold', ':status: accepted',
+       'Ribose Inc. <open.source@ribose.com>', ':sectnums:', '', '== Overview', '', 'Body text.'].join('\n'),
+    );
+    expect(frontmatter.title).toBe('Specification 22 — Threshold session');
+    expect(frontmatter.product).toBe('threshold');
+    expect(frontmatter.status).toBe('accepted');
+    expect(frontmatter.spec_id).toBe(22);
+    expect(body).not.toContain(':sectnums:');
+    expect(body).not.toContain('Ribose');
+  });
+
+  it('always emits title, upstream_path, and category', () => {
+    const { frontmatter } = convert('= Bare\n\nNo attrs at all.');
+    expect(typeof frontmatter.title).toBe('string');
+    expect(frontmatter.upstream_path).toBe('specs/22-threshold-session.adoc');
+    expect(typeof frontmatter.category).toBe('string');
+  });
+
+  it('derives category from :product: first, then number prefix', () => {
+    expect(convert('= T\n:product: pki\n\nX.', '30-x509-pki.adoc').frontmatter.category).toBe('pki');
+    expect(convert('= T\n\nX.', '02-workspace-organization.adoc').frontmatter.category).toBe('architecture');
+    expect(convert('= T\n\nX.', '11-mode2-pki-replacement.adoc').frontmatter.category).toBe('modes');
+    expect(convert('= T\n\nX.', '90-security-model.adoc').frontmatter.category).toBe('security');
+    expect(convert('= T\n\nX.', 'PRODUCTS.adoc').frontmatter.category).toBe('index');
+  });
+
+  it('extracts the first prose sentence as description', () => {
+    const { frontmatter } = convert('= T\n\nFirst sentence here. Second sentence.');
+    expect(frontmatter.description).toBe('First sentence here.');
+  });
+});
+
+describe('block conversions', () => {
+  it('demotes == headings one level and leaves ``` fences untouched', () => {
+    const { body } = convert(['= T', '', '== Overview', '', '```', '|literal| table', '```'].join('\n'));
+    expect(body).toContain('## Overview');
+    expect(body).toContain('|literal| table');
+  });
+
+  it('converts [source] + ---- listings to fenced code', () => {
+    const { body } = convert(['= T', '', '[source,toml]', '----', '[workspace.package]', 'version = "0.3"', '----'].join('\n'));
+    expect(body).toContain('```toml\n[workspace.package]\nversion = "0.3"\n```');
+  });
+
+  it('converts |=== tables to markdown tables', () => {
+    const { body } = convert(
+      ['= T', '', '|===', '|Type |Phases', '|DKG |3 rounds', '|===' ].join('\n'),
+    );
+    expect(body).toContain('| Type | Phases |');
+    expect(body).toContain('| --- | --- |');
+    expect(body).toContain('| DKG | 3 rounds |');
+  });
+
+  it('skips [cols=…] attribute lines inside tables', () => {
+    const { body } = convert(['= T', '', '|===', '[cols="1,1"]', '|A |B', '|===' ].join('\n'));
+    expect(body).not.toContain('cols');
+    expect(body).toContain('| A | B |');
+  });
+});
+
+describe('inline macros', () => {
+  it('rewrites relative spec links to site pages', () => {
+    const { body } = convert('= T\n\nSee link:91-keyless-flow.adoc[Keyless flow] and link:22-threshold-session.adoc[].');
+    expect(body).toContain('[Keyless flow](/specs/91-keyless-flow/)');
+    expect(body).toContain('[22-threshold-session](/specs/22-threshold-session/)');
+  });
+
+  it('links blocked specs to GitHub and degrades unwritten specs to plain text', () => {
+    const { body } = convert('= T\n\nSee link:80-cnml-deployment.adoc[CNML] and link:40-deployment-manifest.adoc[40 — Deployment manifest].');
+    expect(body).toContain('[CNML](https://github.com/confium/specs/blob/main/specs/80-cnml-deployment.adoc)');
+    expect(body).toContain('40 — Deployment manifest');
+    expect(body).not.toContain('40-deployment-manifest.adoc)');
+  });
+
+  it('converts link: macros and bare https://…[label] macros', () => {
+    const { body } = convert('= T\n\nlink:https://example.com/[Example] and https://example.com/x[the x page].');
+    expect(body).toContain('[Example](https://example.com/)');
+    expect(body).toContain('[the x page](https://example.com/x)');
+  });
+
+  it('embeds allowed diagrams, links out skipped ones', () => {
+    const { body } = convert('= T\n\nimage::../images/async-session-lifecycle.svg[Async] and image::../images/cnml-tier-hierarchy.svg[CNML tiers].');
+    expect(body).toContain('![Async](/specs/images/async-session-lifecycle.svg)');
+    expect(body).toContain('[CNML tiers (SVG)](https://github.com/confium/specs/blob/main/images/cnml-tier-hierarchy.svg)');
+  });
+});
+
+describe('serialization', () => {
+  it('round-trips frontmatter as parseable YAML with required keys', () => {
+    const out = serializeSpec(convert('= T: with "quotes"\n\nBody.'));
+    const fm = out.match(/^---\n([\s\S]*?)\n---/)[1];
+    expect(fm).toContain('title: "T: with \\"quotes\\""');
+    expect(fm).toContain('upstream_path:');
+    expect(fm).toContain('category:');
+  });
+});
+
+describe('golden corpus (vendor/specs)', () => {
+  it.skipIf(!existsSync(VENDOR_SPECS))(
+    'every converted spec honors the site contract',
+    () => {
+      const adocs = readdirSync(VENDOR_SPECS).filter((f) => f.endsWith('.adoc'));
+      expect(adocs.length).toBeGreaterThan(10);
+      const resolve = testResolve();
+      const ids = new Set(adocs.map((f) => f.replace(/\.adoc$/, '')));
+      const fsResolve = {
+        specHref: (leaf) => (ids.has(leaf) && !isBlockedSpec(`${leaf}.adoc`) ? `/specs/${leaf}/` : null),
+        specStatus: (leaf) =>
+          isBlockedSpec(`${leaf}.adoc`) ? 'blocked' : ids.has(leaf) ? 'page' : 'missing',
+        imageHref: () => null,
+        blobUrl: (path) => `https://github.com/confium/specs/blob/main/${path}`,
+      };
+      for (const f of adocs) {
+        if (isBlockedSpec(f)) continue;
+        const converted = convertSpec(readFileSync(join(VENDOR_SPECS, f), 'utf8'), f, fsResolve);
+        const md = serializeSpec(converted);
+        expect(converted.frontmatter.title, `${f}: title`).toBeTruthy();
+        expect(converted.frontmatter.upstream_path, `${f}: upstream_path`).toBe(`specs/${f}`);
+        expect(converted.frontmatter.category, `${f}: category`).toBeTruthy();
+        expect(md, `${f}: OIML must not render`).not.toMatch(/oiml/i);
+        expect(md, `${f}: gate language`).not.toMatch(/TODO|coming soon|planned|milestone|roadmap/i);
+        for (const href of md.matchAll(/\]\(\/specs\/([^/)]+)\/?\)/g)) {
+          expect(ids, `${f}: internal link ${href[1]}`).toContain(href[1].toLowerCase());
+        }
+      }
+    },
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
  */
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/lib/**/*.test.mjs'],
     environment: 'node',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Architecture deepening of the specs pipeline (follow-up to #91): the pure converter gets a real interface and a test surface.

### Extract — deep module behind a resolver seam

- `scripts/lib/specs-converter.mjs` — `convertSpec(text, name, resolve)` is pure: no fs, no git. The seam carries every environment question (`specHref`, `specStatus`, `imageHref`, `blobUrl`). Two adapters make the seam real: fs-backed in `fetch-sources.mjs`, in-memory in tests.
- `scripts/lib/neutrality.mjs` — one module owns the neutrality policy (blocked docs, blocked specs, OIML-label SVG detection) instead of three scattered encodings.
- `scripts/fetch-sources.mjs` slims to orchestration; converter output byte-stable on regeneration.

### Contract — 16 new tests

- Unit: every AsciiDoc construct (headers, `|===` tables, `[source]`+`----`, ``` fences, `link:`/bare-URL/`image::` macros), frontmatter invariants (`title`/`upstream_path`/`category` always present), resolver behavior (blocked → GitHub link, unwritten → plain text, skipped diagram → link-out).
- Golden corpus: converts the vendored specs and asserts the site contract — required frontmatter, zero OIML/gate language, every internal cross-link resolves. Runs in CI (tests.yml fetches the corpus via `fetch-sources.mjs specs`).

### Stale-vendor trap

- `CONFIUM_REFRESH_SOURCES=1` fast-forwards existing vendor clones; default reuse stays for offline dev.

### Verification

- 82/82 tests (66 + 16). `astro check` 0 errors. Build 447 pages, OIML gate 0, language gate 0, specs-corpus lychee 0 errors. dist byte-identical pages.
