### PR TITLE
refactor(pipeline): close the silent-failure paths around the vendor pull

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Fetch specs corpus (golden converter tests)
       run: node scripts/fetch-sources.mjs specs
+    - name: Verify specs corpus landed
+      run: test -d vendor/specs/specs || (echo "specs corpus missing — fetch degraded silently"; exit 1)
 
     - name: Run Vitest
       run: npm test

--- a/scripts/check-gates.mjs
+++ b/scripts/check-gates.mjs
@@ -12,6 +12,9 @@
  *     whose converter output silently came out empty would otherwise
  *     ship with only its hero. Specs have multiple sections upstream,
  *     so two or more <h2> headings is the completeness signal.
+ *  4. dist/specs carries at least `minSpecPages` pages — an empty or
+ *     gutted specs section (failed vendor pull) must fail loudly, not
+ *     pass vacuously.
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -20,6 +23,7 @@ import { pathToFileURL } from 'node:url';
 
 const FORBIDDEN_LANGUAGE = /TODO|coming soon|planned|milestone|roadmap/i;
 const LANGUAGE_EXTENSIONS = new Set(['.html', '.md', '.mdx']);
+const DEFAULT_MIN_SPEC_PAGES = 30;
 
 function walkFiles(root) {
   const out = [];
@@ -33,13 +37,14 @@ function walkFiles(root) {
 
 /**
  * @param {string} distDir - absolute or repo-relative dist directory
+ * @param {{ minSpecPages?: number }} [options] - floor for gate 4 (tests lower it)
  * @returns {{
  *   oiml: string[],
  *   language: string[],
  *   incompleteSpecs: string[],
  * }} violating files per gate; empty arrays = clean
  */
-export function collectGateViolations(distDir) {
+export function collectGateViolations(distDir, { minSpecPages = DEFAULT_MIN_SPEC_PAGES } = {}) {
   const files = walkFiles(distDir);
   const oiml = [];
   const language = [];
@@ -52,12 +57,19 @@ export function collectGateViolations(distDir) {
   }
   const incompleteSpecs = [];
   const specsDir = join(distDir, 'specs');
+  let specPages = 0;
   for (const entry of readdirSync(specsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const index = join(specsDir, entry.name, 'index.html');
     if (!existsSync(index)) continue;
+    specPages += 1;
     const headings = (readFileSync(index, 'utf8').match(/<h2/g) ?? []).length;
     if (headings < 2) incompleteSpecs.push(index);
+  }
+  if (specPages < minSpecPages) {
+    incompleteSpecs.push(
+      `${specsDir} — only ${specPages} spec pages (expected >= ${minSpecPages}; did the vendor pull fail?)`,
+    );
   }
   return { oiml, language, incompleteSpecs };
 }
@@ -80,7 +92,7 @@ if (isEntry) {
     for (const f of language) console.error(`  ${f}`);
   }
   if (incompleteSpecs.length) {
-    console.error('ERROR: spec pages rendering without content (<2 h2 headings)');
+    console.error('ERROR: incomplete spec pages (missing content, or too few pages)');
     for (const f of incompleteSpecs) console.error(`  ${f}`);
   }
   const total = oiml.length + language.length + incompleteSpecs.length;

--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -29,6 +29,7 @@ import { execSync } from 'node:child_process';
 import { convertSpec, serializeSpec } from './lib/specs-converter.mjs';
 import { rewriteDocText } from './lib/doc-links.mjs';
 import { sanitizeMdx } from './lib/mdx-sanitize.mjs';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
 import { BLOCKED_DOCS, isBlockedSpec, isNeutralitySvg } from './lib/neutrality.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -82,24 +83,6 @@ function sparseClone(repo, ref, targetDir, sparsePaths) {
   }
 }
 
-/**
- * @param {string} filePath
- * @returns {Record<string, string> | null}
- */
-function loadFrontmatter(filePath) {
-  if (!existsSync(filePath)) return null;
-  const text = readFileSync(filePath, 'utf8');
-  const match = text.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return null;
-  /** @type {Record<string, string>} */
-  const frontmatter = {};
-  for (const line of match[1].split('\n')) {
-    const m = line.match(/^(\w+):\s*"?(.*?)"?\s*$/);
-    if (m) frontmatter[m[1]] = m[2];
-  }
-  return frontmatter;
-}
-
 function fetchSoftwareDocs() {
   const softwareDir = join(ROOT, 'src/content/software');
   if (!existsSync(softwareDir)) {
@@ -109,7 +92,7 @@ function fetchSoftwareDocs() {
   const vendored = [];
   for (const file of readdirSync(softwareDir)) {
     if (!file.endsWith('.md') && !file.endsWith('.mdx')) continue;
-    const fm = loadFrontmatter(join(softwareDir, file));
+    const fm = parseFrontmatter(readFileSync(join(softwareDir, file), 'utf8'));
     if (!fm || !fm.docs_repo) continue;
     const id = file.replace(/\.(md|mdx)$/, '');
     const repoHttps = normalizeRepoUrl(fm.docs_repo);
@@ -178,11 +161,9 @@ function sanitizeVendorMdx(root) {
 }
 
 function fetchSpecs() {
-  const specsDir = join(ROOT, 'src/content/specs');
-  if (!existsSync(specsDir)) {
-    console.log('[fetch-sources] no src/content/specs/ — skipping specs');
-    return;
-  }
+  // Specs are core content, not opt-in: fetching is unconditional.
+  // (The switch on a source directory could let the whole section
+  // vanish silently — check-gates' spec-page floor backstops this.)
   const target = join(VENDOR, 'specs');
   sparseClone(SPECS_REPO, SPECS_REF, target, ['specs/', 'images/']);
   const skippedImages = copySpecImages(target);

--- a/scripts/lib/check-gates.test.mjs
+++ b/scripts/lib/check-gates.test.mjs
@@ -23,7 +23,7 @@ function write(rel, content) {
 describe('collectGateViolations', () => {
   it('reports OIML in any dist file, including svg', () => {
     write('diagram.svg', '<svg><text>OIML label</text></svg>');
-    const v = collectGateViolations(dir);
+    const v = collectGateViolations(dir, { minSpecPages: 0 });
     expect(v.oiml).toHaveLength(1);
     expect(v.oiml[0]).toContain('diagram.svg');
     expect(v.incompleteSpecs).toHaveLength(0);
@@ -33,7 +33,7 @@ describe('collectGateViolations', () => {
     write('page.html', '<p>coming soon</p>');
     write('page.md', 'see the roadmap');
     write('ignored.json', '{"note": "planned"}');
-    const v = collectGateViolations(dir);
+    const v = collectGateViolations(dir, { minSpecPages: 0 });
     expect(v.language.some((f) => f.endsWith('page.html'))).toBe(true);
     expect(v.language.some((f) => f.endsWith('page.md'))).toBe(true);
     expect(v.language.some((f) => f.endsWith('ignored.json'))).toBe(false);
@@ -41,8 +41,15 @@ describe('collectGateViolations', () => {
 
   it('flags spec pages that render without content', () => {
     write(join('specs', '00-empty', 'index.html'), '<h1>Only hero</h1>');
-    const v = collectGateViolations(dir);
+    const v = collectGateViolations(dir, { minSpecPages: 0 });
     expect(v.incompleteSpecs).toHaveLength(1);
     expect(v.incompleteSpecs[0]).toContain('00-empty');
+  });
+
+  it('fails loudly when the specs section is gutted (page-count floor)', () => {
+    write(join('specs', '22-already-counted', 'index.html'), '<h2>a</h2><h2>b</h2>');
+    const v = collectGateViolations(dir); // default floor: 30
+    const floor = v.incompleteSpecs.filter((e) => e.includes('vendor pull'));
+    expect(floor).toHaveLength(1);
   });
 });

--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -1,0 +1,35 @@
+/**
+ * Minimal YAML frontmatter parser for the vendor-pull configuration
+ * in `src/content/software/*.md`. Handles the shapes those files use
+ * — plain scalars and quoted strings — without pulling in a YAML
+ * dependency: values may contain colons, quotes are stripped, and
+ * non-frontmatter text is never misread as a key.
+ *
+ * Returns null when the text has no frontmatter block.
+ */
+
+/**
+ * @param {string} text
+ * @returns {Record<string, string> | null}
+ */
+export function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  /** @type {Record<string, string>} */
+  const frontmatter = {};
+  for (const line of match[1].split('\n')) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const m = line.match(/^(\w+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, raw] = m;
+    let value = raw.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1);
+    }
+    frontmatter[key] = value;
+  }
+  return frontmatter;
+}

--- a/scripts/lib/frontmatter.test.mjs
+++ b/scripts/lib/frontmatter.test.mjs
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseFrontmatter } from './frontmatter.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOFTWARE_DIR = join(__dirname, '..', '..', 'src', 'content', 'software');
+
+describe('parseFrontmatter', () => {
+  it('parses plain and quoted values, colons included', () => {
+    const fm = parseFrontmatter(
+      '---\nplain: docs\nquoted: "docs v2: bindings"\nsingle: \'kept\'\nrepo: github.com/confium/confium-ruby\n---\n\nbody',
+    );
+    expect(fm).toEqual({
+      plain: 'docs',
+      quoted: 'docs v2: bindings',
+      single: 'kept',
+      repo: 'github.com/confium/confium-ruby',
+    });
+  });
+
+  it('skips blanks and comments, never reads body text as keys', () => {
+    const fm = parseFrontmatter('---\n# comment\na: 1\n\n---\nnot_a_key: nope');
+    expect(fm).toEqual({ a: '1' });
+  });
+
+  it('returns null without a frontmatter block', () => {
+    expect(parseFrontmatter('# just a page\n\nbody')).toBeNull();
+  });
+});
+
+describe('the real vendor configuration parses cleanly', () => {
+  it.skipIf(!existsSync(SOFTWARE_DIR))('every software page yields its docs_* keys', () => {
+    const files = readdirSync(SOFTWARE_DIR).filter((f) => /\.(md|mdx)$/.test(f));
+    expect(files.length).toBeGreaterThan(3);
+    for (const f of files) {
+      const fm = parseFrontmatter(readFileSync(join(SOFTWARE_DIR, f), 'utf8'));
+      expect(fm, `${f}: frontmatter`).not.toBeNull();
+      expect(fm, `${f}: keys`).toHaveProperty('name');
+      if (fm.docs_repo) {
+        // The keys the fetch pipeline depends on must survive parsing.
+        expect(fm.docs_repo.trim()).toBe(fm.docs_repo);
+        expect(fm.docs_subtree ?? 'docs').not.toMatch(/"/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Round 3: the wiring around rounds 1–2 — the last paths where the specs section could fail silently.

### The silent-failure chain, closed

`fetchSpecs()` switched on `existsSync(src/content/specs/)` — a directory holding only the 7 curated files that have been dead since the specDocs cutover (#91). Removing that dead data would have stopped specs vendoring while **every check stayed green**: golden corpus test `skipIf` → skips; completeness gate → no spec dirs → vacuous pass; CI fetch step → exit 0 by graceful-degradation design.

- **Specs fetch is unconditional** — core content, not opt-in. The software-docs switch stays (its directory *is* the config source).
- **check-gates spec-page floor** (`minSpecPages`, default 30, injectable): a gutted `dist/specs` now fails loudly with a "did the vendor pull fail?" message.
- **tests.yml verifies the corpus landed** after the fetch step — graceful degradation can no longer silently skip the golden tests in CI.

### `frontmatter.mjs` — the vendor config parser, tested

The hand-rolled regex that decided which repos become 202 public pages is now a small parser with fixtures (quoted values, colons in values, comments, no false keys from body text) plus an assertion that every real `src/content/software/*.md` parses with its `docs_*` keys intact.

### Verification

- 103/103 tests (4 new). Gates clean: 447 pages, 37 spec pages, all three gates + floor.
- No corpus output change (both parsers strip quotes identically on the real config values).
