### PR TITLE
refactor(vendor): tested link rewriter, MDX sanitizer, and runnable gates

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -52,21 +52,8 @@ jobs:
         env:
           CI: true
 
-      - name: Quality gate — no OIML references
-        run: |
-          if grep -ril OIML dist/; then
-            echo "ERROR: OIML references found in built site"
-            grep -ril OIML dist/
-            exit 1
-          fi
-
-      - name: Quality gate — no TODO / roadmap language
-        run: |
-          if grep -rEi 'TODO|coming soon|planned|milestone|roadmap' dist/ \
-              --include='*.html' --include='*.md' --include='*.mdx'; then
-            echo "ERROR: forbidden language found in built site"
-            exit 1
-          fi
+      - name: Quality gates (OIML, forbidden language, spec completeness)
+        run: npm run check:gates
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "node scripts/fetch-sources.mjs",
     "postbuild": "pagefind --site dist",
     "fetch-sources": "node scripts/fetch-sources.mjs",
+    "check:gates": "node scripts/check-gates.mjs dist",
     "check:links": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
     "check:links:external": "lychee --root-dir \"$PWD/dist\" --config lychee.toml --no-progress 'dist/**/*.html'",
     "test": "vitest run",

--- a/scripts/check-gates.mjs
+++ b/scripts/check-gates.mjs
@@ -1,0 +1,91 @@
+/**
+ * The site's quality gates, in one runnable module: the same checks
+ * CI enforces on dist/ are available locally via `npm run
+ * check:gates`, and the collector is unit-testable.
+ *
+ * Gates:
+ *  1. No OIML reference anywhere in dist/ (any file — the neutrality
+ *     policy covers diagram text as well as pages).
+ *  2. No TODO / coming-soon / planned / milestone / roadmap language
+ *     in built html/md/mdx.
+ *  3. Every page under dist/specs renders real content — a spec page
+ *     whose converter output silently came out empty would otherwise
+ *     ship with only its hero. Specs have multiple sections upstream,
+ *     so two or more <h2> headings is the completeness signal.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const FORBIDDEN_LANGUAGE = /TODO|coming soon|planned|milestone|roadmap/i;
+const LANGUAGE_EXTENSIONS = new Set(['.html', '.md', '.mdx']);
+
+function walkFiles(root) {
+  const out = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(path));
+    else if (entry.isFile()) out.push(path);
+  }
+  return out;
+}
+
+/**
+ * @param {string} distDir - absolute or repo-relative dist directory
+ * @returns {{
+ *   oiml: string[],
+ *   language: string[],
+ *   incompleteSpecs: string[],
+ * }} violating files per gate; empty arrays = clean
+ */
+export function collectGateViolations(distDir) {
+  const files = walkFiles(distDir);
+  const oiml = [];
+  const language = [];
+  for (const path of files) {
+    const text = readFileSync(path, 'utf8');
+    if (/oiml/i.test(text)) oiml.push(path);
+    if (LANGUAGE_EXTENSIONS.has(extname(path)) && FORBIDDEN_LANGUAGE.test(text)) {
+      language.push(path);
+    }
+  }
+  const incompleteSpecs = [];
+  const specsDir = join(distDir, 'specs');
+  for (const entry of readdirSync(specsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const index = join(specsDir, entry.name, 'index.html');
+    if (!existsSync(index)) continue;
+    const headings = (readFileSync(index, 'utf8').match(/<h2/g) ?? []).length;
+    if (headings < 2) incompleteSpecs.push(index);
+  }
+  return { oiml, language, incompleteSpecs };
+}
+
+// CLI: only when executed directly (node scripts/check-gates.mjs dist).
+const isEntry = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
+if (isEntry) {
+  const distDir = process.argv[2];
+  if (!distDir) {
+    console.error('usage: node scripts/check-gates.mjs <dist-dir>');
+    process.exit(2);
+  }
+  const { oiml, language, incompleteSpecs } = collectGateViolations(distDir);
+  if (oiml.length) {
+    console.error('ERROR: OIML references found in built site');
+    for (const f of oiml) console.error(`  ${f}`);
+  }
+  if (language.length) {
+    console.error('ERROR: forbidden language found in built site');
+    for (const f of language) console.error(`  ${f}`);
+  }
+  if (incompleteSpecs.length) {
+    console.error('ERROR: spec pages rendering without content (<2 h2 headings)');
+    for (const f of incompleteSpecs) console.error(`  ${f}`);
+  }
+  const total = oiml.length + language.length + incompleteSpecs.length;
+  if (total === 0) {
+    console.log(`[check-gates] clean: ${distDir}`);
+  }
+  process.exit(total === 0 ? 0 : 1);
+}

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -27,6 +27,8 @@ import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 
 import { convertSpec, serializeSpec } from './lib/specs-converter.mjs';
+import { rewriteDocText } from './lib/doc-links.mjs';
+import { sanitizeMdx } from './lib/mdx-sanitize.mjs';
 import { BLOCKED_DOCS, isBlockedSpec, isNeutralitySvg } from './lib/neutrality.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -123,8 +125,55 @@ function fetchSoftwareDocs() {
   // Second pass: link rewriting needs every vendor present — the
   // per-language docs cross-link into the full tree under `rust`.
   for (const v of vendored) {
-    rewriteDocLinks(v.target, v.subtree, v.id, v.repo, v.ref);
-    sanitizeMdxHeaders(v.target);
+    rewriteVendorDocLinks(v);
+    sanitizeVendorMdx(v.target);
+  }
+}
+
+/**
+ * Walker for the pure link rewriter (scripts/lib/doc-links.mjs):
+ * reads each vendored doc, applies the mapping through an fs-backed
+ * io adapter, and writes back the files that changed.
+ */
+function rewriteVendorDocLinks(v) {
+  // Cone-mode sparse checkout of a nested subtree (docs/bindings)
+  // also pulls the files directly under docs/; walk the whole docs
+  // root so those top-level files get rewritten too.
+  const docsRoot = join(v.target, v.subtree.split('/')[0]);
+  const files = readdirSync(docsRoot, { withFileTypes: true, recursive: true });
+  for (const entry of files) {
+    if (!entry.isFile() || (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx'))) continue;
+    const parent = entry.path ?? entry.parentPath ?? docsRoot;
+    const path = join(parent, entry.name);
+    const { text, changed } = rewriteDocText(readFileSync(path, 'utf8'), {
+      path,
+      docsRoot,
+      repoRoot: v.target,
+      id: v.id,
+      repoHttps: v.repo,
+      ref: v.ref,
+      rustDocsRoot: join(VENDOR, 'rust', 'docs'),
+      io: { exists: existsSync },
+    });
+    if (changed) {
+      writeFileSync(path, text);
+      console.log(`[fetch-sources] rewrote links in ${relative(ROOT, path)}`);
+    }
+  }
+}
+
+/** Walker for the pure MDX sanitizer (scripts/lib/mdx-sanitize.mjs). */
+function sanitizeVendorMdx(root) {
+  const files = readdirSync(root, { withFileTypes: true, recursive: true });
+  for (const entry of files) {
+    if (!entry.isFile() || !entry.name.endsWith('.mdx')) continue;
+    const parent = entry.path ?? entry.parentPath ?? root;
+    const path = join(parent, entry.name);
+    const sanitized = sanitizeMdx(readFileSync(path, 'utf8'));
+    if (sanitized !== readFileSync(path, 'utf8')) {
+      writeFileSync(path, sanitized);
+      console.log(`[fetch-sources] sanitized ${relative(ROOT, path)}`);
+    }
   }
 }
 
@@ -138,7 +187,7 @@ function fetchSpecs() {
   sparseClone(SPECS_REPO, SPECS_REF, target, ['specs/', 'images/']);
   const skippedImages = copySpecImages(target);
   convertSpecs(target, skippedImages);
-  sanitizeMdxHeaders(target);
+  sanitizeVendorMdx(target);
 }
 
 /**
@@ -217,143 +266,6 @@ function copySpecImages(target) {
     console.log(`[fetch-sources] kept off-site (neutrality): ${skipped.join(', ')}`);
   }
   return skipped;
-}
-
-/**
- * Patches vendored MDX to survive the MDX 3 parser:
- *
- *  - HTML comments at the top of a file (`<!-- ... -->`) are illegal;
- *    the `<!` is parsed as JSX. Rewrite to MDX-style comments.
- *  - Markdown autolinks (`<https://...>`) are not accepted by MDX;
- *    rewrite to explicit `[label](url)` links.
- */
-/**
- * Rewrite repo-relative `.md`/`.mdx` links in vendored docs into
- * absolute site URLs (`/software/{id}/docs/...`). Upstream docs are
- * written for GitHub browsing; on the nested site the same relative
- * links would resolve against the rendered page's URL and 404.
- * Only links whose target exists inside the vendored subtree are
- * rewritten; anything else (anchors, images, external) is kept.
- */
-function rewriteDocLinks(root, subtree, id, repoHttps, ref) {
-  // Cone-mode sparse checkout of a nested subtree (docs/bindings)
-  // also pulls the files directly under docs/; walk the whole docs
-  // root so those top-level files get rewritten too.
-  const docsRoot = join(root, subtree.split('/')[0]);
-  const files = readdirSync(docsRoot, { withFileTypes: true, recursive: true });
-  for (const entry of files) {
-    if (!entry.isFile() || (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx'))) continue;
-    const parent = entry.path ?? entry.parentPath ?? docsRoot;
-    const path = join(parent, entry.name);
-    const text = readFileSync(path, 'utf8');
-    const re = /\]\(([^)#\s]+?)(#[^)\s]*)?\)/g;
-    let changed = false;
-    const out = text.replace(re, (m, target, anchor) => {
-      // Upstream docs sometimes assume the site's /docs/ IA; map
-      // those into this vendor's own docs tree.
-      if (target.startsWith('/docs/')) {
-        const t = target.slice('/docs/'.length)
-          .replace(/\.(md|mdx)$/, '')
-          .split('/')
-          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
-          .join('/');
-        const cands = [join(docsRoot, `${t}.mdx`), join(docsRoot, `${t}.md`),
-                       join(docsRoot, t, 'index.mdx')];
-        for (const c of cands) {
-          if (existsSync(c)) {
-            changed = true;
-            return `](/software/${id}/docs/${t}${anchor ?? ''})`;
-          }
-        }
-        return m;
-      }
-      // Only rewrite relative, potentially-doc links: skip URLs,
-      // images, mailto, and site-absolute links.
-      if (/^(https?:|mailto:|\/|\.png|\.jpe?g|\.svg|\.gif)/i.test(target)) return m;
-      let resolved = resolvePath(dirname(path), target);
-      // Extensionless sibling links: try the .mdx/.md/index forms.
-      if (!/\.(md|mdx)$/.test(resolved)) {
-        for (const cand of [`${resolved}.mdx`, `${resolved}.md`,
-                            join(resolved, 'index.mdx'), join(resolved, 'index.md')]) {
-          if (existsSync(cand)) { resolved = cand; break; }
-        }
-      }
-      if (!/\.(md|mdx)$/.test(resolved)) {
-        // Escapes the docs root (e.g. ../CONTRIBUTING.md): link to
-        // the upstream repository.
-        if (!resolved.startsWith(resolvePath(root) + '/')) return m;
-        const inRepoRoot = relative(join(VENDOR, id), resolved);
-        return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
-      }
-      if (!resolved.startsWith(resolvePath(docsRoot) + '/')) {
-        if (!resolved.startsWith(resolvePath(root) + '/')) return m;
-        const inRepoRoot = relative(join(VENDOR, id), resolved);
-        return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
-      }
-      if (existsSync(resolved)) {
-        // Mirror Astro's github-slugger (dots and other
-        // non-word chars are stripped per segment).
-        const rel = relative(resolvePath(docsRoot), resolved)
-          .replace(/\.(md|mdx)$/, '')
-          .replace(/\/index$/, '')
-          .split('/')
-          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
-          .join('/');
-        changed = true;
-        return `](/software/${id}/docs/${rel}${anchor ?? ''})`;
-      }
-      // The per-language vendors pull only the bindings subtree plus
-      // the top level of docs/; links into the rest of the confium
-      // docs resolve against the full tree vendored under `rust`,
-      // mapped by position within the docs root.
-      const rustDocs = join(VENDOR, 'rust', 'docs');
-      const alt = resolvePath(rustDocs, relative(resolvePath(docsRoot), resolved));
-      if (existsSync(rustDocs) && alt.startsWith(resolvePath(rustDocs) + '/') && existsSync(alt)) {
-        const rel = relative(resolvePath(rustDocs), alt)
-          .replace(/\.(md|mdx)$/, '')
-          .replace(/\/index$/, '')
-          .split('/')
-          .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
-          .join('/');
-        changed = true;
-        return `](/software/rust/docs/${rel}${anchor ?? ''})`;
-      }
-      // Target exists nowhere in the vendored trees: send readers to
-      // the upstream repository instead of a dead link.
-      const inRepo = relative(join(VENDOR, id), resolved);
-      changed = true;
-      return `](${repoHttps.replace(/\.git$/, '')}/blob/${ref}/${inRepo}${anchor ?? ''})`;
-    });
-    if (changed) {
-      writeFileSync(path, out);
-      console.log(`[fetch-sources] rewrote links in ${relative(ROOT, path)}`);
-    }
-  }
-}
-
-function sanitizeMdxHeaders(root) {
-  const files = readdirSync(root, { withFileTypes: true, recursive: true });
-  for (const entry of files) {
-    if (!entry.isFile() || !entry.name.endsWith('.mdx')) continue;
-    const parent = entry.path ?? entry.parentPath ?? root;
-    const path = join(parent, entry.name);
-    const text = readFileSync(path, 'utf8');
-    let sanitized = text;
-    if (sanitized.match(/^<!--/m)) {
-      sanitized = sanitized.replace(/^<!--([\s\S]*?)-->/, '{/*$1*/}');
-    }
-    sanitized = sanitized.replace(
-      /<((?:https?|mailto):[^>\s]+)>/g,
-      (_, url) => `[${url}](${url})`,
-    );
-    // Escape {braces} in prose so upstream template placeholders
-    // render literally instead of failing as JSX expressions.
-    sanitized = sanitized.replace(/(^|[^`{])\{([a-zA-Z][a-zA-Z0-9_-]*)\}/g, '$1\\{$2\\}');
-    if (sanitized !== text) {
-      writeFileSync(path, sanitized);
-      console.log(`[fetch-sources] sanitized ${path}`);
-    }
-  }
 }
 
 /**

--- a/scripts/lib/check-gates.test.mjs
+++ b/scripts/lib/check-gates.test.mjs
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectGateViolations } from '../check-gates.mjs';
+
+let dir;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'gates-'));
+  // Baseline: one healthy spec page so the specs walk always has data.
+  write(join('specs', '22-full', 'index.html'), '<h1>t</h1><h2>a</h2><h2>b</h2>');
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function write(rel, content) {
+  const path = join(dir, rel);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+describe('collectGateViolations', () => {
+  it('reports OIML in any dist file, including svg', () => {
+    write('diagram.svg', '<svg><text>OIML label</text></svg>');
+    const v = collectGateViolations(dir);
+    expect(v.oiml).toHaveLength(1);
+    expect(v.oiml[0]).toContain('diagram.svg');
+    expect(v.incompleteSpecs).toHaveLength(0);
+  });
+
+  it('reports forbidden language only in html/md/mdx', () => {
+    write('page.html', '<p>coming soon</p>');
+    write('page.md', 'see the roadmap');
+    write('ignored.json', '{"note": "planned"}');
+    const v = collectGateViolations(dir);
+    expect(v.language.some((f) => f.endsWith('page.html'))).toBe(true);
+    expect(v.language.some((f) => f.endsWith('page.md'))).toBe(true);
+    expect(v.language.some((f) => f.endsWith('ignored.json'))).toBe(false);
+  });
+
+  it('flags spec pages that render without content', () => {
+    write(join('specs', '00-empty', 'index.html'), '<h1>Only hero</h1>');
+    const v = collectGateViolations(dir);
+    expect(v.incompleteSpecs).toHaveLength(1);
+    expect(v.incompleteSpecs[0]).toContain('00-empty');
+  });
+});

--- a/scripts/lib/doc-links.mjs
+++ b/scripts/lib/doc-links.mjs
@@ -1,0 +1,124 @@
+/**
+ * Repo-relative link rewriting for vendored software docs, as a pure
+ * function: the mapping runs against an injected `io.exists`, so
+ * tests drive it with an in-memory file map and the fetch script
+ * passes the filesystem.
+ *
+ * Upstream docs are written for GitHub browsing; on the nested site
+ * (/software/{id}/docs/…) the same relative links would resolve
+ * against the rendered page's URL and 404. Five fallbacks, in order:
+ *
+ *  1. `/docs/…` prefix → this vendor's own docs tree (mirrors
+ *     Astro's github-slugger: lowercase, non-word chars stripped per
+ *     segment).
+ *  2. Relative `.md`/`.mdx` inside the docs root → site URL.
+ *  3. Extensionless siblings → `.mdx` / `.md` / `dir/index.*` forms.
+ *  4. Escapes the vendor root → upstream GitHub blob URL.
+ *  5. Target missing everywhere → the per-language vendors pull only
+ *     the bindings subtree plus the docs root, so try the same
+ *     position in the full tree vendored under `rust` before falling
+ *     back to GitHub.
+ */
+
+import { relative, resolve as resolvePath, dirname } from 'node:path';
+
+function siteSlug(relDocPath) {
+  return relDocPath
+    .replace(/\.(md|mdx)$/, '')
+    .replace(/\/index$/, '')
+    .split('/')
+    .map((seg) => seg.toLowerCase().replace(/[^\w-]/g, ''))
+    .join('/');
+}
+
+/**
+ * @param {string} text - markdown/MDX source of one vendored doc
+ * @param {{
+ *   path: string,          // absolute path of the doc being rewritten
+ *   docsRoot: string,      // absolute vendor docs root (…/<id>/docs)
+ *   repoRoot: string,      // absolute vendor repo root (…/<id>)
+ *   id: string,            // vendor id, e.g. "ruby"
+ *   repoHttps: string,     // https clone URL (.git allowed)
+ *   ref: string,           // upstream ref for blob links
+ *   rustDocsRoot: string,  // absolute …/vendor/rust/docs (fallback #5)
+ *   io: { exists: (abs: string) => boolean },
+ * }} ctx
+ * @returns {{ text: string, changed: boolean }}
+ */
+export function rewriteDocText(text, ctx) {
+  const { path, docsRoot, repoRoot, id, repoHttps, ref, rustDocsRoot, io } = ctx;
+  const blobBase = repoHttps.replace(/\.git$/, '');
+  const re = /\]\(([^)#\s]+?)(#[^)\s]*)?\)/g;
+  let changed = false;
+  const out = text.replace(re, (m, target, anchor) => {
+    // Fallback 1: upstream docs that assume the site's /docs/ IA —
+    // map them into this vendor's own docs tree.
+    if (target.startsWith('/docs/')) {
+      const t = siteSlug(target.slice('/docs/'.length));
+      const docsRootSlash = resolvePath(docsRoot) + '/';
+      for (const c of [
+        resolvePath(docsRoot, `${t}.mdx`),
+        resolvePath(docsRoot, `${t}.md`),
+        resolvePath(docsRoot, t, 'index.mdx'),
+      ]) {
+        if (io.exists(c)) {
+          changed = true;
+          return `](/software/${id}/docs/${t}${anchor ?? ''})`;
+        }
+      }
+      return m;
+    }
+    // Skip URLs, images, mailto, and site-absolute links.
+    if (/^(https?:|mailto:|\/|\.png|\.jpe?g|\.svg|\.gif)/i.test(target)) return m;
+    let resolved = resolvePath(dirname(path), target);
+    // Fallback 3: extensionless sibling links.
+    if (!/\.(md|mdx)$/.test(resolved)) {
+      for (const cand of [
+        `${resolved}.mdx`,
+        `${resolved}.md`,
+        resolvePath(resolved, 'index.mdx'),
+        resolvePath(resolved, 'index.md'),
+      ]) {
+        if (io.exists(cand)) {
+          resolved = cand;
+          break;
+        }
+      }
+    }
+    if (!/\.(md|mdx)$/.test(resolved)) {
+      // Escapes the docs root (e.g. ../CONTRIBUTING.md): link to the
+      // upstream repository. (The original walker did not flag this
+      // rewrite as a change; preserved so output stays identical.)
+      if (!resolved.startsWith(resolvePath(repoRoot) + '/')) return m;
+      const inRepoRoot = relative(repoRoot, resolved);
+      return `](${blobBase}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
+    }
+    if (!resolved.startsWith(resolvePath(docsRoot) + '/')) {
+      if (!resolved.startsWith(resolvePath(repoRoot) + '/')) return m;
+      const inRepoRoot = relative(repoRoot, resolved);
+      return `](${blobBase}/blob/${ref}/${inRepoRoot}${anchor ?? ''})`;
+    }
+    if (io.exists(resolved)) {
+      const rel = siteSlug(relative(resolvePath(docsRoot), resolved));
+      changed = true;
+      return `](/software/${id}/docs/${rel}${anchor ?? ''})`;
+    }
+    // Fallback 5: try the same position in the full rust docs tree.
+    const alt = resolvePath(rustDocsRoot, relative(resolvePath(docsRoot), resolved));
+    if (
+      io.exists(rustDocsRoot) &&
+      alt.startsWith(resolvePath(rustDocsRoot) + '/') &&
+      io.exists(alt)
+    ) {
+      const rel = siteSlug(relative(resolvePath(rustDocsRoot), alt));
+      changed = true;
+      return `](/software/rust/docs/${rel}${anchor ?? ''})`;
+    }
+    // Target exists nowhere in the vendored trees: send readers to
+    // the upstream repository instead of a dead link.
+    const inRepo = relative(repoRoot, resolved);
+    changed = true;
+    return `](${blobBase}/blob/${ref}/${inRepo}${anchor ?? ''})`;
+  });
+  return { text: out, changed };
+}

--- a/scripts/lib/doc-links.test.mjs
+++ b/scripts/lib/doc-links.test.mjs
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { rewriteDocText } from './doc-links.mjs';
+import { sanitizeMdx } from './mdx-sanitize.mjs';
+
+const DOCS = '/vendor/ruby/docs';
+const REPO = '/vendor/ruby';
+
+function ioWith(files) {
+  return { exists: (p) => files.includes(p) };
+}
+
+function ctx(io, path = `${DOCS}/index.md`, over = {}) {
+  return {
+    path,
+    docsRoot: DOCS,
+    repoRoot: REPO,
+    id: 'ruby',
+    repoHttps: 'https://github.com/confium/confium-ruby.git',
+    ref: 'main',
+    rustDocsRoot: '/vendor/rust/docs',
+    io,
+    ...over,
+  };
+}
+
+describe('rewriteDocText — fallbacks in order', () => {
+  it('rewrites relative .md links inside the docs root to site URLs', () => {
+    const io = ioWith([`${DOCS}/installation.md`]);
+    const { text, changed } = rewriteDocText('see [install](installation.md#section)', ctx(io));
+    expect(changed).toBe(true);
+    expect(text).toBe('see [install](/software/ruby/docs/installation#section)');
+  });
+
+  it('mirrors the Astro slugger: lowercase, dots stripped per segment', () => {
+    const io = ioWith([`${DOCS}/guides/0.3-to-0.4.mdx`]);
+    const { text } = rewriteDocText('[guide](guides/0.3-to-0.4.mdx)', ctx(io));
+    expect(text).toBe('[guide](/software/ruby/docs/guides/03-to-04)');
+  });
+
+  it('resolves extensionless siblings through .mdx/.md/index forms', () => {
+    const io = ioWith([`${DOCS}/api/index.mdx`]);
+    const { text } = rewriteDocText('[api](../api)', ctx(io, `${DOCS}/bindings/quickstart.md`));
+    expect(text).toBe('[api](/software/ruby/docs/api)');
+  });
+
+  it('maps upstream /docs/… assumptions into this vendor tree', () => {
+    const io = ioWith([`${DOCS}/installation.mdx`]);
+    const { text } = rewriteDocText('[x](/docs/installation)', ctx(io));
+    expect(text).toBe('[x](/software/ruby/docs/installation)');
+  });
+
+  it('falls back to the rust tree by position for cross-vendor links', () => {
+    const io = ioWith(['/vendor/rust/docs', '/vendor/rust/docs/bindings/policy.md']);
+    // A python-vendor doc referencing a rust-only page:
+    const { text } = rewriteDocText('[p](policy.md)', ctx(io, '/vendor/python/docs/bindings/x.md', {
+      docsRoot: '/vendor/python/docs',
+      repoRoot: '/vendor/python',
+      id: 'python',
+      repoHttps: 'https://github.com/confium/confium-python.git',
+    }));
+    expect(text).toBe('[p](/software/rust/docs/bindings/policy)');
+  });
+
+  it('sends dead targets to the upstream GitHub blob, .git stripped', () => {
+    const io = ioWith([]);
+    const { text, changed } = rewriteDocText('[x](gone/never.md)', ctx(io));
+    expect(changed).toBe(true);
+    expect(text).toBe('[x](https://github.com/confium/confium-ruby/blob/main/docs/gone/never.md)');
+  });
+
+  it('leaves URLs, mailto, and site-absolute links untouched', () => {
+    const src = '[a](https://x.y/z) [m](mailto:a@b.c) [s](/threshold/)';
+    const { text, changed } = rewriteDocText(src, ctx(ioWith([])));
+    expect(changed).toBe(false);
+    expect(text).toBe(src);
+  });
+
+  it('sends image-looking targets that miss the docs tree to GitHub (parity: the skip regex only matches targets literally starting with the extension)', () => {
+    const { text } = rewriteDocText('![p](../pic.svg)', ctx(ioWith([])));
+    expect(text).toBe('![p](https://github.com/confium/confium-ruby/blob/main/pic.svg)');
+  });
+
+  it('keeps repo-escaping doc links but does not flag them as changes (parity with the old walker)', () => {
+    const io = ioWith([]);
+    const { text, changed } = rewriteDocText('[c](../../CONTRIBUTING.md)', ctx(io, `${DOCS}/bindings/quickstart.md`));
+    expect(changed).toBe(false);
+    expect(text).toBe('[c](https://github.com/confium/confium-ruby/blob/main/CONTRIBUTING.md)');
+  });
+});
+
+describe('sanitizeMdx', () => {
+  it('rewrites a leading HTML comment to an MDX comment', () => {
+    expect(sanitizeMdx('<!-- note -->\nbody')).toBe('{/* note */}\nbody');
+  });
+
+  it('rewrites markdown autolinks to explicit links', () => {
+    expect(sanitizeMdx('go <https://x.y> now')).toBe('go [https://x.y](https://x.y) now');
+    expect(sanitizeMdx('mail <mailto:a@b.c>')).toBe('mail [mailto:a@b.c](mailto:a@b.c)');
+  });
+
+  it('escapes bare identifiers in braces but leaves code alone', () => {
+    expect(sanitizeMdx('set {user_id} here')).toBe('set \\{user_id\\} here');
+    expect(sanitizeMdx('`{code}` stays')).toBe('`{code}` stays');
+    expect(sanitizeMdx('already \\{escaped\\}')).toBe('already \\{escaped\\}');
+  });
+
+  it('leaves text without constructs untouched', () => {
+    const src = '# Title\n\nplain prose with no macros';
+    expect(sanitizeMdx(src)).toBe(src);
+  });
+});

--- a/scripts/lib/mdx-sanitize.mjs
+++ b/scripts/lib/mdx-sanitize.mjs
@@ -1,0 +1,28 @@
+/**
+ * Patches vendored MDX to survive the MDX 3 parser. Pure
+ * string → string; the fetch script owns traversal and writing.
+ *
+ *  - HTML comments at the top of a file (`<!-- ... -->`) are illegal;
+ *    the `<!` is parsed as JSX. Rewritten to MDX-style comments.
+ *  - Markdown autolinks (`<https://...>`) are not accepted by MDX;
+ *    rewritten to explicit `[label](url)` links.
+ *  - `{word}` in prose parses as a JSX expression; escaped so
+ *    upstream template placeholders render literally. Inline code
+ *    and already-escaped braces are left alone.
+ */
+
+export function sanitizeMdx(text) {
+  let sanitized = text;
+  if (sanitized.match(/^<!--/m)) {
+    sanitized = sanitized.replace(/^<!--([\s\S]*?)-->/, '{/*$1*/}');
+  }
+  sanitized = sanitized.replace(
+    /<((?:https?|mailto):[^>\s]+)>/g,
+    (_, url) => `[${url}](${url})`,
+  );
+  sanitized = sanitized.replace(
+    /(^|[^`{])\{([a-zA-Z][a-zA-Z0-9_-]*)\}/g,
+    '$1\\{$2\\}',
+  );
+  return sanitized;
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -41,13 +41,6 @@ const softwareFrontmatter = z.object({
   weight: z.number().default(0),
 });
 
-const specsFrontmatter = z.object({
-  title: z.string(),
-  description: z.string(),
-  upstream_path: z.string(),
-  category: z.string().default('spec'),
-});
-
 export const collections = {
   blog: defineCollection({
     loader: glob({ base: './src/content/blog', pattern: '**/*.mdx' }),
@@ -84,11 +77,6 @@ export const collections = {
   software: defineCollection({
     loader: glob({ base: './src/content/software', pattern: '**/*.md' }),
     schema: softwareFrontmatter,
-  }),
-
-  specs: defineCollection({
-    loader: glob({ base: './src/content/specs', pattern: '**/*.md' }),
-    schema: specsFrontmatter,
   }),
 
   // Vendor-pulled: per-repo implementation docs. Pattern matches both

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -110,7 +110,7 @@ export { DOC_GROUP_LABELS, DOC_GROUP_ORDER };
  * Map a collection to CardItem for the index-page card grids.
  */
 export function toCardItems<
-  C extends 'docs' | 'concepts' | 'use_cases' | 'glossary' | 'specs',
+  C extends 'docs' | 'concepts' | 'use_cases' | 'glossary',
 >(entries: CollectionEntry<C>[]): CardItem[] {
   return byOrder(entries).map((e) => ({
     title: e.data.title,


### PR DESCRIPTION
## Summary

Round 2 of the vendor-pipeline deepening (round 1: specs converter, #92).

### `doc-links.mjs` — the software-docs link rewriter, extracted (Strong)

The five-fallback IA mapping for 202 public pages moves behind an injected `io.exists` seam; the rust cross-vendor fallback takes the rust docs root as a parameter instead of reading a global. **Parity proven byte-for-byte**: every vendor tree restored to pristine upstream via `git checkout`, re-run through the new code, hashed — identical across all five vendors.

### `mdx-sanitize.mjs` — pure sanitizer (Worth exploring)

The three in-place MDX patch rules as a pure string→string function. Fixtures pin each rule and the non-targets (inline code, already-escaped braces).

### `check-gates.mjs` — gates leave CI folklore (Worth exploring)

- `npm run check:gates` runs locally what only `build_deploy.yml` could run: OIML-anywhere and forbidden-language greps.
- New **spec-completeness gate**: every `dist/specs/*/index.html` must render ≥2 `<h2>` headings — a spec whose conversion silently produced an empty body now fails the build instead of shipping a hero-only page.
- CI shrinks to one line; the collector is unit-tested (3 cases).

### Curated specs collection retired

`specDocs` has been the only spec source since #91; the unread `specs` collection is gone from content.config (the curated `.md` files stay on disk). `toCardItems` drops the dead `specs` union member.

### Verification

- 98/98 tests. `astro check` 0 errors. Build 447 pages, 37 spec pages.
- `npm run check:gates` → clean (all three gates).
- lychee on specs + software corpora: 28,864 links, 0 errors.
