### PR TITLE
feat(specs): right-rail TOC on spec pages

### DIFF
--- a/src/pages/specs/[id].astro
+++ b/src/pages/specs/[id].astro
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 }
 
 const { spec } = Astro.props;
-const { Content } = await render(spec);
+const { Content, headings } = await render(spec);
 
 const sidebar = groupSpecsByCategory(await getCollection('specDocs')).map((group) => ({
   heading: group.label,
@@ -27,6 +27,7 @@ const sidebar = groupSpecsByCategory(await getCollection('specDocs')).map((group
   description={spec.data.description}
   sidebar={sidebar}
   sourcePath={`github.com/confium/specs/blob/main/${spec.data.upstream_path}`}
+  headings={headings}
 >
   <PageHero
     eyebrow="Specification"


### PR DESCRIPTION
DocsLayout's TocNav was waiting for a headings prop the spec routes never passed. Long specs now get anchor navigation; all heading ids verified to resolve in the built pages.